### PR TITLE
mlir backend: refactoring transform generation

### DIFF
--- a/tests/filecheck/backends/test_conv2d_mini_mlir.py
+++ b/tests/filecheck/backends/test_conv2d_mini_mlir.py
@@ -59,9 +59,8 @@ print(f"CODE: {res}")
 # CHECK-NEXT:      transform.annotate %loops_3 "./w" : !transform.any_op
 # CHECK-NEXT:      %tiled_linalg_op_4, %loops_5 = transform.structured.tile_using_for %tiled_linalg_op_2 tile_sizes [0, 0, 0, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
 # CHECK-NEXT:      transform.annotate %loops_5 "./f" : !transform.any_op
-# CHECK-NEXT:      %1 = transform.get_parent_op %loops {isolated_from_above} : (!transform.any_op) -> !transform.any_op
-# CHECK-NEXT:      %2 = transform.structured.match attributes {__xtc_id_O_} in %arg0 : (!transform.any_op) -> !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_6, %loops_7 = transform.structured.tile_using_for %2 tile_sizes [1, 0, 0, 0, 0, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      %1 = transform.structured.match attributes {__xtc_id_O_} in %arg0 : (!transform.any_op) -> !transform.any_op
+# CHECK-NEXT:      %tiled_linalg_op_6, %loops_7 = transform.structured.tile_using_for %1 tile_sizes [1, 0, 0, 0, 0, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
 # CHECK-NEXT:      transform.annotate %loops_7 "./b" : !transform.any_op
 # CHECK-NEXT:      %tiled_linalg_op_8, %loops_9 = transform.structured.tile_using_for %tiled_linalg_op_6 tile_sizes [0, 1, 0, 0, 0, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
 # CHECK-NEXT:      transform.annotate %loops_9 "./h" : !transform.any_op
@@ -75,7 +74,6 @@ print(f"CODE: {res}")
 # CHECK-NEXT:      transform.annotate %loops_17 "./s" : !transform.any_op
 # CHECK-NEXT:      %tiled_linalg_op_18, %loops_19 = transform.structured.tile_using_for %tiled_linalg_op_16 tile_sizes [0, 0, 0, 0, 0, 0, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
 # CHECK-NEXT:      transform.annotate %loops_19 "./c" : !transform.any_op
-# CHECK-NEXT:      %3 = transform.get_parent_op %loops_7 {isolated_from_above} : (!transform.any_op) -> !transform.any_op
 # CHECK-NEXT:      transform.yield 
 # CHECK-NEXT:    }
 # CHECK-NEXT:  }

--- a/tests/filecheck/backends/test_conv2d_r181_mlir_sv.py
+++ b/tests/filecheck/backends/test_conv2d_r181_mlir_sv.py
@@ -39,6 +39,8 @@ module = comp.compile(sched)
 executor = module.get_executor(validate=True)
 res = executor.execute()
 print(f"CODE: {res}")
+
+
 # CHECK:       // -----// IR Dump Before transform //----- //
 # CHECK-NEXT:  #map = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d1 * 2 + d4, d2 * 2 + d5, d6)>
 # CHECK-NEXT:  #map1 = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d4, d5, d6, d3)>
@@ -73,9 +75,8 @@ print(f"CODE: {res}")
 # CHECK-NEXT:      transform.annotate %loops_3 "./w" : !transform.any_op
 # CHECK-NEXT:      %tiled_linalg_op_4, %loops_5 = transform.structured.tile_using_for %tiled_linalg_op_2 tile_sizes [0, 0, 0, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
 # CHECK-NEXT:      transform.annotate %loops_5 "./f" : !transform.any_op
-# CHECK-NEXT:      %1 = transform.get_parent_op %loops {isolated_from_above} : (!transform.any_op) -> !transform.any_op
-# CHECK-NEXT:      %2 = transform.structured.match attributes {__xtc_id_O_} in %arg0 : (!transform.any_op) -> !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_6, %loops_7 = transform.structured.tile_using_for %2 tile_sizes [1, 0, 0, 0, 0, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      %1 = transform.structured.match attributes {__xtc_id_O_} in %arg0 : (!transform.any_op) -> !transform.any_op
+# CHECK-NEXT:      %tiled_linalg_op_6, %loops_7 = transform.structured.tile_using_for %1 tile_sizes [1, 0, 0, 0, 0, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
 # CHECK-NEXT:      transform.annotate %loops_7 "./b" : !transform.any_op
 # CHECK-NEXT:      %tiled_linalg_op_8, %loops_9 = transform.structured.tile_using_for %tiled_linalg_op_6 tile_sizes [0, 1, 0, 0, 0, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
 # CHECK-NEXT:      transform.annotate %loops_9 "./h" : !transform.any_op
@@ -91,27 +92,18 @@ print(f"CODE: {res}")
 # CHECK-NEXT:      transform.annotate %loops_19 "./c" : !transform.any_op
 # CHECK-NEXT:      %tiled_linalg_op_20, %loops_21 = transform.structured.tile_using_for %tiled_linalg_op_18 tile_sizes [0, 0, 1, 0, 0, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
 # CHECK-NEXT:      transform.annotate %loops_21 "./w1" : !transform.any_op
-# CHECK-NEXT:      %3 = transform.get_parent_op %loops_7 {isolated_from_above} : (!transform.any_op) -> !transform.any_op
-# CHECK-NEXT:      transform.apply_patterns to %3 {
-# CHECK-NEXT:        transform.apply_patterns.vector.reduction_to_contract
-# CHECK-NEXT:        transform.apply_patterns.vector.transfer_permutation_patterns
-# CHECK-NEXT:      } : !transform.any_op
-# CHECK-NEXT:      transform.apply_patterns to %3 {
-# CHECK-NEXT:        transform.apply_patterns.vector.lower_outerproduct
-# CHECK-NEXT:        transform.apply_patterns.vector.lower_contraction
-# CHECK-NEXT:      } : !transform.any_op
-# CHECK-NEXT:      %4 = transform.structured.match attributes {"./w1"} in %3 : (!transform.any_op) -> !transform.any_op
 # CHECK-NEXT:      transform.loop.unroll %loops_21 {factor = 4 : i64} : !transform.any_op
-# CHECK-NEXT:      %5 = transform.structured.match attributes {"./c"} in %3 : (!transform.any_op) -> !transform.any_op
 # CHECK-NEXT:      transform.loop.unroll %loops_19 {factor = 3 : i64} : !transform.any_op
-# CHECK-NEXT:      %6 = transform.get_parent_op %loops_7 {isolated_from_above} : (!transform.any_op) -> !transform.any_op
-# CHECK-NEXT:      %7 = transform.apply_registered_pass "convert-linalg-to-affine-loops" to %6 : (!transform.any_op) -> !transform.any_op
-# CHECK-NEXT:      %8 = transform.include @_super_vectorize failures(suppress) (%7) : (!transform.any_op) -> !transform.any_op
+# CHECK-NEXT:      %2 = transform.get_parent_op %loops_7 {isolated_from_above} : (!transform.any_op) -> !transform.any_op
+# CHECK-NEXT:      %3 = transform.apply_registered_pass "convert-linalg-to-affine-loops" to %2 : (!transform.any_op) -> !transform.any_op
+# CHECK-NEXT:      %4 = transform.include @_super_vectorize failures(suppress) (%3) : (!transform.any_op) -> !transform.any_op
 # CHECK-NEXT:      transform.yield 
 # CHECK-NEXT:    }
 # CHECK-NEXT:  }
-# CHECK:       RuntimeError: MLIR Error: NYI: non-trivial layout map
-# CHECK:       // -----// IR Dump After transform //----- //
+
+# CHECK: MLIR Error: NYI: non-trivial layout map
+
+# CHECK:  // -----// IR Dump After transform //----- //
 # CHECK-NEXT:  #map = affine_map<(d0) -> (d0 * 2)>
 # CHECK-NEXT:  #map1 = affine_map<(d0, d1) -> (d0 * 2 + d1)>
 # CHECK-NEXT:  module attributes {transform.with_named_sequence} {

--- a/tests/filecheck/backends/test_matmul_mlir.py
+++ b/tests/filecheck/backends/test_matmul_mlir.py
@@ -50,9 +50,8 @@ print(f"CODE: {res}")
 # CHECK-NEXT:      transform.annotate %loops "./i" : !transform.any_op
 # CHECK-NEXT:      %tiled_linalg_op_0, %loops_1 = transform.structured.tile_using_for %tiled_linalg_op tile_sizes [0, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
 # CHECK-NEXT:      transform.annotate %loops_1 "./j" : !transform.any_op
-# CHECK-NEXT:      %1 = transform.get_parent_op %loops {isolated_from_above} : (!transform.any_op) -> !transform.any_op
-# CHECK-NEXT:      %2 = transform.structured.match attributes {__xtc_id_C_} in %arg0 : (!transform.any_op) -> !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_2, %loops_3 = transform.structured.tile_using_for %2 tile_sizes [0, 0, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      %1 = transform.structured.match attributes {__xtc_id_C_} in %arg0 : (!transform.any_op) -> !transform.any_op
+# CHECK-NEXT:      %tiled_linalg_op_2, %loops_3 = transform.structured.tile_using_for %1 tile_sizes [0, 0, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
 # CHECK-NEXT:      transform.annotate %loops_3 "./k" : !transform.any_op
 # CHECK-NEXT:      %tiled_linalg_op_4, %loops_5 = transform.structured.tile_using_for %tiled_linalg_op_2 tile_sizes [2, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
 # CHECK-NEXT:      transform.annotate %loops_5 "./i" : !transform.any_op
@@ -60,18 +59,17 @@ print(f"CODE: {res}")
 # CHECK-NEXT:      transform.annotate %loops_7 "./j" : !transform.any_op
 # CHECK-NEXT:      %tiled_linalg_op_8, %loops_9 = transform.structured.tile_using_for %tiled_linalg_op_6 tile_sizes [1, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
 # CHECK-NEXT:      transform.annotate %loops_9 "./i1" : !transform.any_op
-# CHECK-NEXT:      %3 = transform.get_parent_op %loops_3 {isolated_from_above} : (!transform.any_op) -> !transform.any_op
 # CHECK-NEXT:      transform.include @_vecto failures(suppress) (%tiled_linalg_op_8) : (!transform.any_op) -> ()
-# CHECK-NEXT:      transform.apply_patterns to %3 {
+# CHECK-NEXT:      transform.loop.unroll %loops_9 {factor = 2 : i64} : !transform.any_op
+# CHECK-NEXT:      %2 = transform.get_parent_op %loops_3 {isolated_from_above} : (!transform.any_op) -> !transform.any_op
+# CHECK-NEXT:      transform.apply_patterns to %2 {
 # CHECK-NEXT:        transform.apply_patterns.vector.reduction_to_contract
 # CHECK-NEXT:        transform.apply_patterns.vector.transfer_permutation_patterns
 # CHECK-NEXT:      } : !transform.any_op
-# CHECK-NEXT:      transform.apply_patterns to %3 {
+# CHECK-NEXT:      transform.apply_patterns to %2 {
 # CHECK-NEXT:        transform.apply_patterns.vector.lower_outerproduct
 # CHECK-NEXT:        transform.apply_patterns.vector.lower_contraction
 # CHECK-NEXT:      } : !transform.any_op
-# CHECK-NEXT:      %4 = transform.structured.match attributes {"./i1"} in %3 : (!transform.any_op) -> !transform.any_op
-# CHECK-NEXT:      transform.loop.unroll %loops_9 {factor = 2 : i64} : !transform.any_op
 # CHECK-NEXT:      transform.yield 
 # CHECK-NEXT:    }
 # CHECK-NEXT:  }
@@ -106,34 +104,30 @@ print(f"CODE: {res}")
 # CHECK-NEXT:          scf.for %arg5 = %c0 to %c32 step %c16 {
 # CHECK-NEXT:            %subview_5 = memref.subview %subview_1[0, %arg5] [1, 16] [1, 1] : memref<1x32xf32, strided<[32, 1], offset: ?>> to memref<1x16xf32, strided<[32, 1], offset: ?>>
 # CHECK-NEXT:            %subview_6 = memref.subview %subview_4[0, %arg5] [2, 16] [1, 1] : memref<2x32xf32, strided<[32, 1], offset: ?>> to memref<2x16xf32, strided<[32, 1], offset: ?>>
-# CHECK-NEXT:            %c2_7 = arith.constant 2 : index
-# CHECK-NEXT:            %subview_8 = memref.subview %subview_3[%c0, 0] [1, 1] [1, 1] : memref<2x1xf32, strided<[512, 1], offset: ?>> to memref<1x1xf32, strided<[512, 1], offset: ?>>
-# CHECK-NEXT:            %subview_9 = memref.subview %subview_6[%c0, 0] [1, 16] [1, 1] : memref<2x16xf32, strided<[32, 1], offset: ?>> to memref<1x16xf32, strided<[32, 1], offset: ?>>
-# CHECK-NEXT:            %1 = vector.transfer_read %subview_8[%c0, %c0], %0 {in_bounds = [true, true]} : memref<1x1xf32, strided<[512, 1], offset: ?>>, vector<1x1xf32>
+# CHECK-NEXT:            %subview_7 = memref.subview %subview_3[%c0, 0] [1, 1] [1, 1] : memref<2x1xf32, strided<[512, 1], offset: ?>> to memref<1x1xf32, strided<[512, 1], offset: ?>>
+# CHECK-NEXT:            %subview_8 = memref.subview %subview_6[%c0, 0] [1, 16] [1, 1] : memref<2x16xf32, strided<[32, 1], offset: ?>> to memref<1x16xf32, strided<[32, 1], offset: ?>>
+# CHECK-NEXT:            %1 = vector.transfer_read %subview_7[%c0, %c0], %0 {in_bounds = [true, true]} : memref<1x1xf32, strided<[512, 1], offset: ?>>, vector<1x1xf32>
 # CHECK-NEXT:            %2 = vector.transfer_read %subview_5[%c0, %c0], %0 {in_bounds = [true, true]} : memref<1x16xf32, strided<[32, 1], offset: ?>>, vector<1x16xf32>
-# CHECK-NEXT:            %3 = vector.transfer_read %subview_9[%c0, %c0], %0 {in_bounds = [true, true]} : memref<1x16xf32, strided<[32, 1], offset: ?>>, vector<1x16xf32>
+# CHECK-NEXT:            %3 = vector.transfer_read %subview_8[%c0, %c0], %0 {in_bounds = [true, true]} : memref<1x16xf32, strided<[32, 1], offset: ?>>, vector<1x16xf32>
 # CHECK-NEXT:            %4 = vector.extract %2[0] : vector<16xf32> from vector<1x16xf32>
 # CHECK-NEXT:            %5 = vector.extract %1[0, 0] : f32 from vector<1x1xf32>
 # CHECK-NEXT:            %6 = vector.broadcast %5 : f32 to vector<16xf32>
 # CHECK-NEXT:            %7 = vector.extract %3[0] : vector<16xf32> from vector<1x16xf32>
 # CHECK-NEXT:            %8 = vector.fma %6, %4, %7 : vector<16xf32>
 # CHECK-NEXT:            %9 = vector.insert %8, %cst [0] : vector<16xf32> into vector<1x16xf32>
-# CHECK-NEXT:            vector.transfer_write %9, %subview_9[%c0, %c0] {in_bounds = [true, true]} : vector<1x16xf32>, memref<1x16xf32, strided<[32, 1], offset: ?>>
-# CHECK-NEXT:            %c1_10 = arith.constant 1 : index
-# CHECK-NEXT:            %10 = arith.muli %c1, %c1_10 : index
-# CHECK-NEXT:            %11 = arith.addi %c0, %10 : index
-# CHECK-NEXT:            %subview_11 = memref.subview %subview_3[%11, 0] [1, 1] [1, 1] : memref<2x1xf32, strided<[512, 1], offset: ?>> to memref<1x1xf32, strided<[512, 1], offset: ?>>
-# CHECK-NEXT:            %subview_12 = memref.subview %subview_6[%11, 0] [1, 16] [1, 1] : memref<2x16xf32, strided<[32, 1], offset: ?>> to memref<1x16xf32, strided<[32, 1], offset: ?>>
-# CHECK-NEXT:            %12 = vector.transfer_read %subview_11[%c0, %c0], %0 {in_bounds = [true, true]} : memref<1x1xf32, strided<[512, 1], offset: ?>>, vector<1x1xf32>
-# CHECK-NEXT:            %13 = vector.transfer_read %subview_5[%c0, %c0], %0 {in_bounds = [true, true]} : memref<1x16xf32, strided<[32, 1], offset: ?>>, vector<1x16xf32>
-# CHECK-NEXT:            %14 = vector.transfer_read %subview_12[%c0, %c0], %0 {in_bounds = [true, true]} : memref<1x16xf32, strided<[32, 1], offset: ?>>, vector<1x16xf32>
-# CHECK-NEXT:            %15 = vector.extract %13[0] : vector<16xf32> from vector<1x16xf32>
-# CHECK-NEXT:            %16 = vector.extract %12[0, 0] : f32 from vector<1x1xf32>
-# CHECK-NEXT:            %17 = vector.broadcast %16 : f32 to vector<16xf32>
-# CHECK-NEXT:            %18 = vector.extract %14[0] : vector<16xf32> from vector<1x16xf32>
-# CHECK-NEXT:            %19 = vector.fma %17, %15, %18 : vector<16xf32>
-# CHECK-NEXT:            %20 = vector.insert %19, %cst [0] : vector<16xf32> into vector<1x16xf32>
-# CHECK-NEXT:            vector.transfer_write %20, %subview_12[%c0, %c0] {in_bounds = [true, true]} : vector<1x16xf32>, memref<1x16xf32, strided<[32, 1], offset: ?>>
+# CHECK-NEXT:            vector.transfer_write %9, %subview_8[%c0, %c0] {in_bounds = [true, true]} : vector<1x16xf32>, memref<1x16xf32, strided<[32, 1], offset: ?>>
+# CHECK-NEXT:            %subview_9 = memref.subview %subview_3[%c1, 0] [1, 1] [1, 1] : memref<2x1xf32, strided<[512, 1], offset: ?>> to memref<1x1xf32, strided<[512, 1], offset: ?>>
+# CHECK-NEXT:            %subview_10 = memref.subview %subview_6[%c1, 0] [1, 16] [1, 1] : memref<2x16xf32, strided<[32, 1], offset: ?>> to memref<1x16xf32, strided<[32, 1], offset: ?>>
+# CHECK-NEXT:            %10 = vector.transfer_read %subview_9[%c0, %c0], %0 {in_bounds = [true, true]} : memref<1x1xf32, strided<[512, 1], offset: ?>>, vector<1x1xf32>
+# CHECK-NEXT:            %11 = vector.transfer_read %subview_5[%c0, %c0], %0 {in_bounds = [true, true]} : memref<1x16xf32, strided<[32, 1], offset: ?>>, vector<1x16xf32>
+# CHECK-NEXT:            %12 = vector.transfer_read %subview_10[%c0, %c0], %0 {in_bounds = [true, true]} : memref<1x16xf32, strided<[32, 1], offset: ?>>, vector<1x16xf32>
+# CHECK-NEXT:            %13 = vector.extract %11[0] : vector<16xf32> from vector<1x16xf32>
+# CHECK-NEXT:            %14 = vector.extract %10[0, 0] : f32 from vector<1x1xf32>
+# CHECK-NEXT:            %15 = vector.broadcast %14 : f32 to vector<16xf32>
+# CHECK-NEXT:            %16 = vector.extract %12[0] : vector<16xf32> from vector<1x16xf32>
+# CHECK-NEXT:            %17 = vector.fma %15, %13, %16 : vector<16xf32>
+# CHECK-NEXT:            %18 = vector.insert %17, %cst [0] : vector<16xf32> into vector<1x16xf32>
+# CHECK-NEXT:            vector.transfer_write %18, %subview_10[%c0, %c0] {in_bounds = [true, true]} : vector<1x16xf32>, memref<1x16xf32, strided<[32, 1], offset: ?>>
 # CHECK-NEXT:          } {"./j"}
 # CHECK-NEXT:        } {"./i"}
 # CHECK-NEXT:      } {"./k"}

--- a/tests/filecheck/backends/test_matmul_ndiv_mlir.py
+++ b/tests/filecheck/backends/test_matmul_ndiv_mlir.py
@@ -51,9 +51,8 @@ print(f"CODE: {res}")
 # CHECK-NEXT:      transform.annotate %loops "./i" : !transform.any_op
 # CHECK-NEXT:      %tiled_linalg_op_0, %loops_1 = transform.structured.tile_using_for %tiled_linalg_op tile_sizes [0, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
 # CHECK-NEXT:      transform.annotate %loops_1 "./j" : !transform.any_op
-# CHECK-NEXT:      %1 = transform.get_parent_op %loops {isolated_from_above} : (!transform.any_op) -> !transform.any_op
-# CHECK-NEXT:      %2 = transform.structured.match attributes {__xtc_id_C_} in %arg0 : (!transform.any_op) -> !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_2, %loops_3 = transform.structured.tile_using_for %2 tile_sizes [0, 0, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      %1 = transform.structured.match attributes {__xtc_id_C_} in %arg0 : (!transform.any_op) -> !transform.any_op
+# CHECK-NEXT:      %tiled_linalg_op_2, %loops_3 = transform.structured.tile_using_for %1 tile_sizes [0, 0, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
 # CHECK-NEXT:      transform.annotate %loops_3 "./k" : !transform.any_op
 # CHECK-NEXT:      %tiled_linalg_op_4, %loops_5 = transform.structured.tile_using_for %tiled_linalg_op_2 tile_sizes [3, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
 # CHECK-NEXT:      transform.annotate %loops_5 "./i" : !transform.any_op
@@ -61,18 +60,17 @@ print(f"CODE: {res}")
 # CHECK-NEXT:      transform.annotate %loops_7 "./j" : !transform.any_op
 # CHECK-NEXT:      %tiled_linalg_op_8, %loops_9 = transform.structured.tile_using_for %tiled_linalg_op_6 tile_sizes [1, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
 # CHECK-NEXT:      transform.annotate %loops_9 "./i1" : !transform.any_op
-# CHECK-NEXT:      %3 = transform.get_parent_op %loops_3 {isolated_from_above} : (!transform.any_op) -> !transform.any_op
 # CHECK-NEXT:      transform.include @_vecto failures(suppress) (%tiled_linalg_op_8) : (!transform.any_op) -> ()
-# CHECK-NEXT:      transform.apply_patterns to %3 {
+# CHECK-NEXT:      transform.loop.unroll %loops_9 {factor = 2 : i64} : !transform.any_op
+# CHECK-NEXT:      %2 = transform.get_parent_op %loops_3 {isolated_from_above} : (!transform.any_op) -> !transform.any_op
+# CHECK-NEXT:      transform.apply_patterns to %2 {
 # CHECK-NEXT:        transform.apply_patterns.vector.reduction_to_contract
 # CHECK-NEXT:        transform.apply_patterns.vector.transfer_permutation_patterns
 # CHECK-NEXT:      } : !transform.any_op
-# CHECK-NEXT:      transform.apply_patterns to %3 {
+# CHECK-NEXT:      transform.apply_patterns to %2 {
 # CHECK-NEXT:        transform.apply_patterns.vector.lower_outerproduct
 # CHECK-NEXT:        transform.apply_patterns.vector.lower_contraction
 # CHECK-NEXT:      } : !transform.any_op
-# CHECK-NEXT:      %4 = transform.structured.match attributes {"./i1"} in %3 : (!transform.any_op) -> !transform.any_op
-# CHECK-NEXT:      transform.loop.unroll %loops_9 {factor = 2 : i64} : !transform.any_op
 # CHECK-NEXT:      transform.yield 
 # CHECK-NEXT:    }
 # CHECK-NEXT:  }
@@ -83,6 +81,7 @@ print(f"CODE: {res}")
 # CHECK-NEXT:    func.func @matmul(%arg0: memref<4x512xf32> {llvm.noalias}, %arg1: memref<512x32xf32> {llvm.noalias}, %arg2: memref<4x32xf32> {llvm.noalias}) {
 # CHECK-NEXT:      %cst = arith.constant dense<0.000000e+00> : vector<1x16xf32>
 # CHECK-NEXT:      %0 = ub.poison : f32
+# CHECK-NEXT:      %c2 = arith.constant 2 : index
 # CHECK-NEXT:      %c16 = arith.constant 16 : index
 # CHECK-NEXT:      %c3 = arith.constant 3 : index
 # CHECK-NEXT:      %c512 = arith.constant 512 : index
@@ -109,59 +108,48 @@ print(f"CODE: {res}")
 # CHECK-NEXT:          scf.for %arg5 = %c0 to %c32 step %c16 {
 # CHECK-NEXT:            %subview_5 = memref.subview %subview_1[0, %arg5] [1, 16] [1, 1] : memref<1x32xf32, strided<[32, 1], offset: ?>> to memref<1x16xf32, strided<[32, 1], offset: ?>>
 # CHECK-NEXT:            %subview_6 = memref.subview %subview_4[0, %arg5] [%1, 16] [1, 1] : memref<?x32xf32, strided<[32, 1], offset: ?>> to memref<?x16xf32, strided<[32, 1], offset: ?>>
-# CHECK-NEXT:            %2 = arith.subi %1, %c0 : index
-# CHECK-NEXT:            %c1_7 = arith.constant 1 : index
-# CHECK-NEXT:            %3 = arith.subi %c1, %c1_7 : index
-# CHECK-NEXT:            %4 = arith.addi %2, %3 : index
-# CHECK-NEXT:            %5 = arith.divui %4, %c1 : index
-# CHECK-NEXT:            %c2 = arith.constant 2 : index
-# CHECK-NEXT:            %6 = arith.remsi %5, %c2 : index
-# CHECK-NEXT:            %7 = arith.subi %5, %6 : index
-# CHECK-NEXT:            %8 = arith.muli %7, %c1 : index
-# CHECK-NEXT:            %9 = arith.addi %c0, %8 : index
-# CHECK-NEXT:            %10 = arith.muli %c1, %c2 : index
-# CHECK-NEXT:            scf.for %arg6 = %c0 to %9 step %10 {
-# CHECK-NEXT:              %subview_8 = memref.subview %subview_3[%arg6, 0] [1, 1] [1, 1] : memref<?x1xf32, strided<[512, 1], offset: ?>> to memref<1x1xf32, strided<[512, 1], offset: ?>>
-# CHECK-NEXT:              %subview_9 = memref.subview %subview_6[%arg6, 0] [1, 16] [1, 1] : memref<?x16xf32, strided<[32, 1], offset: ?>> to memref<1x16xf32, strided<[32, 1], offset: ?>>
-# CHECK-NEXT:              %11 = vector.transfer_read %subview_8[%c0, %c0], %0 {in_bounds = [true, true]} : memref<1x1xf32, strided<[512, 1], offset: ?>>, vector<1x1xf32>
-# CHECK-NEXT:              %12 = vector.transfer_read %subview_5[%c0, %c0], %0 {in_bounds = [true, true]} : memref<1x16xf32, strided<[32, 1], offset: ?>>, vector<1x16xf32>
-# CHECK-NEXT:              %13 = vector.transfer_read %subview_9[%c0, %c0], %0 {in_bounds = [true, true]} : memref<1x16xf32, strided<[32, 1], offset: ?>>, vector<1x16xf32>
-# CHECK-NEXT:              %14 = vector.extract %12[0] : vector<16xf32> from vector<1x16xf32>
-# CHECK-NEXT:              %15 = vector.extract %11[0, 0] : f32 from vector<1x1xf32>
-# CHECK-NEXT:              %16 = vector.broadcast %15 : f32 to vector<16xf32>
-# CHECK-NEXT:              %17 = vector.extract %13[0] : vector<16xf32> from vector<1x16xf32>
-# CHECK-NEXT:              %18 = vector.fma %16, %14, %17 : vector<16xf32>
-# CHECK-NEXT:              %19 = vector.insert %18, %cst [0] : vector<16xf32> into vector<1x16xf32>
-# CHECK-NEXT:              vector.transfer_write %19, %subview_9[%c0, %c0] {in_bounds = [true, true]} : vector<1x16xf32>, memref<1x16xf32, strided<[32, 1], offset: ?>>
-# CHECK-NEXT:              %c1_10 = arith.constant 1 : index
-# CHECK-NEXT:              %20 = arith.muli %c1, %c1_10 : index
-# CHECK-NEXT:              %21 = arith.addi %arg6, %20 : index
-# CHECK-NEXT:              %subview_11 = memref.subview %subview_3[%21, 0] [1, 1] [1, 1] : memref<?x1xf32, strided<[512, 1], offset: ?>> to memref<1x1xf32, strided<[512, 1], offset: ?>>
-# CHECK-NEXT:              %subview_12 = memref.subview %subview_6[%21, 0] [1, 16] [1, 1] : memref<?x16xf32, strided<[32, 1], offset: ?>> to memref<1x16xf32, strided<[32, 1], offset: ?>>
-# CHECK-NEXT:              %22 = vector.transfer_read %subview_11[%c0, %c0], %0 {in_bounds = [true, true]} : memref<1x1xf32, strided<[512, 1], offset: ?>>, vector<1x1xf32>
-# CHECK-NEXT:              %23 = vector.transfer_read %subview_5[%c0, %c0], %0 {in_bounds = [true, true]} : memref<1x16xf32, strided<[32, 1], offset: ?>>, vector<1x16xf32>
-# CHECK-NEXT:              %24 = vector.transfer_read %subview_12[%c0, %c0], %0 {in_bounds = [true, true]} : memref<1x16xf32, strided<[32, 1], offset: ?>>, vector<1x16xf32>
-# CHECK-NEXT:              %25 = vector.extract %23[0] : vector<16xf32> from vector<1x16xf32>
-# CHECK-NEXT:              %26 = vector.extract %22[0, 0] : f32 from vector<1x1xf32>
-# CHECK-NEXT:              %27 = vector.broadcast %26 : f32 to vector<16xf32>
-# CHECK-NEXT:              %28 = vector.extract %24[0] : vector<16xf32> from vector<1x16xf32>
-# CHECK-NEXT:              %29 = vector.fma %27, %25, %28 : vector<16xf32>
-# CHECK-NEXT:              %30 = vector.insert %29, %cst [0] : vector<16xf32> into vector<1x16xf32>
-# CHECK-NEXT:              vector.transfer_write %30, %subview_12[%c0, %c0] {in_bounds = [true, true]} : vector<1x16xf32>, memref<1x16xf32, strided<[32, 1], offset: ?>>
+# CHECK-NEXT:            %2 = arith.remsi %1, %c2 : index
+# CHECK-NEXT:            %3 = arith.subi %1, %2 : index
+# CHECK-NEXT:            scf.for %arg6 = %c0 to %3 step %c2 {
+# CHECK-NEXT:              %subview_7 = memref.subview %subview_3[%arg6, 0] [1, 1] [1, 1] : memref<?x1xf32, strided<[512, 1], offset: ?>> to memref<1x1xf32, strided<[512, 1], offset: ?>>
+# CHECK-NEXT:              %subview_8 = memref.subview %subview_6[%arg6, 0] [1, 16] [1, 1] : memref<?x16xf32, strided<[32, 1], offset: ?>> to memref<1x16xf32, strided<[32, 1], offset: ?>>
+# CHECK-NEXT:              %4 = vector.transfer_read %subview_7[%c0, %c0], %0 {in_bounds = [true, true]} : memref<1x1xf32, strided<[512, 1], offset: ?>>, vector<1x1xf32>
+# CHECK-NEXT:              %5 = vector.transfer_read %subview_5[%c0, %c0], %0 {in_bounds = [true, true]} : memref<1x16xf32, strided<[32, 1], offset: ?>>, vector<1x16xf32>
+# CHECK-NEXT:              %6 = vector.transfer_read %subview_8[%c0, %c0], %0 {in_bounds = [true, true]} : memref<1x16xf32, strided<[32, 1], offset: ?>>, vector<1x16xf32>
+# CHECK-NEXT:              %7 = vector.extract %5[0] : vector<16xf32> from vector<1x16xf32>
+# CHECK-NEXT:              %8 = vector.extract %4[0, 0] : f32 from vector<1x1xf32>
+# CHECK-NEXT:              %9 = vector.broadcast %8 : f32 to vector<16xf32>
+# CHECK-NEXT:              %10 = vector.extract %6[0] : vector<16xf32> from vector<1x16xf32>
+# CHECK-NEXT:              %11 = vector.fma %9, %7, %10 : vector<16xf32>
+# CHECK-NEXT:              %12 = vector.insert %11, %cst [0] : vector<16xf32> into vector<1x16xf32>
+# CHECK-NEXT:              vector.transfer_write %12, %subview_8[%c0, %c0] {in_bounds = [true, true]} : vector<1x16xf32>, memref<1x16xf32, strided<[32, 1], offset: ?>>
+# CHECK-NEXT:              %13 = arith.addi %arg6, %c1 : index
+# CHECK-NEXT:              %subview_9 = memref.subview %subview_3[%13, 0] [1, 1] [1, 1] : memref<?x1xf32, strided<[512, 1], offset: ?>> to memref<1x1xf32, strided<[512, 1], offset: ?>>
+# CHECK-NEXT:              %subview_10 = memref.subview %subview_6[%13, 0] [1, 16] [1, 1] : memref<?x16xf32, strided<[32, 1], offset: ?>> to memref<1x16xf32, strided<[32, 1], offset: ?>>
+# CHECK-NEXT:              %14 = vector.transfer_read %subview_9[%c0, %c0], %0 {in_bounds = [true, true]} : memref<1x1xf32, strided<[512, 1], offset: ?>>, vector<1x1xf32>
+# CHECK-NEXT:              %15 = vector.transfer_read %subview_5[%c0, %c0], %0 {in_bounds = [true, true]} : memref<1x16xf32, strided<[32, 1], offset: ?>>, vector<1x16xf32>
+# CHECK-NEXT:              %16 = vector.transfer_read %subview_10[%c0, %c0], %0 {in_bounds = [true, true]} : memref<1x16xf32, strided<[32, 1], offset: ?>>, vector<1x16xf32>
+# CHECK-NEXT:              %17 = vector.extract %15[0] : vector<16xf32> from vector<1x16xf32>
+# CHECK-NEXT:              %18 = vector.extract %14[0, 0] : f32 from vector<1x1xf32>
+# CHECK-NEXT:              %19 = vector.broadcast %18 : f32 to vector<16xf32>
+# CHECK-NEXT:              %20 = vector.extract %16[0] : vector<16xf32> from vector<1x16xf32>
+# CHECK-NEXT:              %21 = vector.fma %19, %17, %20 : vector<16xf32>
+# CHECK-NEXT:              %22 = vector.insert %21, %cst [0] : vector<16xf32> into vector<1x16xf32>
+# CHECK-NEXT:              vector.transfer_write %22, %subview_10[%c0, %c0] {in_bounds = [true, true]} : vector<1x16xf32>, memref<1x16xf32, strided<[32, 1], offset: ?>>
 # CHECK-NEXT:            } {"./i1"}
-# CHECK-NEXT:            scf.for %arg6 = %9 to %1 step %c1 {
-# CHECK-NEXT:              %subview_8 = memref.subview %subview_3[%arg6, 0] [1, 1] [1, 1] : memref<?x1xf32, strided<[512, 1], offset: ?>> to memref<1x1xf32, strided<[512, 1], offset: ?>>
-# CHECK-NEXT:              %subview_9 = memref.subview %subview_6[%arg6, 0] [1, 16] [1, 1] : memref<?x16xf32, strided<[32, 1], offset: ?>> to memref<1x16xf32, strided<[32, 1], offset: ?>>
-# CHECK-NEXT:              %11 = vector.transfer_read %subview_8[%c0, %c0], %0 {in_bounds = [true, true]} : memref<1x1xf32, strided<[512, 1], offset: ?>>, vector<1x1xf32>
-# CHECK-NEXT:              %12 = vector.transfer_read %subview_5[%c0, %c0], %0 {in_bounds = [true, true]} : memref<1x16xf32, strided<[32, 1], offset: ?>>, vector<1x16xf32>
-# CHECK-NEXT:              %13 = vector.transfer_read %subview_9[%c0, %c0], %0 {in_bounds = [true, true]} : memref<1x16xf32, strided<[32, 1], offset: ?>>, vector<1x16xf32>
-# CHECK-NEXT:              %14 = vector.extract %12[0] : vector<16xf32> from vector<1x16xf32>
-# CHECK-NEXT:              %15 = vector.extract %11[0, 0] : f32 from vector<1x1xf32>
-# CHECK-NEXT:              %16 = vector.broadcast %15 : f32 to vector<16xf32>
-# CHECK-NEXT:              %17 = vector.extract %13[0] : vector<16xf32> from vector<1x16xf32>
-# CHECK-NEXT:              %18 = vector.fma %16, %14, %17 : vector<16xf32>
-# CHECK-NEXT:              %19 = vector.insert %18, %cst [0] : vector<16xf32> into vector<1x16xf32>
-# CHECK-NEXT:              vector.transfer_write %19, %subview_9[%c0, %c0] {in_bounds = [true, true]} : vector<1x16xf32>, memref<1x16xf32, strided<[32, 1], offset: ?>>
+# CHECK-NEXT:            scf.for %arg6 = %3 to %1 step %c1 {
+# CHECK-NEXT:              %subview_7 = memref.subview %subview_3[%arg6, 0] [1, 1] [1, 1] : memref<?x1xf32, strided<[512, 1], offset: ?>> to memref<1x1xf32, strided<[512, 1], offset: ?>>
+# CHECK-NEXT:              %subview_8 = memref.subview %subview_6[%arg6, 0] [1, 16] [1, 1] : memref<?x16xf32, strided<[32, 1], offset: ?>> to memref<1x16xf32, strided<[32, 1], offset: ?>>
+# CHECK-NEXT:              %4 = vector.transfer_read %subview_7[%c0, %c0], %0 {in_bounds = [true, true]} : memref<1x1xf32, strided<[512, 1], offset: ?>>, vector<1x1xf32>
+# CHECK-NEXT:              %5 = vector.transfer_read %subview_5[%c0, %c0], %0 {in_bounds = [true, true]} : memref<1x16xf32, strided<[32, 1], offset: ?>>, vector<1x16xf32>
+# CHECK-NEXT:              %6 = vector.transfer_read %subview_8[%c0, %c0], %0 {in_bounds = [true, true]} : memref<1x16xf32, strided<[32, 1], offset: ?>>, vector<1x16xf32>
+# CHECK-NEXT:              %7 = vector.extract %5[0] : vector<16xf32> from vector<1x16xf32>
+# CHECK-NEXT:              %8 = vector.extract %4[0, 0] : f32 from vector<1x1xf32>
+# CHECK-NEXT:              %9 = vector.broadcast %8 : f32 to vector<16xf32>
+# CHECK-NEXT:              %10 = vector.extract %6[0] : vector<16xf32> from vector<1x16xf32>
+# CHECK-NEXT:              %11 = vector.fma %9, %7, %10 : vector<16xf32>
+# CHECK-NEXT:              %12 = vector.insert %11, %cst [0] : vector<16xf32> into vector<1x16xf32>
+# CHECK-NEXT:              vector.transfer_write %12, %subview_8[%c0, %c0] {in_bounds = [true, true]} : vector<1x16xf32>, memref<1x16xf32, strided<[32, 1], offset: ?>>
 # CHECK-NEXT:            } {"./i1"}
 # CHECK-NEXT:          } {"./j"}
 # CHECK-NEXT:        } {"./i"}

--- a/tests/filecheck/backends/test_matmul_relu_mlir.py
+++ b/tests/filecheck/backends/test_matmul_relu_mlir.py
@@ -63,9 +63,8 @@ print(f"CODE: {res}")
 # CHECK-NEXT:      transform.annotate %loops "./i" : !transform.any_op
 # CHECK-NEXT:      %tiled_linalg_op_0, %loops_1 = transform.structured.tile_using_for %tiled_linalg_op tile_sizes [0, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
 # CHECK-NEXT:      transform.annotate %loops_1 "./j" : !transform.any_op
-# CHECK-NEXT:      %1 = transform.get_parent_op %loops {isolated_from_above} : (!transform.any_op) -> !transform.any_op
-# CHECK-NEXT:      %2 = transform.structured.match attributes {__xtc_id_matmul_} in %arg0 : (!transform.any_op) -> !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_2, %loops_3 = transform.structured.tile_using_for %2 tile_sizes [0, 0, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      %1 = transform.structured.match attributes {__xtc_id_matmul_} in %arg0 : (!transform.any_op) -> !transform.any_op
+# CHECK-NEXT:      %tiled_linalg_op_2, %loops_3 = transform.structured.tile_using_for %1 tile_sizes [0, 0, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
 # CHECK-NEXT:      transform.annotate %loops_3 "./k" : !transform.any_op
 # CHECK-NEXT:      %tiled_linalg_op_4, %loops_5 = transform.structured.tile_using_for %tiled_linalg_op_2 tile_sizes [2, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
 # CHECK-NEXT:      transform.annotate %loops_5 "./i" : !transform.any_op
@@ -73,22 +72,20 @@ print(f"CODE: {res}")
 # CHECK-NEXT:      transform.annotate %loops_7 "./j" : !transform.any_op
 # CHECK-NEXT:      %tiled_linalg_op_8, %loops_9 = transform.structured.tile_using_for %tiled_linalg_op_6 tile_sizes [1, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
 # CHECK-NEXT:      transform.annotate %loops_9 "./i1" : !transform.any_op
-# CHECK-NEXT:      %3 = transform.get_parent_op %loops_3 {isolated_from_above} : (!transform.any_op) -> !transform.any_op
 # CHECK-NEXT:      transform.include @_vecto failures(suppress) (%tiled_linalg_op_8) : (!transform.any_op) -> ()
-# CHECK-NEXT:      transform.apply_patterns to %3 {
+# CHECK-NEXT:      transform.loop.unroll %loops_9 {factor = 2 : i64} : !transform.any_op
+# CHECK-NEXT:      %2 = transform.get_parent_op %loops_3 {isolated_from_above} : (!transform.any_op) -> !transform.any_op
+# CHECK-NEXT:      transform.apply_patterns to %2 {
 # CHECK-NEXT:        transform.apply_patterns.vector.reduction_to_contract
 # CHECK-NEXT:        transform.apply_patterns.vector.transfer_permutation_patterns
 # CHECK-NEXT:      } : !transform.any_op
-# CHECK-NEXT:      transform.apply_patterns to %3 {
+# CHECK-NEXT:      transform.apply_patterns to %2 {
 # CHECK-NEXT:        transform.apply_patterns.vector.lower_outerproduct
 # CHECK-NEXT:        transform.apply_patterns.vector.lower_contraction
 # CHECK-NEXT:      } : !transform.any_op
-# CHECK-NEXT:      %4 = transform.structured.match attributes {"./i1"} in %3 : (!transform.any_op) -> !transform.any_op
-# CHECK-NEXT:      transform.loop.unroll %loops_9 {factor = 2 : i64} : !transform.any_op
-# CHECK-NEXT:      %5 = transform.structured.match attributes {__xtc_id_relu_} in %arg0 : (!transform.any_op) -> !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_10, %loops_11 = transform.structured.tile_using_for %5 tile_sizes [1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      %3 = transform.structured.match attributes {__xtc_id_relu_} in %arg0 : (!transform.any_op) -> !transform.any_op
+# CHECK-NEXT:      %tiled_linalg_op_10, %loops_11 = transform.structured.tile_using_for %3 tile_sizes [1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
 # CHECK-NEXT:      transform.annotate %loops_11 "./i" : !transform.any_op
-# CHECK-NEXT:      %6 = transform.get_parent_op %loops_11 {isolated_from_above} : (!transform.any_op) -> !transform.any_op
 # CHECK-NEXT:      transform.yield 
 # CHECK-NEXT:    }
 # CHECK-NEXT:  }
@@ -126,34 +123,30 @@ print(f"CODE: {res}")
 # CHECK-NEXT:          scf.for %arg5 = %c0 to %c32 step %c16 {
 # CHECK-NEXT:            %subview_8 = memref.subview %subview_4[0, %arg5] [1, 16] [1, 1] : memref<1x32xf32, strided<[32, 1], offset: ?>> to memref<1x16xf32, strided<[32, 1], offset: ?>>
 # CHECK-NEXT:            %subview_9 = memref.subview %subview_7[0, %arg5] [2, 16] [1, 1] : memref<2x32xf32, strided<[32, 1], offset: ?>> to memref<2x16xf32, strided<[32, 1], offset: ?>>
-# CHECK-NEXT:            %c2_10 = arith.constant 2 : index
-# CHECK-NEXT:            %subview_11 = memref.subview %subview_6[%c0, 0] [1, 1] [1, 1] : memref<2x1xf32, strided<[512, 1], offset: ?>> to memref<1x1xf32, strided<[512, 1], offset: ?>>
-# CHECK-NEXT:            %subview_12 = memref.subview %subview_9[%c0, 0] [1, 16] [1, 1] : memref<2x16xf32, strided<[32, 1], offset: ?>> to memref<1x16xf32, strided<[32, 1], offset: ?>>
-# CHECK-NEXT:            %1 = vector.transfer_read %subview_11[%c0, %c0], %0 {in_bounds = [true, true]} : memref<1x1xf32, strided<[512, 1], offset: ?>>, vector<1x1xf32>
+# CHECK-NEXT:            %subview_10 = memref.subview %subview_6[%c0, 0] [1, 1] [1, 1] : memref<2x1xf32, strided<[512, 1], offset: ?>> to memref<1x1xf32, strided<[512, 1], offset: ?>>
+# CHECK-NEXT:            %subview_11 = memref.subview %subview_9[%c0, 0] [1, 16] [1, 1] : memref<2x16xf32, strided<[32, 1], offset: ?>> to memref<1x16xf32, strided<[32, 1], offset: ?>>
+# CHECK-NEXT:            %1 = vector.transfer_read %subview_10[%c0, %c0], %0 {in_bounds = [true, true]} : memref<1x1xf32, strided<[512, 1], offset: ?>>, vector<1x1xf32>
 # CHECK-NEXT:            %2 = vector.transfer_read %subview_8[%c0, %c0], %0 {in_bounds = [true, true]} : memref<1x16xf32, strided<[32, 1], offset: ?>>, vector<1x16xf32>
-# CHECK-NEXT:            %3 = vector.transfer_read %subview_12[%c0, %c0], %0 {in_bounds = [true, true]} : memref<1x16xf32, strided<[32, 1], offset: ?>>, vector<1x16xf32>
+# CHECK-NEXT:            %3 = vector.transfer_read %subview_11[%c0, %c0], %0 {in_bounds = [true, true]} : memref<1x16xf32, strided<[32, 1], offset: ?>>, vector<1x16xf32>
 # CHECK-NEXT:            %4 = vector.extract %2[0] : vector<16xf32> from vector<1x16xf32>
 # CHECK-NEXT:            %5 = vector.extract %1[0, 0] : f32 from vector<1x1xf32>
 # CHECK-NEXT:            %6 = vector.broadcast %5 : f32 to vector<16xf32>
 # CHECK-NEXT:            %7 = vector.extract %3[0] : vector<16xf32> from vector<1x16xf32>
 # CHECK-NEXT:            %8 = vector.fma %6, %4, %7 : vector<16xf32>
 # CHECK-NEXT:            %9 = vector.insert %8, %cst [0] : vector<16xf32> into vector<1x16xf32>
-# CHECK-NEXT:            vector.transfer_write %9, %subview_12[%c0, %c0] {in_bounds = [true, true]} : vector<1x16xf32>, memref<1x16xf32, strided<[32, 1], offset: ?>>
-# CHECK-NEXT:            %c1_13 = arith.constant 1 : index
-# CHECK-NEXT:            %10 = arith.muli %c1, %c1_13 : index
-# CHECK-NEXT:            %11 = arith.addi %c0, %10 : index
-# CHECK-NEXT:            %subview_14 = memref.subview %subview_6[%11, 0] [1, 1] [1, 1] : memref<2x1xf32, strided<[512, 1], offset: ?>> to memref<1x1xf32, strided<[512, 1], offset: ?>>
-# CHECK-NEXT:            %subview_15 = memref.subview %subview_9[%11, 0] [1, 16] [1, 1] : memref<2x16xf32, strided<[32, 1], offset: ?>> to memref<1x16xf32, strided<[32, 1], offset: ?>>
-# CHECK-NEXT:            %12 = vector.transfer_read %subview_14[%c0, %c0], %0 {in_bounds = [true, true]} : memref<1x1xf32, strided<[512, 1], offset: ?>>, vector<1x1xf32>
-# CHECK-NEXT:            %13 = vector.transfer_read %subview_8[%c0, %c0], %0 {in_bounds = [true, true]} : memref<1x16xf32, strided<[32, 1], offset: ?>>, vector<1x16xf32>
-# CHECK-NEXT:            %14 = vector.transfer_read %subview_15[%c0, %c0], %0 {in_bounds = [true, true]} : memref<1x16xf32, strided<[32, 1], offset: ?>>, vector<1x16xf32>
-# CHECK-NEXT:            %15 = vector.extract %13[0] : vector<16xf32> from vector<1x16xf32>
-# CHECK-NEXT:            %16 = vector.extract %12[0, 0] : f32 from vector<1x1xf32>
-# CHECK-NEXT:            %17 = vector.broadcast %16 : f32 to vector<16xf32>
-# CHECK-NEXT:            %18 = vector.extract %14[0] : vector<16xf32> from vector<1x16xf32>
-# CHECK-NEXT:            %19 = vector.fma %17, %15, %18 : vector<16xf32>
-# CHECK-NEXT:            %20 = vector.insert %19, %cst [0] : vector<16xf32> into vector<1x16xf32>
-# CHECK-NEXT:            vector.transfer_write %20, %subview_15[%c0, %c0] {in_bounds = [true, true]} : vector<1x16xf32>, memref<1x16xf32, strided<[32, 1], offset: ?>>
+# CHECK-NEXT:            vector.transfer_write %9, %subview_11[%c0, %c0] {in_bounds = [true, true]} : vector<1x16xf32>, memref<1x16xf32, strided<[32, 1], offset: ?>>
+# CHECK-NEXT:            %subview_12 = memref.subview %subview_6[%c1, 0] [1, 1] [1, 1] : memref<2x1xf32, strided<[512, 1], offset: ?>> to memref<1x1xf32, strided<[512, 1], offset: ?>>
+# CHECK-NEXT:            %subview_13 = memref.subview %subview_9[%c1, 0] [1, 16] [1, 1] : memref<2x16xf32, strided<[32, 1], offset: ?>> to memref<1x16xf32, strided<[32, 1], offset: ?>>
+# CHECK-NEXT:            %10 = vector.transfer_read %subview_12[%c0, %c0], %0 {in_bounds = [true, true]} : memref<1x1xf32, strided<[512, 1], offset: ?>>, vector<1x1xf32>
+# CHECK-NEXT:            %11 = vector.transfer_read %subview_8[%c0, %c0], %0 {in_bounds = [true, true]} : memref<1x16xf32, strided<[32, 1], offset: ?>>, vector<1x16xf32>
+# CHECK-NEXT:            %12 = vector.transfer_read %subview_13[%c0, %c0], %0 {in_bounds = [true, true]} : memref<1x16xf32, strided<[32, 1], offset: ?>>, vector<1x16xf32>
+# CHECK-NEXT:            %13 = vector.extract %11[0] : vector<16xf32> from vector<1x16xf32>
+# CHECK-NEXT:            %14 = vector.extract %10[0, 0] : f32 from vector<1x1xf32>
+# CHECK-NEXT:            %15 = vector.broadcast %14 : f32 to vector<16xf32>
+# CHECK-NEXT:            %16 = vector.extract %12[0] : vector<16xf32> from vector<1x16xf32>
+# CHECK-NEXT:            %17 = vector.fma %15, %13, %16 : vector<16xf32>
+# CHECK-NEXT:            %18 = vector.insert %17, %cst [0] : vector<16xf32> into vector<1x16xf32>
+# CHECK-NEXT:            vector.transfer_write %18, %subview_13[%c0, %c0] {in_bounds = [true, true]} : vector<1x16xf32>, memref<1x16xf32, strided<[32, 1], offset: ?>>
 # CHECK-NEXT:          } {"./j"}
 # CHECK-NEXT:        } {"./i"}
 # CHECK-NEXT:      } {"./k"}

--- a/tests/filecheck/backends/test_matmul_scalar_mlir.py
+++ b/tests/filecheck/backends/test_matmul_scalar_mlir.py
@@ -42,7 +42,7 @@ print(f"CODE: {res}")
 # CHECK-NEXT:    }
 # CHECK-NEXT:    transform.named_sequence @_vecto(%arg0: !transform.any_op {transform.consumed}) {
 # CHECK-NEXT:      transform.structured.vectorize %arg0 : !transform.any_op
-# CHECK-NEXT:      transform.yield
+# CHECK-NEXT:      transform.yield 
 # CHECK-NEXT:    }
 # CHECK-NEXT:    transform.named_sequence @__transform_main(%arg0: !transform.any_op {transform.readonly}) {
 # CHECK-NEXT:      %0 = transform.structured.match attributes {__xtc_id_C_0_} in %arg0 : (!transform.any_op) -> !transform.any_op
@@ -50,9 +50,8 @@ print(f"CODE: {res}")
 # CHECK-NEXT:      transform.annotate %loops "./i" : !transform.any_op
 # CHECK-NEXT:      %tiled_linalg_op_0, %loops_1 = transform.structured.tile_using_for %tiled_linalg_op tile_sizes [0, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
 # CHECK-NEXT:      transform.annotate %loops_1 "./j" : !transform.any_op
-# CHECK-NEXT:      %1 = transform.get_parent_op %loops {isolated_from_above} : (!transform.any_op) -> !transform.any_op
-# CHECK-NEXT:      %2 = transform.structured.match attributes {__xtc_id_C_} in %arg0 : (!transform.any_op) -> !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_2, %loops_3 = transform.structured.tile_using_for %2 tile_sizes [0, 0, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      %1 = transform.structured.match attributes {__xtc_id_C_} in %arg0 : (!transform.any_op) -> !transform.any_op
+# CHECK-NEXT:      %tiled_linalg_op_2, %loops_3 = transform.structured.tile_using_for %1 tile_sizes [0, 0, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
 # CHECK-NEXT:      transform.annotate %loops_3 "./k" : !transform.any_op
 # CHECK-NEXT:      %tiled_linalg_op_4, %loops_5 = transform.structured.tile_using_for %tiled_linalg_op_2 tile_sizes [2, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
 # CHECK-NEXT:      transform.annotate %loops_5 "./i" : !transform.any_op
@@ -62,10 +61,8 @@ print(f"CODE: {res}")
 # CHECK-NEXT:      transform.annotate %loops_9 "./i1" : !transform.any_op
 # CHECK-NEXT:      %tiled_linalg_op_10, %loops_11 = transform.structured.tile_using_for %tiled_linalg_op_8 tile_sizes [0, 1, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
 # CHECK-NEXT:      transform.annotate %loops_11 "./j1" : !transform.any_op
-# CHECK-NEXT:      %3 = transform.get_parent_op %loops_3 {isolated_from_above} : (!transform.any_op) -> !transform.any_op
-# CHECK-NEXT:      %4 = transform.structured.match attributes {"./i1"} in %3 : (!transform.any_op) -> !transform.any_op
 # CHECK-NEXT:      transform.loop.unroll %loops_9 {factor = 2 : i64} : !transform.any_op
-# CHECK-NEXT:      transform.yield
+# CHECK-NEXT:      transform.yield 
 # CHECK-NEXT:    }
 # CHECK-NEXT:  }
 # CHECK-NEXT:  

--- a/tests/filecheck/mlir_loop/descript_syntax/other/i_unused_split.mlir
+++ b/tests/filecheck/mlir_loop/descript_syntax/other/i_unused_split.mlir
@@ -33,13 +33,10 @@ func.func @matmul(%A: memref<256x512xf64>, %B: memref<512x256xf64>, %C: memref<2
 // CHECK-NEXT:      transform.annotate %loops_1 "__node0__/i[0]/j" : !transform.any_op
 // CHECK-NEXT:      %tiled_linalg_op_2, %loops_3 = transform.structured.tile_using_for %tiled_linalg_op_0 tile_sizes [0, 0, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
 // CHECK-NEXT:      transform.annotate %loops_3 "__node0__/i[0]/k" : !transform.any_op
-// CHECK-NEXT:      %3 = transform.get_parent_op %loops {isolated_from_above} : (!transform.any_op) -> !transform.any_op
 // CHECK-NEXT:      %tiled_linalg_op_4, %loops_5 = transform.structured.tile_using_for %2#1 tile_sizes [1, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
 // CHECK-NEXT:      transform.annotate %loops_5 "__node0__/i[1]/i" : !transform.any_op
 // CHECK-NEXT:      %tiled_linalg_op_6, %loops_7 = transform.structured.tile_using_for %tiled_linalg_op_4 tile_sizes [0, 1, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
 // CHECK-NEXT:      transform.annotate %loops_7 "__node0__/i[1]/j" : !transform.any_op
-// CHECK-NEXT:      %4 = transform.get_parent_op %loops_5 {isolated_from_above} : (!transform.any_op) -> !transform.any_op
-// CHECK-NEXT:      %5 = transform.get_parent_op %loops {isolated_from_above} : (!transform.any_op) -> !transform.any_op
 // CHECK-NEXT:      transform.yield 
 // CHECK-NEXT:    }
 // CHECK-NEXT:  }

--- a/tests/filecheck/mlir_loop/descript_syntax/other/v_tiling_unrolling.mlir
+++ b/tests/filecheck/mlir_loop/descript_syntax/other/v_tiling_unrolling.mlir
@@ -40,8 +40,6 @@ func.func @matmul(%A: memref<256x512xf64>, %B: memref<512x256xf64>, %C: memref<2
 // CHECK-NEXT:      transform.annotate %loops_7 "__node0__/k0" : !transform.any_op
 // CHECK-NEXT:      %tiled_linalg_op_8, %loops_9 = transform.structured.tile_using_for %tiled_linalg_op_6 tile_sizes [0, 1, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
 // CHECK-NEXT:      transform.annotate %loops_9 "__node0__/j0" : !transform.any_op
-// CHECK-NEXT:      %1 = transform.get_parent_op %loops {isolated_from_above} : (!transform.any_op) -> !transform.any_op
-// CHECK-NEXT:      %2 = transform.structured.match attributes {"__node0__/j0"} in %1 : (!transform.any_op) -> !transform.any_op
 // CHECK-NEXT:      transform.loop.unroll %loops_9 {factor = 2 : i64} : !transform.any_op
 // CHECK-NEXT:      transform.yield 
 // CHECK-NEXT:    }

--- a/tests/filecheck/mlir_loop/descript_syntax/parallelize/v_parallelize1.mlir
+++ b/tests/filecheck/mlir_loop/descript_syntax/parallelize/v_parallelize1.mlir
@@ -32,7 +32,6 @@ func.func @matmul(%A: memref<256x512xf64>, %B: memref<512x256xf64>, %C: memref<2
 // CHECK-NEXT:      transform.annotate %loops_1 "__node0__/k" : !transform.any_op
 // CHECK-NEXT:      %tiled_op, %forall_op = transform.structured.tile_using_forall %tiled_linalg_op_0 tile_sizes [0, 1, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
 // CHECK-NEXT:      transform.annotate %forall_op "__node0__/j" : !transform.any_op
-// CHECK-NEXT:      %1 = transform.get_parent_op %loops {isolated_from_above} : (!transform.any_op) -> !transform.any_op
 // CHECK-NEXT:      transform.yield 
 // CHECK-NEXT:    }
 // CHECK-NEXT:  }

--- a/tests/filecheck/mlir_loop/descript_syntax/parallelize/v_parallelize2.mlir
+++ b/tests/filecheck/mlir_loop/descript_syntax/parallelize/v_parallelize2.mlir
@@ -12,25 +12,5 @@ func.func @matmul(%A: memref<256x512xf64>, %B: memref<512x256xf64>, %C: memref<2
 	ins(%A, %B : memref<256x512xf64>, memref<512x256xf64>)
 	outs(%C: memref<256x256xf64>)
 	return
-}// CHECK:       // -----// IR Dump Before transform //----- //
-// CHECK-NEXT:  module attributes {transform.with_named_sequence} {
-// CHECK-NEXT:    func.func @matmul(%arg0: memref<256x512xf64> {llvm.noalias}, %arg1: memref<512x256xf64> {llvm.noalias}, %arg2: memref<256x256xf64> {llvm.noalias}) {
-// CHECK-NEXT:      linalg.matmul {__node0__} ins(%arg0, %arg1 : memref<256x512xf64>, memref<512x256xf64>) outs(%arg2 : memref<256x256xf64>)
-// CHECK-NEXT:      return
-// CHECK-NEXT:    }
-// CHECK-NEXT:    transform.named_sequence @_vecto(%arg0: !transform.any_op {transform.consumed}) {
-// CHECK-NEXT:      transform.structured.vectorize %arg0 : !transform.any_op
-// CHECK-NEXT:      transform.yield 
-// CHECK-NEXT:    }
-// CHECK-NEXT:    transform.named_sequence @__transform_main(%arg0: !transform.any_op {transform.readonly}) {
-// CHECK-NEXT:      %0 = transform.structured.match attributes {__node0__} in %arg0 : (!transform.any_op) -> !transform.any_op
-// CHECK-NEXT:      %tiled_linalg_op, %loops = transform.structured.tile_using_for %0 tile_sizes [1, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-// CHECK-NEXT:      transform.annotate %loops "__node0__/i" : !transform.any_op
-// CHECK-NEXT:      %tiled_op, %forall_op = transform.structured.tile_using_forall %tiled_linalg_op tile_sizes [0, 0, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-// CHECK-NEXT:      transform.annotate %forall_op "__node0__/k" : !transform.any_op
-// CHECK-NEXT:      %tiled_linalg_op_0, %loops_1 = transform.structured.tile_using_for %tiled_op tile_sizes [0, 1, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-// CHECK-NEXT:      transform.annotate %loops_1 "__node0__/j" : !transform.any_op
-// CHECK-NEXT:      %1 = transform.get_parent_op %loops {isolated_from_above} : (!transform.any_op) -> !transform.any_op
-// CHECK-NEXT:      transform.yield 
-// CHECK-NEXT:    }
-// CHECK-NEXT:  }
+}
+// CHECK: MLIR Error: tiling is not thread safe at axis #2

--- a/tests/filecheck/mlir_loop/descript_syntax/parallelize/v_parallelize3.mlir
+++ b/tests/filecheck/mlir_loop/descript_syntax/parallelize/v_parallelize3.mlir
@@ -32,7 +32,6 @@ func.func @matmul(%A: memref<256x512xf64>, %B: memref<512x256xf64>, %C: memref<2
 // CHECK-NEXT:      transform.annotate %loops "__node0__/k" : !transform.any_op
 // CHECK-NEXT:      %tiled_linalg_op_0, %loops_1 = transform.structured.tile_using_for %tiled_linalg_op tile_sizes [0, 1, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
 // CHECK-NEXT:      transform.annotate %loops_1 "__node0__/j" : !transform.any_op
-// CHECK-NEXT:      %1 = transform.get_parent_op %forall_op {isolated_from_above} : (!transform.any_op) -> !transform.any_op
 // CHECK-NEXT:      transform.yield 
 // CHECK-NEXT:    }
 // CHECK-NEXT:  }

--- a/tests/filecheck/mlir_loop/descript_syntax/splitting/v_splitting.mlir
+++ b/tests/filecheck/mlir_loop/descript_syntax/splitting/v_splitting.mlir
@@ -30,13 +30,10 @@ func.func @matmul(%A: memref<256x512xf64>, %B: memref<512x256xf64>, %C: memref<2
 // CHECK-NEXT:      transform.annotate %loops "__node0__/i[0]/i" : !transform.any_op
 // CHECK-NEXT:      %tiled_linalg_op_0, %loops_1 = transform.structured.tile_using_for %tiled_linalg_op tile_sizes [0, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
 // CHECK-NEXT:      transform.annotate %loops_1 "__node0__/i[0]/j" : !transform.any_op
-// CHECK-NEXT:      %3 = transform.get_parent_op %loops {isolated_from_above} : (!transform.any_op) -> !transform.any_op
 // CHECK-NEXT:      %tiled_linalg_op_2, %loops_3 = transform.structured.tile_using_for %2#1 tile_sizes [1, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
 // CHECK-NEXT:      transform.annotate %loops_3 "__node0__/i[1]/i" : !transform.any_op
 // CHECK-NEXT:      %tiled_linalg_op_4, %loops_5 = transform.structured.tile_using_for %tiled_linalg_op_2 tile_sizes [0, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
 // CHECK-NEXT:      transform.annotate %loops_5 "__node0__/i[1]/j" : !transform.any_op
-// CHECK-NEXT:      %4 = transform.get_parent_op %loops_3 {isolated_from_above} : (!transform.any_op) -> !transform.any_op
-// CHECK-NEXT:      %5 = transform.get_parent_op %loops {isolated_from_above} : (!transform.any_op) -> !transform.any_op
 // CHECK-NEXT:      transform.yield 
 // CHECK-NEXT:    }
 // CHECK-NEXT:  }

--- a/tests/filecheck/mlir_loop/descript_syntax/splitting/v_useless_splitting.mlir
+++ b/tests/filecheck/mlir_loop/descript_syntax/splitting/v_useless_splitting.mlir
@@ -31,8 +31,6 @@ func.func @matmul(%A: memref<256x512xf64>, %B: memref<512x256xf64>, %C: memref<2
 // CHECK-NEXT:      transform.annotate %loops_1 "__node0__/k" : !transform.any_op
 // CHECK-NEXT:      %tiled_linalg_op_2, %loops_3 = transform.structured.tile_using_for %tiled_linalg_op_0 tile_sizes [0, 1, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
 // CHECK-NEXT:      transform.annotate %loops_3 "__node0__/j[0]/j" : !transform.any_op
-// CHECK-NEXT:      %1 = transform.get_parent_op %loops_3 {isolated_from_above} : (!transform.any_op) -> !transform.any_op
-// CHECK-NEXT:      %2 = transform.get_parent_op %loops {isolated_from_above} : (!transform.any_op) -> !transform.any_op
 // CHECK-NEXT:      transform.yield 
 // CHECK-NEXT:    }
 // CHECK-NEXT:  }

--- a/tests/filecheck/mlir_loop/descript_syntax/tiling/v_inner_tile.mlir
+++ b/tests/filecheck/mlir_loop/descript_syntax/tiling/v_inner_tile.mlir
@@ -46,15 +46,12 @@ func.func @matmul(%A: memref<256x512xf64>, %B: memref<512x256xf64>, %C: memref<2
 // CHECK-NEXT:      transform.annotate %loops_7 "__node0__/k[0]/k0" : !transform.any_op
 // CHECK-NEXT:      %tiled_linalg_op_8, %loops_9 = transform.structured.tile_using_for %tiled_linalg_op_6 tile_sizes [0, 1, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
 // CHECK-NEXT:      transform.annotate %loops_9 "__node0__/k[0]/j0" : !transform.any_op
-// CHECK-NEXT:      %3 = transform.get_parent_op %loops_5 {isolated_from_above} : (!transform.any_op) -> !transform.any_op
 // CHECK-NEXT:      %tiled_linalg_op_10, %loops_11 = transform.structured.tile_using_for %2#1 tile_sizes [0, 0, 8] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
 // CHECK-NEXT:      transform.annotate %loops_11 "__node0__/k[1]/k" : !transform.any_op
 // CHECK-NEXT:      %tiled_linalg_op_12, %loops_13 = transform.structured.tile_using_for %tiled_linalg_op_10 tile_sizes [0, 0, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
 // CHECK-NEXT:      transform.annotate %loops_13 "__node0__/k[1]/k0" : !transform.any_op
 // CHECK-NEXT:      %tiled_linalg_op_14, %loops_15 = transform.structured.tile_using_for %tiled_linalg_op_12 tile_sizes [0, 1, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
 // CHECK-NEXT:      transform.annotate %loops_15 "__node0__/k[1]/j0" : !transform.any_op
-// CHECK-NEXT:      %4 = transform.get_parent_op %loops_11 {isolated_from_above} : (!transform.any_op) -> !transform.any_op
-// CHECK-NEXT:      %5 = transform.get_parent_op %loops {isolated_from_above} : (!transform.any_op) -> !transform.any_op
 // CHECK-NEXT:      transform.yield 
 // CHECK-NEXT:    }
 // CHECK-NEXT:  }

--- a/tests/filecheck/mlir_loop/descript_syntax/tiling/v_one_axis_positive_lower_tiling.mlir
+++ b/tests/filecheck/mlir_loop/descript_syntax/tiling/v_one_axis_positive_lower_tiling.mlir
@@ -36,7 +36,6 @@ func.func @matmul(%A: memref<256x512xf64>, %B: memref<512x256xf64>, %C: memref<2
 // CHECK-NEXT:      transform.annotate %loops_5 "__node0__/k1" : !transform.any_op
 // CHECK-NEXT:      %tiled_linalg_op_6, %loops_7 = transform.structured.tile_using_for %tiled_linalg_op_4 tile_sizes [0, 1, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
 // CHECK-NEXT:      transform.annotate %loops_7 "__node0__/j" : !transform.any_op
-// CHECK-NEXT:      %1 = transform.get_parent_op %loops {isolated_from_above} : (!transform.any_op) -> !transform.any_op
 // CHECK-NEXT:      transform.yield 
 // CHECK-NEXT:    }
 // CHECK-NEXT:  }

--- a/tests/filecheck/mlir_loop/descript_syntax/tiling/v_tiling.mlir
+++ b/tests/filecheck/mlir_loop/descript_syntax/tiling/v_tiling.mlir
@@ -39,7 +39,6 @@ func.func @matmul(%A: memref<256x512xf64>, %B: memref<512x256xf64>, %C: memref<2
 // CHECK-NEXT:      transform.annotate %loops_7 "__node0__/k0" : !transform.any_op
 // CHECK-NEXT:      %tiled_linalg_op_8, %loops_9 = transform.structured.tile_using_for %tiled_linalg_op_6 tile_sizes [0, 1, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
 // CHECK-NEXT:      transform.annotate %loops_9 "__node0__/j0" : !transform.any_op
-// CHECK-NEXT:      %1 = transform.get_parent_op %loops {isolated_from_above} : (!transform.any_op) -> !transform.any_op
 // CHECK-NEXT:      transform.yield 
 // CHECK-NEXT:    }
 // CHECK-NEXT:  }

--- a/tests/filecheck/mlir_loop/descript_syntax/unrolling/v_no_param_unroll.mlir
+++ b/tests/filecheck/mlir_loop/descript_syntax/unrolling/v_no_param_unroll.mlir
@@ -35,8 +35,6 @@ func.func @matmul(%A: memref<256x512xf64>, %B: memref<512x256xf64>, %C: memref<2
 // CHECK-NEXT:      transform.annotate %loops_3 "__node0__/j" : !transform.any_op
 // CHECK-NEXT:      %tiled_linalg_op_4, %loops_5 = transform.structured.tile_using_for %tiled_linalg_op_2 tile_sizes [0, 1, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
 // CHECK-NEXT:      transform.annotate %loops_5 "__node0__/j0" : !transform.any_op
-// CHECK-NEXT:      %1 = transform.get_parent_op %loops {isolated_from_above} : (!transform.any_op) -> !transform.any_op
-// CHECK-NEXT:      %2 = transform.structured.match attributes {"__node0__/j0"} in %1 : (!transform.any_op) -> !transform.any_op
 // CHECK-NEXT:      transform.loop.unroll %loops_5 {factor = 1 : i64} : !transform.any_op
 // CHECK-NEXT:      transform.yield 
 // CHECK-NEXT:    }

--- a/tests/filecheck/mlir_loop/descript_syntax/unrolling/v_param_unroll.mlir
+++ b/tests/filecheck/mlir_loop/descript_syntax/unrolling/v_param_unroll.mlir
@@ -32,8 +32,6 @@ func.func @matmul(%A: memref<256x512xf64>, %B: memref<512x256xf64>, %C: memref<2
 // CHECK-NEXT:      transform.annotate %loops_1 "__node0__/k" : !transform.any_op
 // CHECK-NEXT:      %tiled_linalg_op_2, %loops_3 = transform.structured.tile_using_for %tiled_linalg_op_0 tile_sizes [0, 1, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
 // CHECK-NEXT:      transform.annotate %loops_3 "__node0__/j" : !transform.any_op
-// CHECK-NEXT:      %1 = transform.get_parent_op %loops {isolated_from_above} : (!transform.any_op) -> !transform.any_op
-// CHECK-NEXT:      %2 = transform.structured.match attributes {"__node0__/j"} in %1 : (!transform.any_op) -> !transform.any_op
 // CHECK-NEXT:      transform.loop.unroll %loops_3 {factor = 10 : i64} : !transform.any_op
 // CHECK-NEXT:      transform.yield 
 // CHECK-NEXT:    }

--- a/tests/filecheck/mlir_loop/descript_syntax/unrolling/v_positive_positive_unroll.mlir
+++ b/tests/filecheck/mlir_loop/descript_syntax/unrolling/v_positive_positive_unroll.mlir
@@ -30,10 +30,7 @@ func.func @matmul(%A: memref<256x512xf64>, %B: memref<512x256xf64>, %C: memref<2
 // CHECK-NEXT:      transform.annotate %loops_1 "__node0__/k" : !transform.any_op
 // CHECK-NEXT:      %tiled_linalg_op_2, %loops_3 = transform.structured.tile_using_for %tiled_linalg_op_0 tile_sizes [0, 1, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
 // CHECK-NEXT:      transform.annotate %loops_3 "__node0__/j" : !transform.any_op
-// CHECK-NEXT:      %1 = transform.get_parent_op %loops {isolated_from_above} : (!transform.any_op) -> !transform.any_op
-// CHECK-NEXT:      %2 = transform.structured.match attributes {"__node0__/j"} in %1 : (!transform.any_op) -> !transform.any_op
 // CHECK-NEXT:      transform.loop.unroll %loops_3 {factor = 1 : i64} : !transform.any_op
-// CHECK-NEXT:      %3 = transform.structured.match attributes {"__node0__/k"} in %1 : (!transform.any_op) -> !transform.any_op
 // CHECK-NEXT:      transform.loop.unroll %loops_1 {factor = 1 : i64} : !transform.any_op
 // CHECK-NEXT:      transform.yield 
 // CHECK-NEXT:    }

--- a/tests/filecheck/mlir_loop/descript_syntax/unrolling/v_unroll_split.mlir
+++ b/tests/filecheck/mlir_loop/descript_syntax/unrolling/v_unroll_split.mlir
@@ -33,15 +33,11 @@ func.func @matmul(%A: memref<256x512xf64>, %B: memref<512x256xf64>, %C: memref<2
 // CHECK-NEXT:      transform.annotate %loops_1 "__node0__/k[0]/k" : !transform.any_op
 // CHECK-NEXT:      %tiled_linalg_op_2, %loops_3 = transform.structured.tile_using_for %tiled_linalg_op_0 tile_sizes [0, 1, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
 // CHECK-NEXT:      transform.annotate %loops_3 "__node0__/k[0]/j" : !transform.any_op
-// CHECK-NEXT:      %3 = transform.get_parent_op %loops_1 {isolated_from_above} : (!transform.any_op) -> !transform.any_op
-// CHECK-NEXT:      %4 = transform.structured.match attributes {"__node0__/k[0]/j"} in %3 : (!transform.any_op) -> !transform.any_op
 // CHECK-NEXT:      transform.loop.unroll %loops_3 {factor = 256 : i64} : !transform.any_op
 // CHECK-NEXT:      %tiled_linalg_op_4, %loops_5 = transform.structured.tile_using_for %2#1 tile_sizes [0, 0, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
 // CHECK-NEXT:      transform.annotate %loops_5 "__node0__/k[1]/k" : !transform.any_op
 // CHECK-NEXT:      %tiled_linalg_op_6, %loops_7 = transform.structured.tile_using_for %tiled_linalg_op_4 tile_sizes [0, 1, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
 // CHECK-NEXT:      transform.annotate %loops_7 "__node0__/k[1]/j" : !transform.any_op
-// CHECK-NEXT:      %5 = transform.get_parent_op %loops_5 {isolated_from_above} : (!transform.any_op) -> !transform.any_op
-// CHECK-NEXT:      %6 = transform.get_parent_op %loops {isolated_from_above} : (!transform.any_op) -> !transform.any_op
 // CHECK-NEXT:      transform.yield 
 // CHECK-NEXT:    }
 // CHECK-NEXT:  }

--- a/tests/filecheck/mlir_loop/descript_syntax/unrolling/v_unroll_split2.mlir
+++ b/tests/filecheck/mlir_loop/descript_syntax/unrolling/v_unroll_split2.mlir
@@ -34,15 +34,11 @@ func.func @matmul(%A: memref<256x512xf64>, %B: memref<512x256xf64>, %C: memref<2
 // CHECK-NEXT:      transform.annotate %loops_1 "__node0__/k[0]/k" : !transform.any_op
 // CHECK-NEXT:      %tiled_linalg_op_2, %loops_3 = transform.structured.tile_using_for %tiled_linalg_op_0 tile_sizes [0, 1, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
 // CHECK-NEXT:      transform.annotate %loops_3 "__node0__/k[0]/j" : !transform.any_op
-// CHECK-NEXT:      %3 = transform.get_parent_op %loops_1 {isolated_from_above} : (!transform.any_op) -> !transform.any_op
 // CHECK-NEXT:      %tiled_linalg_op_4, %loops_5 = transform.structured.tile_using_for %2#1 tile_sizes [0, 0, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
 // CHECK-NEXT:      transform.annotate %loops_5 "__node0__/k[1]/k" : !transform.any_op
 // CHECK-NEXT:      %tiled_linalg_op_6, %loops_7 = transform.structured.tile_using_for %tiled_linalg_op_4 tile_sizes [0, 1, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
 // CHECK-NEXT:      transform.annotate %loops_7 "__node0__/k[1]/j" : !transform.any_op
-// CHECK-NEXT:      %4 = transform.get_parent_op %loops_5 {isolated_from_above} : (!transform.any_op) -> !transform.any_op
-// CHECK-NEXT:      %5 = transform.structured.match attributes {"__node0__/k[1]/j"} in %4 : (!transform.any_op) -> !transform.any_op
 // CHECK-NEXT:      transform.loop.unroll %loops_7 {factor = 256 : i64} : !transform.any_op
-// CHECK-NEXT:      %6 = transform.get_parent_op %loops {isolated_from_above} : (!transform.any_op) -> !transform.any_op
 // CHECK-NEXT:      transform.yield 
 // CHECK-NEXT:    }
 // CHECK-NEXT:  }

--- a/tests/filecheck/mlir_loop/descript_syntax/vectorize/v_inner_vectorize.mlir
+++ b/tests/filecheck/mlir_loop/descript_syntax/vectorize/v_inner_vectorize.mlir
@@ -42,36 +42,18 @@ func.func @matmul(%A: memref<256x512xf64>, %B: memref<512x256xf64>, %C: memref<2
 // CHECK-NEXT:      %2:2 = transform.split_handle %1 : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
 // CHECK-NEXT:      %tiled_linalg_op_2, %loops_3 = transform.structured.tile_using_for %2#0 tile_sizes [0, 0, 8] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
 // CHECK-NEXT:      transform.annotate %loops_3 "__node0__/k[0]/k" : !transform.any_op
-// CHECK-NEXT:      %3 = transform.get_parent_op %loops_3 {isolated_from_above} : (!transform.any_op) -> !transform.any_op
 // CHECK-NEXT:      transform.include @_vecto failures(suppress) (%tiled_linalg_op_2) : (!transform.any_op) -> ()
-// CHECK-NEXT:      transform.apply_patterns to %3 {
-// CHECK-NEXT:        transform.apply_patterns.vector.reduction_to_contract
-// CHECK-NEXT:        transform.apply_patterns.vector.transfer_permutation_patterns
-// CHECK-NEXT:      } : !transform.any_op
-// CHECK-NEXT:      transform.apply_patterns to %3 {
-// CHECK-NEXT:        transform.apply_patterns.vector.lower_outerproduct
-// CHECK-NEXT:        transform.apply_patterns.vector.lower_contraction
-// CHECK-NEXT:      } : !transform.any_op
 // CHECK-NEXT:      %tiled_linalg_op_4, %loops_5 = transform.structured.tile_using_for %2#1 tile_sizes [0, 0, 8] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
 // CHECK-NEXT:      transform.annotate %loops_5 "__node0__/k[1]/k" : !transform.any_op
 // CHECK-NEXT:      %tiled_linalg_op_6, %loops_7 = transform.structured.tile_using_for %tiled_linalg_op_4 tile_sizes [1, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
 // CHECK-NEXT:      transform.annotate %loops_7 "__node0__/k[1]/i0" : !transform.any_op
-// CHECK-NEXT:      %4 = transform.get_parent_op %loops_5 {isolated_from_above} : (!transform.any_op) -> !transform.any_op
 // CHECK-NEXT:      transform.include @_vecto failures(suppress) (%tiled_linalg_op_6) : (!transform.any_op) -> ()
-// CHECK-NEXT:      transform.apply_patterns to %4 {
+// CHECK-NEXT:      %3 = transform.get_parent_op %loops {isolated_from_above} : (!transform.any_op) -> !transform.any_op
+// CHECK-NEXT:      transform.apply_patterns to %3 {
 // CHECK-NEXT:        transform.apply_patterns.vector.reduction_to_contract
 // CHECK-NEXT:        transform.apply_patterns.vector.transfer_permutation_patterns
 // CHECK-NEXT:      } : !transform.any_op
-// CHECK-NEXT:      transform.apply_patterns to %4 {
-// CHECK-NEXT:        transform.apply_patterns.vector.lower_outerproduct
-// CHECK-NEXT:        transform.apply_patterns.vector.lower_contraction
-// CHECK-NEXT:      } : !transform.any_op
-// CHECK-NEXT:      %5 = transform.get_parent_op %loops {isolated_from_above} : (!transform.any_op) -> !transform.any_op
-// CHECK-NEXT:      transform.apply_patterns to %5 {
-// CHECK-NEXT:        transform.apply_patterns.vector.reduction_to_contract
-// CHECK-NEXT:        transform.apply_patterns.vector.transfer_permutation_patterns
-// CHECK-NEXT:      } : !transform.any_op
-// CHECK-NEXT:      transform.apply_patterns to %5 {
+// CHECK-NEXT:      transform.apply_patterns to %3 {
 // CHECK-NEXT:        transform.apply_patterns.vector.lower_outerproduct
 // CHECK-NEXT:        transform.apply_patterns.vector.lower_contraction
 // CHECK-NEXT:      } : !transform.any_op

--- a/tests/filecheck/mlir_loop/descript_syntax/vectorize/v_tiled.mlir
+++ b/tests/filecheck/mlir_loop/descript_syntax/vectorize/v_tiled.mlir
@@ -39,8 +39,8 @@ func.func @matmul(%A: memref<256x512xf64>, %B: memref<512x256xf64>, %C: memref<2
 // CHECK-NEXT:      transform.annotate %loops_5 "__node0__/i0" : !transform.any_op
 // CHECK-NEXT:      %tiled_linalg_op_6, %loops_7 = transform.structured.tile_using_for %tiled_linalg_op_4 tile_sizes [0, 0, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
 // CHECK-NEXT:      transform.annotate %loops_7 "__node0__/k0" : !transform.any_op
-// CHECK-NEXT:      %1 = transform.get_parent_op %loops {isolated_from_above} : (!transform.any_op) -> !transform.any_op
 // CHECK-NEXT:      transform.include @_vecto failures(suppress) (%tiled_linalg_op_6) : (!transform.any_op) -> ()
+// CHECK-NEXT:      %1 = transform.get_parent_op %loops {isolated_from_above} : (!transform.any_op) -> !transform.any_op
 // CHECK-NEXT:      transform.apply_patterns to %1 {
 // CHECK-NEXT:        transform.apply_patterns.vector.reduction_to_contract
 // CHECK-NEXT:        transform.apply_patterns.vector.transfer_permutation_patterns

--- a/tests/filecheck/mlir_loop/descript_syntax/vectorize/v_vectorize3.mlir
+++ b/tests/filecheck/mlir_loop/descript_syntax/vectorize/v_vectorize3.mlir
@@ -29,8 +29,8 @@ func.func @matmul(%A: memref<256x512xf64>, %B: memref<512x256xf64>, %C: memref<2
 // CHECK-NEXT:      transform.annotate %loops "__node0__/i" : !transform.any_op
 // CHECK-NEXT:      %tiled_linalg_op_0, %loops_1 = transform.structured.tile_using_for %tiled_linalg_op tile_sizes [0, 0, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
 // CHECK-NEXT:      transform.annotate %loops_1 "__node0__/k" : !transform.any_op
-// CHECK-NEXT:      %1 = transform.get_parent_op %loops {isolated_from_above} : (!transform.any_op) -> !transform.any_op
 // CHECK-NEXT:      transform.include @_vecto failures(suppress) (%tiled_linalg_op_0) : (!transform.any_op) -> ()
+// CHECK-NEXT:      %1 = transform.get_parent_op %loops {isolated_from_above} : (!transform.any_op) -> !transform.any_op
 // CHECK-NEXT:      transform.apply_patterns to %1 {
 // CHECK-NEXT:        transform.apply_patterns.vector.reduction_to_contract
 // CHECK-NEXT:        transform.apply_patterns.vector.transfer_permutation_patterns

--- a/tests/filecheck/mlir_loop/gen_assembly/skylake_split_matmul.mlir
+++ b/tests/filecheck/mlir_loop/gen_assembly/skylake_split_matmul.mlir
@@ -28,9 +28,7 @@ func.func @myfun(
     outs(%C : memref<258x256xf32>)
   return
 }
-// CHECK:       Disassembly of section .text:
-// CHECK-NEXT:  
-// CHECK-NEXT:  <myfun>:
+// CHECK:      <myfun>:
 // CHECK-NEXT:  	push   %rbx
 // CHECK-NEXT:  	xor    %ecx,%ecx
 // CHECK-NEXT:  	mov    %rsi,%rax
@@ -449,4 +447,4 @@ func.func @myfun(
 // CHECK-NEXT:  	lea    0x1(%r9),%r9
 // CHECK-NEXT:  	jb     <myfun+0xd0>
 // CHECK-NEXT:  	pop    %rbx
-// CHECK-NEXT:  	vzeroupper 
+// CHECK-NEXT:  	vzeroupper

--- a/tests/filecheck/mlir_loop/gen_ir/fmadd_matmul.mlir
+++ b/tests/filecheck/mlir_loop/gen_ir/fmadd_matmul.mlir
@@ -22,10 +22,10 @@ func.func @myfun(
   return
 }
 // CHECK:                 %8 = vector.fma %6, %4, %7 : vector<64xf32>
-// CHECK-NEXT:            %19 = vector.fma %17, %15, %18 : vector<64xf32>
-// CHECK-NEXT:            %30 = vector.fma %28, %26, %29 : vector<64xf32>
-// CHECK-NEXT:            %41 = vector.fma %39, %37, %40 : vector<64xf32>
-// CHECK-NEXT:            %52 = vector.fma %50, %48, %51 : vector<64xf32>
-// CHECK-NEXT:            %63 = vector.fma %61, %59, %62 : vector<64xf32>
-// CHECK-NEXT:            %74 = vector.fma %72, %70, %73 : vector<64xf32>
-// CHECK-NEXT:            %85 = vector.fma %83, %81, %84 : vector<64xf32>
+// CHECK-NEXT:            %17 = vector.fma %15, %13, %16 : vector<64xf32>
+// CHECK-NEXT:            %26 = vector.fma %24, %22, %25 : vector<64xf32>
+// CHECK-NEXT:            %35 = vector.fma %33, %31, %34 : vector<64xf32>
+// CHECK-NEXT:            %44 = vector.fma %42, %40, %43 : vector<64xf32>
+// CHECK-NEXT:            %53 = vector.fma %51, %49, %52 : vector<64xf32>
+// CHECK-NEXT:            %62 = vector.fma %60, %58, %61 : vector<64xf32>
+// CHECK-NEXT:            %71 = vector.fma %69, %67, %70 : vector<64xf32>

--- a/tests/filecheck/mlir_loop/gen_ir/vecto_matmul.mlir
+++ b/tests/filecheck/mlir_loop/gen_ir/vecto_matmul.mlir
@@ -22,83 +22,83 @@ func.func @myfun(
   return
 }
 
-// CHECK:                 %1 = vector.transfer_read %subview_9[%c0, %c0], %0 {in_bounds = [true, true]} : memref<1x1xf32, strided<[512, 1], offset: ?>>, vector<1x1xf32>
-// CHECK-NEXT:            %2 = vector.transfer_read %subview_10[%c0, %c0], %0 {in_bounds = [true, true]} : memref<1x64xf32, strided<[256, 1], offset: ?>>, vector<1x64xf32>
-// CHECK-NEXT:            %3 = vector.transfer_read %subview_7[%c0, %c0], %0 {in_bounds = [true, true]} : memref<1x64xf32, strided<[256, 1], offset: ?>>, vector<1x64xf32>
+// CHECK:                 %1 = vector.transfer_read %subview_6[%c0, %c0], %0 {in_bounds = [true, true]} : memref<1x1xf32, strided<[512, 1], offset: ?>>, vector<1x1xf32>
+// CHECK-NEXT:            %2 = vector.transfer_read %subview_7[%c0, %c0], %0 {in_bounds = [true, true]} : memref<1x64xf32, strided<[256, 1], offset: ?>>, vector<1x64xf32>
+// CHECK-NEXT:            %3 = vector.transfer_read %subview_3[%c0, %c0], %0 {in_bounds = [true, true]} : memref<1x64xf32, strided<[256, 1], offset: ?>>, vector<1x64xf32>
 // CHECK-NEXT:            %4 = vector.extract %2[0] : vector<64xf32> from vector<1x64xf32>
 // CHECK-NEXT:            %5 = vector.extract %1[0, 0] : f32 from vector<1x1xf32>
 // CHECK-NEXT:            %6 = vector.broadcast %5 : f32 to vector<64xf32>
 // CHECK-NEXT:            %7 = vector.extract %3[0] : vector<64xf32> from vector<1x64xf32>
 // CHECK-NEXT:            %8 = vector.fma %6, %4, %7 : vector<64xf32>
 // CHECK-NEXT:            %9 = vector.insert %8, %cst [0] : vector<64xf32> into vector<1x64xf32>
-// CHECK-NEXT:            vector.transfer_write %9, %subview_7[%c0, %c0] {in_bounds = [true, true]} : vector<1x64xf32>, memref<1x64xf32, strided<[256, 1], offset: ?>>
-// CHECK-NEXT:            %12 = vector.transfer_read %subview_12[%c0, %c0], %0 {in_bounds = [true, true]} : memref<1x1xf32, strided<[512, 1], offset: ?>>, vector<1x1xf32>
-// CHECK-NEXT:            %13 = vector.transfer_read %subview_13[%c0, %c0], %0 {in_bounds = [true, true]} : memref<1x64xf32, strided<[256, 1], offset: ?>>, vector<1x64xf32>
-// CHECK-NEXT:            %14 = vector.transfer_read %subview_7[%c0, %c0], %0 {in_bounds = [true, true]} : memref<1x64xf32, strided<[256, 1], offset: ?>>, vector<1x64xf32>
-// CHECK-NEXT:            %15 = vector.extract %13[0] : vector<64xf32> from vector<1x64xf32>
-// CHECK-NEXT:            %16 = vector.extract %12[0, 0] : f32 from vector<1x1xf32>
-// CHECK-NEXT:            %17 = vector.broadcast %16 : f32 to vector<64xf32>
-// CHECK-NEXT:            %18 = vector.extract %14[0] : vector<64xf32> from vector<1x64xf32>
-// CHECK-NEXT:            %19 = vector.fma %17, %15, %18 : vector<64xf32>
-// CHECK-NEXT:            %20 = vector.insert %19, %cst [0] : vector<64xf32> into vector<1x64xf32>
-// CHECK-NEXT:            vector.transfer_write %20, %subview_7[%c0, %c0] {in_bounds = [true, true]} : vector<1x64xf32>, memref<1x64xf32, strided<[256, 1], offset: ?>>
-// CHECK-NEXT:            %23 = vector.transfer_read %subview_14[%c0, %c0], %0 {in_bounds = [true, true]} : memref<1x1xf32, strided<[512, 1], offset: ?>>, vector<1x1xf32>
-// CHECK-NEXT:            %24 = vector.transfer_read %subview_15[%c0, %c0], %0 {in_bounds = [true, true]} : memref<1x64xf32, strided<[256, 1], offset: ?>>, vector<1x64xf32>
-// CHECK-NEXT:            %25 = vector.transfer_read %subview_7[%c0, %c0], %0 {in_bounds = [true, true]} : memref<1x64xf32, strided<[256, 1], offset: ?>>, vector<1x64xf32>
-// CHECK-NEXT:            %26 = vector.extract %24[0] : vector<64xf32> from vector<1x64xf32>
-// CHECK-NEXT:            %27 = vector.extract %23[0, 0] : f32 from vector<1x1xf32>
-// CHECK-NEXT:            %28 = vector.broadcast %27 : f32 to vector<64xf32>
-// CHECK-NEXT:            %29 = vector.extract %25[0] : vector<64xf32> from vector<1x64xf32>
-// CHECK-NEXT:            %30 = vector.fma %28, %26, %29 : vector<64xf32>
-// CHECK-NEXT:            %31 = vector.insert %30, %cst [0] : vector<64xf32> into vector<1x64xf32>
-// CHECK-NEXT:            vector.transfer_write %31, %subview_7[%c0, %c0] {in_bounds = [true, true]} : vector<1x64xf32>, memref<1x64xf32, strided<[256, 1], offset: ?>>
-// CHECK-NEXT:            %34 = vector.transfer_read %subview_16[%c0, %c0], %0 {in_bounds = [true, true]} : memref<1x1xf32, strided<[512, 1], offset: ?>>, vector<1x1xf32>
-// CHECK-NEXT:            %35 = vector.transfer_read %subview_17[%c0, %c0], %0 {in_bounds = [true, true]} : memref<1x64xf32, strided<[256, 1], offset: ?>>, vector<1x64xf32>
-// CHECK-NEXT:            %36 = vector.transfer_read %subview_7[%c0, %c0], %0 {in_bounds = [true, true]} : memref<1x64xf32, strided<[256, 1], offset: ?>>, vector<1x64xf32>
-// CHECK-NEXT:            %37 = vector.extract %35[0] : vector<64xf32> from vector<1x64xf32>
-// CHECK-NEXT:            %38 = vector.extract %34[0, 0] : f32 from vector<1x1xf32>
-// CHECK-NEXT:            %39 = vector.broadcast %38 : f32 to vector<64xf32>
-// CHECK-NEXT:            %40 = vector.extract %36[0] : vector<64xf32> from vector<1x64xf32>
-// CHECK-NEXT:            %41 = vector.fma %39, %37, %40 : vector<64xf32>
-// CHECK-NEXT:            %42 = vector.insert %41, %cst [0] : vector<64xf32> into vector<1x64xf32>
-// CHECK-NEXT:            vector.transfer_write %42, %subview_7[%c0, %c0] {in_bounds = [true, true]} : vector<1x64xf32>, memref<1x64xf32, strided<[256, 1], offset: ?>>
-// CHECK-NEXT:            %45 = vector.transfer_read %subview_18[%c0, %c0], %0 {in_bounds = [true, true]} : memref<1x1xf32, strided<[512, 1], offset: ?>>, vector<1x1xf32>
-// CHECK-NEXT:            %46 = vector.transfer_read %subview_19[%c0, %c0], %0 {in_bounds = [true, true]} : memref<1x64xf32, strided<[256, 1], offset: ?>>, vector<1x64xf32>
-// CHECK-NEXT:            %47 = vector.transfer_read %subview_7[%c0, %c0], %0 {in_bounds = [true, true]} : memref<1x64xf32, strided<[256, 1], offset: ?>>, vector<1x64xf32>
-// CHECK-NEXT:            %48 = vector.extract %46[0] : vector<64xf32> from vector<1x64xf32>
-// CHECK-NEXT:            %49 = vector.extract %45[0, 0] : f32 from vector<1x1xf32>
-// CHECK-NEXT:            %50 = vector.broadcast %49 : f32 to vector<64xf32>
-// CHECK-NEXT:            %51 = vector.extract %47[0] : vector<64xf32> from vector<1x64xf32>
-// CHECK-NEXT:            %52 = vector.fma %50, %48, %51 : vector<64xf32>
-// CHECK-NEXT:            %53 = vector.insert %52, %cst [0] : vector<64xf32> into vector<1x64xf32>
-// CHECK-NEXT:            vector.transfer_write %53, %subview_7[%c0, %c0] {in_bounds = [true, true]} : vector<1x64xf32>, memref<1x64xf32, strided<[256, 1], offset: ?>>
-// CHECK-NEXT:            %56 = vector.transfer_read %subview_20[%c0, %c0], %0 {in_bounds = [true, true]} : memref<1x1xf32, strided<[512, 1], offset: ?>>, vector<1x1xf32>
-// CHECK-NEXT:            %57 = vector.transfer_read %subview_21[%c0, %c0], %0 {in_bounds = [true, true]} : memref<1x64xf32, strided<[256, 1], offset: ?>>, vector<1x64xf32>
-// CHECK-NEXT:            %58 = vector.transfer_read %subview_7[%c0, %c0], %0 {in_bounds = [true, true]} : memref<1x64xf32, strided<[256, 1], offset: ?>>, vector<1x64xf32>
-// CHECK-NEXT:            %59 = vector.extract %57[0] : vector<64xf32> from vector<1x64xf32>
-// CHECK-NEXT:            %60 = vector.extract %56[0, 0] : f32 from vector<1x1xf32>
-// CHECK-NEXT:            %61 = vector.broadcast %60 : f32 to vector<64xf32>
-// CHECK-NEXT:            %62 = vector.extract %58[0] : vector<64xf32> from vector<1x64xf32>
-// CHECK-NEXT:            %63 = vector.fma %61, %59, %62 : vector<64xf32>
-// CHECK-NEXT:            %64 = vector.insert %63, %cst [0] : vector<64xf32> into vector<1x64xf32>
-// CHECK-NEXT:            vector.transfer_write %64, %subview_7[%c0, %c0] {in_bounds = [true, true]} : vector<1x64xf32>, memref<1x64xf32, strided<[256, 1], offset: ?>>
-// CHECK-NEXT:            %67 = vector.transfer_read %subview_22[%c0, %c0], %0 {in_bounds = [true, true]} : memref<1x1xf32, strided<[512, 1], offset: ?>>, vector<1x1xf32>
-// CHECK-NEXT:            %68 = vector.transfer_read %subview_23[%c0, %c0], %0 {in_bounds = [true, true]} : memref<1x64xf32, strided<[256, 1], offset: ?>>, vector<1x64xf32>
-// CHECK-NEXT:            %69 = vector.transfer_read %subview_7[%c0, %c0], %0 {in_bounds = [true, true]} : memref<1x64xf32, strided<[256, 1], offset: ?>>, vector<1x64xf32>
-// CHECK-NEXT:            %70 = vector.extract %68[0] : vector<64xf32> from vector<1x64xf32>
-// CHECK-NEXT:            %71 = vector.extract %67[0, 0] : f32 from vector<1x1xf32>
-// CHECK-NEXT:            %72 = vector.broadcast %71 : f32 to vector<64xf32>
-// CHECK-NEXT:            %73 = vector.extract %69[0] : vector<64xf32> from vector<1x64xf32>
-// CHECK-NEXT:            %74 = vector.fma %72, %70, %73 : vector<64xf32>
-// CHECK-NEXT:            %75 = vector.insert %74, %cst [0] : vector<64xf32> into vector<1x64xf32>
-// CHECK-NEXT:            vector.transfer_write %75, %subview_7[%c0, %c0] {in_bounds = [true, true]} : vector<1x64xf32>, memref<1x64xf32, strided<[256, 1], offset: ?>>
-// CHECK-NEXT:            %78 = vector.transfer_read %subview_24[%c0, %c0], %0 {in_bounds = [true, true]} : memref<1x1xf32, strided<[512, 1], offset: ?>>, vector<1x1xf32>
-// CHECK-NEXT:            %79 = vector.transfer_read %subview_25[%c0, %c0], %0 {in_bounds = [true, true]} : memref<1x64xf32, strided<[256, 1], offset: ?>>, vector<1x64xf32>
-// CHECK-NEXT:            %80 = vector.transfer_read %subview_7[%c0, %c0], %0 {in_bounds = [true, true]} : memref<1x64xf32, strided<[256, 1], offset: ?>>, vector<1x64xf32>
-// CHECK-NEXT:            %81 = vector.extract %79[0] : vector<64xf32> from vector<1x64xf32>
-// CHECK-NEXT:            %82 = vector.extract %78[0, 0] : f32 from vector<1x1xf32>
-// CHECK-NEXT:            %83 = vector.broadcast %82 : f32 to vector<64xf32>
-// CHECK-NEXT:            %84 = vector.extract %80[0] : vector<64xf32> from vector<1x64xf32>
-// CHECK-NEXT:            %85 = vector.fma %83, %81, %84 : vector<64xf32>
-// CHECK-NEXT:            %86 = vector.insert %85, %cst [0] : vector<64xf32> into vector<1x64xf32>
-// CHECK-NEXT:            vector.transfer_write %86, %subview_7[%c0, %c0] {in_bounds = [true, true]} : vector<1x64xf32>, memref<1x64xf32, strided<[256, 1], offset: ?>>
+// CHECK-NEXT:            vector.transfer_write %9, %subview_3[%c0, %c0] {in_bounds = [true, true]} : vector<1x64xf32>, memref<1x64xf32, strided<[256, 1], offset: ?>>
+// CHECK-NEXT:            %10 = vector.transfer_read %subview_8[%c0, %c0], %0 {in_bounds = [true, true]} : memref<1x1xf32, strided<[512, 1], offset: ?>>, vector<1x1xf32>
+// CHECK-NEXT:            %11 = vector.transfer_read %subview_9[%c0, %c0], %0 {in_bounds = [true, true]} : memref<1x64xf32, strided<[256, 1], offset: ?>>, vector<1x64xf32>
+// CHECK-NEXT:            %12 = vector.transfer_read %subview_3[%c0, %c0], %0 {in_bounds = [true, true]} : memref<1x64xf32, strided<[256, 1], offset: ?>>, vector<1x64xf32>
+// CHECK-NEXT:            %13 = vector.extract %11[0] : vector<64xf32> from vector<1x64xf32>
+// CHECK-NEXT:            %14 = vector.extract %10[0, 0] : f32 from vector<1x1xf32>
+// CHECK-NEXT:            %15 = vector.broadcast %14 : f32 to vector<64xf32>
+// CHECK-NEXT:            %16 = vector.extract %12[0] : vector<64xf32> from vector<1x64xf32>
+// CHECK-NEXT:            %17 = vector.fma %15, %13, %16 : vector<64xf32>
+// CHECK-NEXT:            %18 = vector.insert %17, %cst [0] : vector<64xf32> into vector<1x64xf32>
+// CHECK-NEXT:            vector.transfer_write %18, %subview_3[%c0, %c0] {in_bounds = [true, true]} : vector<1x64xf32>, memref<1x64xf32, strided<[256, 1], offset: ?>>
+// CHECK-NEXT:            %19 = vector.transfer_read %subview_10[%c0, %c0], %0 {in_bounds = [true, true]} : memref<1x1xf32, strided<[512, 1], offset: ?>>, vector<1x1xf32>
+// CHECK-NEXT:            %20 = vector.transfer_read %subview_11[%c0, %c0], %0 {in_bounds = [true, true]} : memref<1x64xf32, strided<[256, 1], offset: ?>>, vector<1x64xf32>
+// CHECK-NEXT:            %21 = vector.transfer_read %subview_3[%c0, %c0], %0 {in_bounds = [true, true]} : memref<1x64xf32, strided<[256, 1], offset: ?>>, vector<1x64xf32>
+// CHECK-NEXT:            %22 = vector.extract %20[0] : vector<64xf32> from vector<1x64xf32>
+// CHECK-NEXT:            %23 = vector.extract %19[0, 0] : f32 from vector<1x1xf32>
+// CHECK-NEXT:            %24 = vector.broadcast %23 : f32 to vector<64xf32>
+// CHECK-NEXT:            %25 = vector.extract %21[0] : vector<64xf32> from vector<1x64xf32>
+// CHECK-NEXT:            %26 = vector.fma %24, %22, %25 : vector<64xf32>
+// CHECK-NEXT:            %27 = vector.insert %26, %cst [0] : vector<64xf32> into vector<1x64xf32>
+// CHECK-NEXT:            vector.transfer_write %27, %subview_3[%c0, %c0] {in_bounds = [true, true]} : vector<1x64xf32>, memref<1x64xf32, strided<[256, 1], offset: ?>>
+// CHECK-NEXT:            %28 = vector.transfer_read %subview_12[%c0, %c0], %0 {in_bounds = [true, true]} : memref<1x1xf32, strided<[512, 1], offset: ?>>, vector<1x1xf32>
+// CHECK-NEXT:            %29 = vector.transfer_read %subview_13[%c0, %c0], %0 {in_bounds = [true, true]} : memref<1x64xf32, strided<[256, 1], offset: ?>>, vector<1x64xf32>
+// CHECK-NEXT:            %30 = vector.transfer_read %subview_3[%c0, %c0], %0 {in_bounds = [true, true]} : memref<1x64xf32, strided<[256, 1], offset: ?>>, vector<1x64xf32>
+// CHECK-NEXT:            %31 = vector.extract %29[0] : vector<64xf32> from vector<1x64xf32>
+// CHECK-NEXT:            %32 = vector.extract %28[0, 0] : f32 from vector<1x1xf32>
+// CHECK-NEXT:            %33 = vector.broadcast %32 : f32 to vector<64xf32>
+// CHECK-NEXT:            %34 = vector.extract %30[0] : vector<64xf32> from vector<1x64xf32>
+// CHECK-NEXT:            %35 = vector.fma %33, %31, %34 : vector<64xf32>
+// CHECK-NEXT:            %36 = vector.insert %35, %cst [0] : vector<64xf32> into vector<1x64xf32>
+// CHECK-NEXT:            vector.transfer_write %36, %subview_3[%c0, %c0] {in_bounds = [true, true]} : vector<1x64xf32>, memref<1x64xf32, strided<[256, 1], offset: ?>>
+// CHECK-NEXT:            %37 = vector.transfer_read %subview_14[%c0, %c0], %0 {in_bounds = [true, true]} : memref<1x1xf32, strided<[512, 1], offset: ?>>, vector<1x1xf32>
+// CHECK-NEXT:            %38 = vector.transfer_read %subview_15[%c0, %c0], %0 {in_bounds = [true, true]} : memref<1x64xf32, strided<[256, 1], offset: ?>>, vector<1x64xf32>
+// CHECK-NEXT:            %39 = vector.transfer_read %subview_3[%c0, %c0], %0 {in_bounds = [true, true]} : memref<1x64xf32, strided<[256, 1], offset: ?>>, vector<1x64xf32>
+// CHECK-NEXT:            %40 = vector.extract %38[0] : vector<64xf32> from vector<1x64xf32>
+// CHECK-NEXT:            %41 = vector.extract %37[0, 0] : f32 from vector<1x1xf32>
+// CHECK-NEXT:            %42 = vector.broadcast %41 : f32 to vector<64xf32>
+// CHECK-NEXT:            %43 = vector.extract %39[0] : vector<64xf32> from vector<1x64xf32>
+// CHECK-NEXT:            %44 = vector.fma %42, %40, %43 : vector<64xf32>
+// CHECK-NEXT:            %45 = vector.insert %44, %cst [0] : vector<64xf32> into vector<1x64xf32>
+// CHECK-NEXT:            vector.transfer_write %45, %subview_3[%c0, %c0] {in_bounds = [true, true]} : vector<1x64xf32>, memref<1x64xf32, strided<[256, 1], offset: ?>>
+// CHECK-NEXT:            %46 = vector.transfer_read %subview_16[%c0, %c0], %0 {in_bounds = [true, true]} : memref<1x1xf32, strided<[512, 1], offset: ?>>, vector<1x1xf32>
+// CHECK-NEXT:            %47 = vector.transfer_read %subview_17[%c0, %c0], %0 {in_bounds = [true, true]} : memref<1x64xf32, strided<[256, 1], offset: ?>>, vector<1x64xf32>
+// CHECK-NEXT:            %48 = vector.transfer_read %subview_3[%c0, %c0], %0 {in_bounds = [true, true]} : memref<1x64xf32, strided<[256, 1], offset: ?>>, vector<1x64xf32>
+// CHECK-NEXT:            %49 = vector.extract %47[0] : vector<64xf32> from vector<1x64xf32>
+// CHECK-NEXT:            %50 = vector.extract %46[0, 0] : f32 from vector<1x1xf32>
+// CHECK-NEXT:            %51 = vector.broadcast %50 : f32 to vector<64xf32>
+// CHECK-NEXT:            %52 = vector.extract %48[0] : vector<64xf32> from vector<1x64xf32>
+// CHECK-NEXT:            %53 = vector.fma %51, %49, %52 : vector<64xf32>
+// CHECK-NEXT:            %54 = vector.insert %53, %cst [0] : vector<64xf32> into vector<1x64xf32>
+// CHECK-NEXT:            vector.transfer_write %54, %subview_3[%c0, %c0] {in_bounds = [true, true]} : vector<1x64xf32>, memref<1x64xf32, strided<[256, 1], offset: ?>>
+// CHECK-NEXT:            %55 = vector.transfer_read %subview_18[%c0, %c0], %0 {in_bounds = [true, true]} : memref<1x1xf32, strided<[512, 1], offset: ?>>, vector<1x1xf32>
+// CHECK-NEXT:            %56 = vector.transfer_read %subview_19[%c0, %c0], %0 {in_bounds = [true, true]} : memref<1x64xf32, strided<[256, 1], offset: ?>>, vector<1x64xf32>
+// CHECK-NEXT:            %57 = vector.transfer_read %subview_3[%c0, %c0], %0 {in_bounds = [true, true]} : memref<1x64xf32, strided<[256, 1], offset: ?>>, vector<1x64xf32>
+// CHECK-NEXT:            %58 = vector.extract %56[0] : vector<64xf32> from vector<1x64xf32>
+// CHECK-NEXT:            %59 = vector.extract %55[0, 0] : f32 from vector<1x1xf32>
+// CHECK-NEXT:            %60 = vector.broadcast %59 : f32 to vector<64xf32>
+// CHECK-NEXT:            %61 = vector.extract %57[0] : vector<64xf32> from vector<1x64xf32>
+// CHECK-NEXT:            %62 = vector.fma %60, %58, %61 : vector<64xf32>
+// CHECK-NEXT:            %63 = vector.insert %62, %cst [0] : vector<64xf32> into vector<1x64xf32>
+// CHECK-NEXT:            vector.transfer_write %63, %subview_3[%c0, %c0] {in_bounds = [true, true]} : vector<1x64xf32>, memref<1x64xf32, strided<[256, 1], offset: ?>>
+// CHECK-NEXT:            %64 = vector.transfer_read %subview_20[%c0, %c0], %0 {in_bounds = [true, true]} : memref<1x1xf32, strided<[512, 1], offset: ?>>, vector<1x1xf32>
+// CHECK-NEXT:            %65 = vector.transfer_read %subview_21[%c0, %c0], %0 {in_bounds = [true, true]} : memref<1x64xf32, strided<[256, 1], offset: ?>>, vector<1x64xf32>
+// CHECK-NEXT:            %66 = vector.transfer_read %subview_3[%c0, %c0], %0 {in_bounds = [true, true]} : memref<1x64xf32, strided<[256, 1], offset: ?>>, vector<1x64xf32>
+// CHECK-NEXT:            %67 = vector.extract %65[0] : vector<64xf32> from vector<1x64xf32>
+// CHECK-NEXT:            %68 = vector.extract %64[0, 0] : f32 from vector<1x1xf32>
+// CHECK-NEXT:            %69 = vector.broadcast %68 : f32 to vector<64xf32>
+// CHECK-NEXT:            %70 = vector.extract %66[0] : vector<64xf32> from vector<1x64xf32>
+// CHECK-NEXT:            %71 = vector.fma %69, %67, %70 : vector<64xf32>
+// CHECK-NEXT:            %72 = vector.insert %71, %cst [0] : vector<64xf32> into vector<1x64xf32>
+// CHECK-NEXT:            vector.transfer_write %72, %subview_3[%c0, %c0] {in_bounds = [true, true]} : vector<1x64xf32>, memref<1x64xf32, strided<[256, 1], offset: ?>>

--- a/tests/filecheck/mlir_loop/gen_transform/dims_matmul.mlir
+++ b/tests/filecheck/mlir_loop/gen_transform/dims_matmul.mlir
@@ -31,7 +31,6 @@ func.func @myfun(
 // CHECK-NEXT:      transform.annotate %loops_1 "./J" : !transform.any_op
 // CHECK-NEXT:      %tiled_linalg_op_2, %loops_3 = transform.structured.tile_using_for %tiled_linalg_op_0 tile_sizes [0, 0, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
 // CHECK-NEXT:      transform.annotate %loops_3 "./K" : !transform.any_op
-// CHECK-NEXT:      %1 = transform.get_parent_op %loops {isolated_from_above} : (!transform.any_op) -> !transform.any_op
 // CHECK-NEXT:      transform.yield 
 // CHECK-NEXT:    }
 // CHECK-NEXT:  }

--- a/tests/filecheck/mlir_loop/gen_transform/interchange_matmul.mlir
+++ b/tests/filecheck/mlir_loop/gen_transform/interchange_matmul.mlir
@@ -36,7 +36,6 @@ func.func @myfun(
 // CHECK-NEXT:      transform.annotate %loops_1 "__node0__/K" : !transform.any_op
 // CHECK-NEXT:      %tiled_linalg_op_2, %loops_3 = transform.structured.tile_using_for %tiled_linalg_op_0 tile_sizes [0, 1, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
 // CHECK-NEXT:      transform.annotate %loops_3 "__node0__/J" : !transform.any_op
-// CHECK-NEXT:      %1 = transform.get_parent_op %loops {isolated_from_above} : (!transform.any_op) -> !transform.any_op
 // CHECK-NEXT:      transform.yield 
 // CHECK-NEXT:    }
 // CHECK-NEXT:  }

--- a/tests/filecheck/mlir_loop/gen_transform/parallel_matmul.mlir
+++ b/tests/filecheck/mlir_loop/gen_transform/parallel_matmul.mlir
@@ -36,7 +36,6 @@ func.func @myfun(
 // CHECK-NEXT:      transform.annotate %loops "__node0__/K" : !transform.any_op
 // CHECK-NEXT:      %tiled_linalg_op_0, %loops_1 = transform.structured.tile_using_for %tiled_linalg_op tile_sizes [0, 1, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
 // CHECK-NEXT:      transform.annotate %loops_1 "__node0__/J" : !transform.any_op
-// CHECK-NEXT:      %1 = transform.get_parent_op %forall_op {isolated_from_above} : (!transform.any_op) -> !transform.any_op
 // CHECK-NEXT:      transform.yield 
 // CHECK-NEXT:    }
 // CHECK-NEXT:  }

--- a/tests/filecheck/mlir_loop/gen_transform/parallel_tiling_unroll_vecto_matmul.mlir
+++ b/tests/filecheck/mlir_loop/gen_transform/parallel_tiling_unroll_vecto_matmul.mlir
@@ -43,8 +43,10 @@ func.func @myfun(
 // CHECK-NEXT:      transform.annotate %loops_3 "__node0__/I0" : !transform.any_op
 // CHECK-NEXT:      %tiled_linalg_op_4, %loops_5 = transform.structured.tile_using_for %tiled_linalg_op_2 tile_sizes [0, 0, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
 // CHECK-NEXT:      transform.annotate %loops_5 "__node0__/K0" : !transform.any_op
-// CHECK-NEXT:      %1 = transform.get_parent_op %forall_op {isolated_from_above} : (!transform.any_op) -> !transform.any_op
 // CHECK-NEXT:      transform.include @_vecto failures(suppress) (%tiled_linalg_op_4) : (!transform.any_op) -> ()
+// CHECK-NEXT:      transform.loop.unroll %loops_5 {factor = 8 : i64} : !transform.any_op
+// CHECK-NEXT:      transform.loop.unroll %loops_3 {factor = 1 : i64} : !transform.any_op
+// CHECK-NEXT:      %1 = transform.get_parent_op %forall_op {isolated_from_above} : (!transform.any_op) -> !transform.any_op
 // CHECK-NEXT:      transform.apply_patterns to %1 {
 // CHECK-NEXT:        transform.apply_patterns.vector.reduction_to_contract
 // CHECK-NEXT:        transform.apply_patterns.vector.transfer_permutation_patterns
@@ -53,10 +55,6 @@ func.func @myfun(
 // CHECK-NEXT:        transform.apply_patterns.vector.lower_outerproduct
 // CHECK-NEXT:        transform.apply_patterns.vector.lower_contraction
 // CHECK-NEXT:      } : !transform.any_op
-// CHECK-NEXT:      %2 = transform.structured.match attributes {"__node0__/K0"} in %1 : (!transform.any_op) -> !transform.any_op
-// CHECK-NEXT:      transform.loop.unroll %loops_5 {factor = 8 : i64} : !transform.any_op
-// CHECK-NEXT:      %3 = transform.structured.match attributes {"__node0__/I0"} in %1 : (!transform.any_op) -> !transform.any_op
-// CHECK-NEXT:      transform.loop.unroll %loops_3 {factor = 1 : i64} : !transform.any_op
 // CHECK-NEXT:      transform.yield 
 // CHECK-NEXT:    }
 // CHECK-NEXT:  }

--- a/tests/filecheck/mlir_loop/gen_transform/split_matmul.mlir
+++ b/tests/filecheck/mlir_loop/gen_transform/split_matmul.mlir
@@ -40,34 +40,16 @@ func.func @myfun(
 // CHECK-NEXT:      %2:2 = transform.split_handle %1 : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
 // CHECK-NEXT:      %tiled_linalg_op_0, %loops_1 = transform.structured.tile_using_for %2#0 tile_sizes [0, 0, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
 // CHECK-NEXT:      transform.annotate %loops_1 "__node0__/K[0]/K" : !transform.any_op
-// CHECK-NEXT:      %3 = transform.get_parent_op %loops_1 {isolated_from_above} : (!transform.any_op) -> !transform.any_op
 // CHECK-NEXT:      transform.include @_vecto failures(suppress) (%tiled_linalg_op_0) : (!transform.any_op) -> ()
-// CHECK-NEXT:      transform.apply_patterns to %3 {
-// CHECK-NEXT:        transform.apply_patterns.vector.reduction_to_contract
-// CHECK-NEXT:        transform.apply_patterns.vector.transfer_permutation_patterns
-// CHECK-NEXT:      } : !transform.any_op
-// CHECK-NEXT:      transform.apply_patterns to %3 {
-// CHECK-NEXT:        transform.apply_patterns.vector.lower_outerproduct
-// CHECK-NEXT:        transform.apply_patterns.vector.lower_contraction
-// CHECK-NEXT:      } : !transform.any_op
 // CHECK-NEXT:      %tiled_linalg_op_2, %loops_3 = transform.structured.tile_using_for %2#1 tile_sizes [0, 0, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
 // CHECK-NEXT:      transform.annotate %loops_3 "__node0__/K[1]/K" : !transform.any_op
-// CHECK-NEXT:      %4 = transform.get_parent_op %loops_3 {isolated_from_above} : (!transform.any_op) -> !transform.any_op
 // CHECK-NEXT:      transform.include @_vecto failures(suppress) (%tiled_linalg_op_2) : (!transform.any_op) -> ()
-// CHECK-NEXT:      transform.apply_patterns to %4 {
+// CHECK-NEXT:      %3 = transform.get_parent_op %loops {isolated_from_above} : (!transform.any_op) -> !transform.any_op
+// CHECK-NEXT:      transform.apply_patterns to %3 {
 // CHECK-NEXT:        transform.apply_patterns.vector.reduction_to_contract
 // CHECK-NEXT:        transform.apply_patterns.vector.transfer_permutation_patterns
 // CHECK-NEXT:      } : !transform.any_op
-// CHECK-NEXT:      transform.apply_patterns to %4 {
-// CHECK-NEXT:        transform.apply_patterns.vector.lower_outerproduct
-// CHECK-NEXT:        transform.apply_patterns.vector.lower_contraction
-// CHECK-NEXT:      } : !transform.any_op
-// CHECK-NEXT:      %5 = transform.get_parent_op %loops {isolated_from_above} : (!transform.any_op) -> !transform.any_op
-// CHECK-NEXT:      transform.apply_patterns to %5 {
-// CHECK-NEXT:        transform.apply_patterns.vector.reduction_to_contract
-// CHECK-NEXT:        transform.apply_patterns.vector.transfer_permutation_patterns
-// CHECK-NEXT:      } : !transform.any_op
-// CHECK-NEXT:      transform.apply_patterns to %5 {
+// CHECK-NEXT:      transform.apply_patterns to %3 {
 // CHECK-NEXT:        transform.apply_patterns.vector.lower_outerproduct
 // CHECK-NEXT:        transform.apply_patterns.vector.lower_contraction
 // CHECK-NEXT:      } : !transform.any_op

--- a/tests/filecheck/mlir_loop/gen_transform/split_root_matmul.mlir
+++ b/tests/filecheck/mlir_loop/gen_transform/split_root_matmul.mlir
@@ -43,15 +43,12 @@ func.func @myfun(
 // CHECK-NEXT:      transform.annotate %loops_1 "__node0__/I[0]/J" : !transform.any_op
 // CHECK-NEXT:      %tiled_linalg_op_2, %loops_3 = transform.structured.tile_using_for %tiled_linalg_op_0 tile_sizes [0, 0, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
 // CHECK-NEXT:      transform.annotate %loops_3 "__node0__/I[0]/K" : !transform.any_op
-// CHECK-NEXT:      %3 = transform.get_parent_op %loops {isolated_from_above} : (!transform.any_op) -> !transform.any_op
 // CHECK-NEXT:      %tiled_linalg_op_4, %loops_5 = transform.structured.tile_using_for %2#1 tile_sizes [1, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
 // CHECK-NEXT:      transform.annotate %loops_5 "__node0__/I[1]/I" : !transform.any_op
 // CHECK-NEXT:      %tiled_linalg_op_6, %loops_7 = transform.structured.tile_using_for %tiled_linalg_op_4 tile_sizes [0, 0, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
 // CHECK-NEXT:      transform.annotate %loops_7 "__node0__/I[1]/K" : !transform.any_op
 // CHECK-NEXT:      %tiled_linalg_op_8, %loops_9 = transform.structured.tile_using_for %tiled_linalg_op_6 tile_sizes [0, 1, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
 // CHECK-NEXT:      transform.annotate %loops_9 "__node0__/I[1]/J" : !transform.any_op
-// CHECK-NEXT:      %4 = transform.get_parent_op %loops_5 {isolated_from_above} : (!transform.any_op) -> !transform.any_op
-// CHECK-NEXT:      %5 = transform.get_parent_op %loops {isolated_from_above} : (!transform.any_op) -> !transform.any_op
 // CHECK-NEXT:      transform.yield 
 // CHECK-NEXT:    }
 // CHECK-NEXT:  }

--- a/tests/filecheck/mlir_loop/gen_transform/split_tiling_matmul.mlir
+++ b/tests/filecheck/mlir_loop/gen_transform/split_tiling_matmul.mlir
@@ -46,7 +46,6 @@ func.func @myfun(
 // CHECK-NEXT:      transform.annotate %loops_1 "__node0__/I[0]/J" : !transform.any_op
 // CHECK-NEXT:      %tiled_linalg_op_2, %loops_3 = transform.structured.tile_using_for %tiled_linalg_op_0 tile_sizes [0, 0, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
 // CHECK-NEXT:      transform.annotate %loops_3 "__node0__/I[0]/K" : !transform.any_op
-// CHECK-NEXT:      %3 = transform.get_parent_op %loops {isolated_from_above} : (!transform.any_op) -> !transform.any_op
 // CHECK-NEXT:      %tiled_linalg_op_4, %loops_5 = transform.structured.tile_using_for %2#1 tile_sizes [2, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
 // CHECK-NEXT:      transform.annotate %loops_5 "__node0__/I[1]/I" : !transform.any_op
 // CHECK-NEXT:      %tiled_linalg_op_6, %loops_7 = transform.structured.tile_using_for %tiled_linalg_op_4 tile_sizes [0, 64, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
@@ -59,8 +58,6 @@ func.func @myfun(
 // CHECK-NEXT:      transform.annotate %loops_13 "__node0__/I[1]/K0" : !transform.any_op
 // CHECK-NEXT:      %tiled_linalg_op_14, %loops_15 = transform.structured.tile_using_for %tiled_linalg_op_12 tile_sizes [0, 1, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
 // CHECK-NEXT:      transform.annotate %loops_15 "__node0__/I[1]/J0" : !transform.any_op
-// CHECK-NEXT:      %4 = transform.get_parent_op %loops_5 {isolated_from_above} : (!transform.any_op) -> !transform.any_op
-// CHECK-NEXT:      %5 = transform.get_parent_op %loops {isolated_from_above} : (!transform.any_op) -> !transform.any_op
 // CHECK-NEXT:      transform.yield 
 // CHECK-NEXT:    }
 // CHECK-NEXT:  }

--- a/tests/filecheck/mlir_loop/gen_transform/tiling_matmul.mlir
+++ b/tests/filecheck/mlir_loop/gen_transform/tiling_matmul.mlir
@@ -45,7 +45,6 @@ func.func @myfun(
 // CHECK-NEXT:      transform.annotate %loops_7 "__node0__/K0" : !transform.any_op
 // CHECK-NEXT:      %tiled_linalg_op_8, %loops_9 = transform.structured.tile_using_for %tiled_linalg_op_6 tile_sizes [0, 1, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
 // CHECK-NEXT:      transform.annotate %loops_9 "__node0__/J0" : !transform.any_op
-// CHECK-NEXT:      %1 = transform.get_parent_op %loops {isolated_from_above} : (!transform.any_op) -> !transform.any_op
 // CHECK-NEXT:      transform.yield 
 // CHECK-NEXT:    }
 // CHECK-NEXT:  }

--- a/tests/filecheck/mlir_loop/gen_transform/tiling_unroll_matmul.mlir
+++ b/tests/filecheck/mlir_loop/gen_transform/tiling_unroll_matmul.mlir
@@ -45,10 +45,7 @@ func.func @myfun(
 // CHECK-NEXT:      transform.annotate %loops_7 "__node0__/K0" : !transform.any_op
 // CHECK-NEXT:      %tiled_linalg_op_8, %loops_9 = transform.structured.tile_using_for %tiled_linalg_op_6 tile_sizes [0, 1, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
 // CHECK-NEXT:      transform.annotate %loops_9 "__node0__/J0" : !transform.any_op
-// CHECK-NEXT:      %1 = transform.get_parent_op %loops {isolated_from_above} : (!transform.any_op) -> !transform.any_op
-// CHECK-NEXT:      %2 = transform.structured.match attributes {"__node0__/K0"} in %1 : (!transform.any_op) -> !transform.any_op
 // CHECK-NEXT:      transform.loop.unroll %loops_7 {factor = 8 : i64} : !transform.any_op
-// CHECK-NEXT:      %3 = transform.structured.match attributes {"__node0__/I0"} in %1 : (!transform.any_op) -> !transform.any_op
 // CHECK-NEXT:      transform.loop.unroll %loops_5 {factor = 1 : i64} : !transform.any_op
 // CHECK-NEXT:      transform.yield 
 // CHECK-NEXT:    }

--- a/tests/filecheck/mlir_loop/gen_transform/tiling_unroll_partial_matmul.mlir
+++ b/tests/filecheck/mlir_loop/gen_transform/tiling_unroll_partial_matmul.mlir
@@ -45,10 +45,7 @@ func.func @myfun(
 // CHECK-NEXT:      transform.annotate %loops_7 "__node0__/K0" : !transform.any_op
 // CHECK-NEXT:      %tiled_linalg_op_8, %loops_9 = transform.structured.tile_using_for %tiled_linalg_op_6 tile_sizes [0, 1, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
 // CHECK-NEXT:      transform.annotate %loops_9 "__node0__/J0" : !transform.any_op
-// CHECK-NEXT:      %1 = transform.get_parent_op %loops {isolated_from_above} : (!transform.any_op) -> !transform.any_op
-// CHECK-NEXT:      %2 = transform.structured.match attributes {"__node0__/K0"} in %1 : (!transform.any_op) -> !transform.any_op
 // CHECK-NEXT:      transform.loop.unroll %loops_7 {factor = 2 : i64} : !transform.any_op
-// CHECK-NEXT:      %3 = transform.structured.match attributes {"__node0__/I0"} in %1 : (!transform.any_op) -> !transform.any_op
 // CHECK-NEXT:      transform.loop.unroll %loops_5 {factor = 1 : i64} : !transform.any_op
 // CHECK-NEXT:      transform.yield 
 // CHECK-NEXT:    }

--- a/tests/filecheck/mlir_loop/gen_transform/tiling_unroll_vecto_matmul.mlir
+++ b/tests/filecheck/mlir_loop/gen_transform/tiling_unroll_vecto_matmul.mlir
@@ -43,8 +43,10 @@ func.func @myfun(
 // CHECK-NEXT:      transform.annotate %loops_5 "__node0__/I0" : !transform.any_op
 // CHECK-NEXT:      %tiled_linalg_op_6, %loops_7 = transform.structured.tile_using_for %tiled_linalg_op_4 tile_sizes [0, 0, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
 // CHECK-NEXT:      transform.annotate %loops_7 "__node0__/K0" : !transform.any_op
-// CHECK-NEXT:      %1 = transform.get_parent_op %loops {isolated_from_above} : (!transform.any_op) -> !transform.any_op
 // CHECK-NEXT:      transform.include @_vecto failures(suppress) (%tiled_linalg_op_6) : (!transform.any_op) -> ()
+// CHECK-NEXT:      transform.loop.unroll %loops_7 {factor = 8 : i64} : !transform.any_op
+// CHECK-NEXT:      transform.loop.unroll %loops_5 {factor = 1 : i64} : !transform.any_op
+// CHECK-NEXT:      %1 = transform.get_parent_op %loops {isolated_from_above} : (!transform.any_op) -> !transform.any_op
 // CHECK-NEXT:      transform.apply_patterns to %1 {
 // CHECK-NEXT:        transform.apply_patterns.vector.reduction_to_contract
 // CHECK-NEXT:        transform.apply_patterns.vector.transfer_permutation_patterns
@@ -53,10 +55,6 @@ func.func @myfun(
 // CHECK-NEXT:        transform.apply_patterns.vector.lower_outerproduct
 // CHECK-NEXT:        transform.apply_patterns.vector.lower_contraction
 // CHECK-NEXT:      } : !transform.any_op
-// CHECK-NEXT:      %2 = transform.structured.match attributes {"__node0__/K0"} in %1 : (!transform.any_op) -> !transform.any_op
-// CHECK-NEXT:      transform.loop.unroll %loops_7 {factor = 8 : i64} : !transform.any_op
-// CHECK-NEXT:      %3 = transform.structured.match attributes {"__node0__/I0"} in %1 : (!transform.any_op) -> !transform.any_op
-// CHECK-NEXT:      transform.loop.unroll %loops_5 {factor = 1 : i64} : !transform.any_op
 // CHECK-NEXT:      transform.yield 
 // CHECK-NEXT:    }
 // CHECK-NEXT:  }

--- a/tests/filecheck/mlir_loop/gen_transform/tiling_vecto_matmul.mlir
+++ b/tests/filecheck/mlir_loop/gen_transform/tiling_vecto_matmul.mlir
@@ -43,8 +43,8 @@ func.func @myfun(
 // CHECK-NEXT:      transform.annotate %loops_5 "__node0__/I0" : !transform.any_op
 // CHECK-NEXT:      %tiled_linalg_op_6, %loops_7 = transform.structured.tile_using_for %tiled_linalg_op_4 tile_sizes [0, 0, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
 // CHECK-NEXT:      transform.annotate %loops_7 "__node0__/K0" : !transform.any_op
-// CHECK-NEXT:      %1 = transform.get_parent_op %loops {isolated_from_above} : (!transform.any_op) -> !transform.any_op
 // CHECK-NEXT:      transform.include @_vecto failures(suppress) (%tiled_linalg_op_6) : (!transform.any_op) -> ()
+// CHECK-NEXT:      %1 = transform.get_parent_op %loops {isolated_from_above} : (!transform.any_op) -> !transform.any_op
 // CHECK-NEXT:      transform.apply_patterns to %1 {
 // CHECK-NEXT:        transform.apply_patterns.vector.reduction_to_contract
 // CHECK-NEXT:        transform.apply_patterns.vector.transfer_permutation_patterns

--- a/tests/filecheck/mlir_loop/gen_transform/unroll_matmul.mlir
+++ b/tests/filecheck/mlir_loop/gen_transform/unroll_matmul.mlir
@@ -36,8 +36,6 @@ func.func @myfun(
 // CHECK-NEXT:      transform.annotate %loops_1 "__node0__/K" : !transform.any_op
 // CHECK-NEXT:      %tiled_linalg_op_2, %loops_3 = transform.structured.tile_using_for %tiled_linalg_op_0 tile_sizes [0, 1, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
 // CHECK-NEXT:      transform.annotate %loops_3 "__node0__/J" : !transform.any_op
-// CHECK-NEXT:      %1 = transform.get_parent_op %loops {isolated_from_above} : (!transform.any_op) -> !transform.any_op
-// CHECK-NEXT:      %2 = transform.structured.match attributes {"__node0__/K"} in %1 : (!transform.any_op) -> !transform.any_op
 // CHECK-NEXT:      transform.loop.unroll %loops_1 {factor = 2 : i64} : !transform.any_op
 // CHECK-NEXT:      transform.yield 
 // CHECK-NEXT:    }

--- a/tests/filecheck/mlir_loop/gen_transform/unroll_outermost_matmul.mlir
+++ b/tests/filecheck/mlir_loop/gen_transform/unroll_outermost_matmul.mlir
@@ -37,8 +37,10 @@ func.func @myfun(
 // CHECK-NEXT:      transform.annotate %loops_1 "__node0__/i" : !transform.any_op
 // CHECK-NEXT:      %tiled_linalg_op_2, %loops_3 = transform.structured.tile_using_for %tiled_linalg_op_0 tile_sizes [0, 16, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
 // CHECK-NEXT:      transform.annotate %loops_3 "__node0__/j" : !transform.any_op
-// CHECK-NEXT:      %1 = transform.get_parent_op %loops {isolated_from_above} : (!transform.any_op) -> !transform.any_op
 // CHECK-NEXT:      transform.include @_vecto failures(suppress) (%tiled_linalg_op_2) : (!transform.any_op) -> ()
+// CHECK-NEXT:      transform.loop.unroll %loops_3 {factor = 32 : i64} : !transform.any_op
+// CHECK-NEXT:      transform.loop.unroll %loops_1 {factor = 8 : i64} : !transform.any_op
+// CHECK-NEXT:      %1 = transform.get_parent_op %loops {isolated_from_above} : (!transform.any_op) -> !transform.any_op
 // CHECK-NEXT:      transform.apply_patterns to %1 {
 // CHECK-NEXT:        transform.apply_patterns.vector.reduction_to_contract
 // CHECK-NEXT:        transform.apply_patterns.vector.transfer_permutation_patterns
@@ -47,10 +49,6 @@ func.func @myfun(
 // CHECK-NEXT:        transform.apply_patterns.vector.lower_outerproduct
 // CHECK-NEXT:        transform.apply_patterns.vector.lower_contraction
 // CHECK-NEXT:      } : !transform.any_op
-// CHECK-NEXT:      %2 = transform.structured.match attributes {"__node0__/j"} in %1 : (!transform.any_op) -> !transform.any_op
-// CHECK-NEXT:      transform.loop.unroll %loops_3 {factor = 32 : i64} : !transform.any_op
-// CHECK-NEXT:      %3 = transform.structured.match attributes {"__node0__/i"} in %1 : (!transform.any_op) -> !transform.any_op
-// CHECK-NEXT:      transform.loop.unroll %loops_1 {factor = 8 : i64} : !transform.any_op
 // CHECK-NEXT:      transform.yield 
 // CHECK-NEXT:    }
 // CHECK-NEXT:  }

--- a/tests/filecheck/mlir_loop/gen_transform/vecto_generic_conv2d_nhwc_hwcf.mlir
+++ b/tests/filecheck/mlir_loop/gen_transform/vecto_generic_conv2d_nhwc_hwcf.mlir
@@ -44,4 +44,107 @@ func.func @myfun(
   return
 }
 
-// CHECK: RuntimeError: MLIR Error: NYI: non-trivial layout map
+// CHECK:       // -----// IR Dump Before transform //----- //
+// CHECK-NEXT:  #map = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d1 + d4, d2 + d5, d6)>
+// CHECK-NEXT:  #map1 = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d4, d5, d6, d3)>
+// CHECK-NEXT:  #map2 = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d1, d2, d3)>
+// CHECK-NEXT:  module attributes {transform.with_named_sequence} {
+// CHECK-NEXT:    func.func @myfun(%arg0: memref<1x30x30x64xf32> {llvm.noalias}, %arg1: memref<3x3x64x128xf32> {llvm.noalias}, %arg2: memref<1x28x28x128xf32> {llvm.noalias}) {
+// CHECK-NEXT:      linalg.generic {indexing_maps = [#map, #map1, #map2], iterator_types = ["parallel", "parallel", "parallel", "parallel", "reduction", "reduction", "reduction"]} ins(%arg0, %arg1 : memref<1x30x30x64xf32>, memref<3x3x64x128xf32>) outs(%arg2 : memref<1x28x28x128xf32>) attrs =  {__node0__} {
+// CHECK-NEXT:      ^bb0(%in: f32, %in_0: f32, %out: f32):
+// CHECK-NEXT:        %0 = arith.mulf %in, %in_0 : f32
+// CHECK-NEXT:        %1 = arith.addf %out, %0 : f32
+// CHECK-NEXT:        linalg.yield %1 : f32
+// CHECK-NEXT:      }
+// CHECK-NEXT:      return
+// CHECK-NEXT:    }
+// CHECK-NEXT:    transform.named_sequence @_vecto(%arg0: !transform.any_op {transform.consumed}) {
+// CHECK-NEXT:      transform.structured.vectorize %arg0 : !transform.any_op
+// CHECK-NEXT:      transform.yield 
+// CHECK-NEXT:    }
+// CHECK-NEXT:    transform.named_sequence @_super_vectorize(%arg0: !transform.any_op {transform.consumed}) -> !transform.any_op {
+// CHECK-NEXT:      %0 = transform.apply_registered_pass "affine-super-vectorize" with options = {"virtual-vector-size" = 8 : i64} to %arg0 : (!transform.any_op) -> !transform.any_op
+// CHECK-NEXT:      transform.yield %0 : !transform.any_op
+// CHECK-NEXT:    }
+// CHECK-NEXT:    transform.named_sequence @__transform_main(%arg0: !transform.any_op {transform.readonly}) {
+// CHECK-NEXT:      %0 = transform.structured.match attributes {__node0__} in %arg0 : (!transform.any_op) -> !transform.any_op
+// CHECK-NEXT:      %tiled_linalg_op, %loops = transform.structured.tile_using_for %0 tile_sizes [1, 0, 0, 0, 0, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+// CHECK-NEXT:      transform.annotate %loops "__node0__/n" : !transform.any_op
+// CHECK-NEXT:      %tiled_linalg_op_0, %loops_1 = transform.structured.tile_using_for %tiled_linalg_op tile_sizes [0, 1, 0, 0, 0, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+// CHECK-NEXT:      transform.annotate %loops_1 "__node0__/h" : !transform.any_op
+// CHECK-NEXT:      %tiled_linalg_op_2, %loops_3 = transform.structured.tile_using_for %tiled_linalg_op_0 tile_sizes [0, 0, 1, 0, 0, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+// CHECK-NEXT:      transform.annotate %loops_3 "__node0__/w" : !transform.any_op
+// CHECK-NEXT:      %tiled_linalg_op_4, %loops_5 = transform.structured.tile_using_for %tiled_linalg_op_2 tile_sizes [0, 0, 0, 1, 0, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+// CHECK-NEXT:      transform.annotate %loops_5 "__node0__/f" : !transform.any_op
+// CHECK-NEXT:      %tiled_linalg_op_6, %loops_7 = transform.structured.tile_using_for %tiled_linalg_op_4 tile_sizes [0, 0, 0, 0, 1, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+// CHECK-NEXT:      transform.annotate %loops_7 "__node0__/r" : !transform.any_op
+// CHECK-NEXT:      %tiled_linalg_op_8, %loops_9 = transform.structured.tile_using_for %tiled_linalg_op_6 tile_sizes [0, 0, 0, 0, 0, 1, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+// CHECK-NEXT:      transform.annotate %loops_9 "__node0__/s" : !transform.any_op
+// CHECK-NEXT:      %1 = transform.get_parent_op %loops {isolated_from_above} : (!transform.any_op) -> !transform.any_op
+// CHECK-NEXT:      %2 = transform.apply_registered_pass "convert-linalg-to-affine-loops" to %1 : (!transform.any_op) -> !transform.any_op
+// CHECK-NEXT:      %3 = transform.include @_super_vectorize failures(suppress) (%2) : (!transform.any_op) -> !transform.any_op
+// CHECK-NEXT:      transform.yield 
+// CHECK-NEXT:    }
+// CHECK-NEXT:  }
+
+// CHECK:  RuntimeError: MLIR Error: NYI: non-trivial layout map
+
+// CHECK:  // -----// IR Dump After transform //----- //
+// CHECK-NEXT:  #map = affine_map<(d0, d1) -> (d0 + d1)>
+// CHECK-NEXT:  module attributes {transform.with_named_sequence} {
+// CHECK-NEXT:    func.func @myfun(%arg0: memref<1x30x30x64xf32> {llvm.noalias}, %arg1: memref<3x3x64x128xf32> {llvm.noalias}, %arg2: memref<1x28x28x128xf32> {llvm.noalias}) {
+// CHECK-NEXT:      %c3 = arith.constant 3 : index
+// CHECK-NEXT:      %c128 = arith.constant 128 : index
+// CHECK-NEXT:      %c28 = arith.constant 28 : index
+// CHECK-NEXT:      %c0 = arith.constant 0 : index
+// CHECK-NEXT:      %c1 = arith.constant 1 : index
+// CHECK-NEXT:      scf.for %arg3 = %c0 to %c1 step %c1 {
+// CHECK-NEXT:        %subview = memref.subview %arg0[%arg3, 0, 0, 0] [1, 30, 30, 64] [1, 1, 1, 1] : memref<1x30x30x64xf32> to memref<1x30x30x64xf32, strided<[57600, 1920, 64, 1], offset: ?>>
+// CHECK-NEXT:        %subview_0 = memref.subview %arg1[0, 0, 0, 0] [3, 3, 64, 128] [1, 1, 1, 1] : memref<3x3x64x128xf32> to memref<3x3x64x128xf32, strided<[24576, 8192, 128, 1]>>
+// CHECK-NEXT:        %subview_1 = memref.subview %arg2[%arg3, 0, 0, 0] [1, 28, 28, 128] [1, 1, 1, 1] : memref<1x28x28x128xf32> to memref<1x28x28x128xf32, strided<[100352, 3584, 128, 1], offset: ?>>
+// CHECK-NEXT:        scf.for %arg4 = %c0 to %c28 step %c1 {
+// CHECK-NEXT:          %subview_2 = memref.subview %subview[0, %arg4, 0, 0] [1, 3, 30, 64] [1, 1, 1, 1] : memref<1x30x30x64xf32, strided<[57600, 1920, 64, 1], offset: ?>> to memref<1x3x30x64xf32, strided<[57600, 1920, 64, 1], offset: ?>>
+// CHECK-NEXT:          %subview_3 = memref.subview %subview_1[0, %arg4, 0, 0] [1, 1, 28, 128] [1, 1, 1, 1] : memref<1x28x28x128xf32, strided<[100352, 3584, 128, 1], offset: ?>> to memref<1x1x28x128xf32, strided<[100352, 3584, 128, 1], offset: ?>>
+// CHECK-NEXT:          scf.for %arg5 = %c0 to %c28 step %c1 {
+// CHECK-NEXT:            %subview_4 = memref.subview %subview_2[0, 0, %arg5, 0] [1, 3, 3, 64] [1, 1, 1, 1] : memref<1x3x30x64xf32, strided<[57600, 1920, 64, 1], offset: ?>> to memref<1x3x3x64xf32, strided<[57600, 1920, 64, 1], offset: ?>>
+// CHECK-NEXT:            %subview_5 = memref.subview %subview_3[0, 0, %arg5, 0] [1, 1, 1, 128] [1, 1, 1, 1] : memref<1x1x28x128xf32, strided<[100352, 3584, 128, 1], offset: ?>> to memref<1x1x1x128xf32, strided<[100352, 3584, 128, 1], offset: ?>>
+// CHECK-NEXT:            scf.for %arg6 = %c0 to %c128 step %c1 {
+// CHECK-NEXT:              %subview_6 = memref.subview %subview_0[0, 0, 0, %arg6] [3, 3, 64, 1] [1, 1, 1, 1] : memref<3x3x64x128xf32, strided<[24576, 8192, 128, 1]>> to memref<3x3x64x1xf32, strided<[24576, 8192, 128, 1], offset: ?>>
+// CHECK-NEXT:              %subview_7 = memref.subview %subview_5[0, 0, 0, %arg6] [1, 1, 1, 1] [1, 1, 1, 1] : memref<1x1x1x128xf32, strided<[100352, 3584, 128, 1], offset: ?>> to memref<1x1x1x1xf32, strided<[100352, 3584, 128, 1], offset: ?>>
+// CHECK-NEXT:              scf.for %arg7 = %c0 to %c3 step %c1 {
+// CHECK-NEXT:                %subview_8 = memref.subview %subview_4[0, %arg7, 0, 0] [1, 1, 3, 64] [1, 1, 1, 1] : memref<1x3x3x64xf32, strided<[57600, 1920, 64, 1], offset: ?>> to memref<1x1x3x64xf32, strided<[57600, 1920, 64, 1], offset: ?>>
+// CHECK-NEXT:                %subview_9 = memref.subview %subview_6[%arg7, 0, 0, 0] [1, 3, 64, 1] [1, 1, 1, 1] : memref<3x3x64x1xf32, strided<[24576, 8192, 128, 1], offset: ?>> to memref<1x3x64x1xf32, strided<[24576, 8192, 128, 1], offset: ?>>
+// CHECK-NEXT:                scf.for %arg8 = %c0 to %c3 step %c1 {
+// CHECK-NEXT:                  %subview_10 = memref.subview %subview_8[0, 0, %arg8, 0] [1, 1, 1, 64] [1, 1, 1, 1] : memref<1x1x3x64xf32, strided<[57600, 1920, 64, 1], offset: ?>> to memref<1x1x1x64xf32, strided<[57600, 1920, 64, 1], offset: ?>>
+// CHECK-NEXT:                  %subview_11 = memref.subview %subview_9[0, %arg8, 0, 0] [1, 1, 64, 1] [1, 1, 1, 1] : memref<1x3x64x1xf32, strided<[24576, 8192, 128, 1], offset: ?>> to memref<1x1x64x1xf32, strided<[24576, 8192, 128, 1], offset: ?>>
+// CHECK-NEXT:                  affine.for %arg9 = 0 to 1 {
+// CHECK-NEXT:                    affine.for %arg10 = 0 to 1 {
+// CHECK-NEXT:                      affine.for %arg11 = 0 to 1 {
+// CHECK-NEXT:                        affine.for %arg12 = 0 to 1 {
+// CHECK-NEXT:                          affine.for %arg13 = 0 to 1 {
+// CHECK-NEXT:                            affine.for %arg14 = 0 to 1 {
+// CHECK-NEXT:                              affine.for %arg15 = 0 to 64 {
+// CHECK-NEXT:                                %0 = affine.apply #map(%arg10, %arg13)
+// CHECK-NEXT:                                %1 = affine.apply #map(%arg11, %arg14)
+// CHECK-NEXT:                                %2 = affine.load %subview_10[%arg9, %0, %1, %arg15] : memref<1x1x1x64xf32, strided<[57600, 1920, 64, 1], offset: ?>>
+// CHECK-NEXT:                                %3 = affine.load %subview_11[%arg13, %arg14, %arg15, %arg12] : memref<1x1x64x1xf32, strided<[24576, 8192, 128, 1], offset: ?>>
+// CHECK-NEXT:                                %4 = affine.load %subview_7[%arg9, %arg10, %arg11, %arg12] : memref<1x1x1x1xf32, strided<[100352, 3584, 128, 1], offset: ?>>
+// CHECK-NEXT:                                %5 = arith.mulf %2, %3 : f32
+// CHECK-NEXT:                                %6 = arith.addf %4, %5 : f32
+// CHECK-NEXT:                                affine.store %6, %subview_7[%arg9, %arg10, %arg11, %arg12] : memref<1x1x1x1xf32, strided<[100352, 3584, 128, 1], offset: ?>>
+// CHECK-NEXT:                              }
+// CHECK-NEXT:                            }
+// CHECK-NEXT:                          }
+// CHECK-NEXT:                        }
+// CHECK-NEXT:                      }
+// CHECK-NEXT:                    }
+// CHECK-NEXT:                  }
+// CHECK-NEXT:                } {"__node0__/s"}
+// CHECK-NEXT:              } {"__node0__/r"}
+// CHECK-NEXT:            } {"__node0__/f"}
+// CHECK-NEXT:          } {"__node0__/w"}
+// CHECK-NEXT:        } {"__node0__/h"}
+// CHECK-NEXT:      } {"__node0__/n"}
+// CHECK-NEXT:      return
+// CHECK-NEXT:    }
+// CHECK-NEXT:  }

--- a/tests/filecheck/mlir_loop/gen_transform/vecto_matmul.mlir
+++ b/tests/filecheck/mlir_loop/gen_transform/vecto_matmul.mlir
@@ -34,8 +34,8 @@ func.func @myfun(
 // CHECK-NEXT:      transform.annotate %loops "__node0__/I" : !transform.any_op
 // CHECK-NEXT:      %tiled_linalg_op_0, %loops_1 = transform.structured.tile_using_for %tiled_linalg_op tile_sizes [0, 0, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
 // CHECK-NEXT:      transform.annotate %loops_1 "__node0__/K" : !transform.any_op
-// CHECK-NEXT:      %1 = transform.get_parent_op %loops {isolated_from_above} : (!transform.any_op) -> !transform.any_op
 // CHECK-NEXT:      transform.include @_vecto failures(suppress) (%tiled_linalg_op_0) : (!transform.any_op) -> ()
+// CHECK-NEXT:      %1 = transform.get_parent_op %loops {isolated_from_above} : (!transform.any_op) -> !transform.any_op
 // CHECK-NEXT:      transform.apply_patterns to %1 {
 // CHECK-NEXT:        transform.apply_patterns.vector.reduction_to_contract
 // CHECK-NEXT:        transform.apply_patterns.vector.transfer_permutation_patterns

--- a/tests/filecheck/schedules/test_matmul_descript_mlir.py
+++ b/tests/filecheck/schedules/test_matmul_descript_mlir.py
@@ -61,9 +61,8 @@ print(f"CODE: {res}")
 # CHECK-NEXT:      transform.annotate %loops "./i" : !transform.any_op
 # CHECK-NEXT:      %tiled_linalg_op_0, %loops_1 = transform.structured.tile_using_for %tiled_linalg_op tile_sizes [0, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
 # CHECK-NEXT:      transform.annotate %loops_1 "./j" : !transform.any_op
-# CHECK-NEXT:      %1 = transform.get_parent_op %loops {isolated_from_above} : (!transform.any_op) -> !transform.any_op
-# CHECK-NEXT:      %2 = transform.structured.match attributes {__xtc_id_C_} in %arg0 : (!transform.any_op) -> !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_2, %loops_3 = transform.structured.tile_using_for %2 tile_sizes [0, 0, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      %1 = transform.structured.match attributes {__xtc_id_C_} in %arg0 : (!transform.any_op) -> !transform.any_op
+# CHECK-NEXT:      %tiled_linalg_op_2, %loops_3 = transform.structured.tile_using_for %1 tile_sizes [0, 0, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
 # CHECK-NEXT:      transform.annotate %loops_3 "C/K" : !transform.any_op
 # CHECK-NEXT:      %tiled_linalg_op_4, %loops_5 = transform.structured.tile_using_for %tiled_linalg_op_2 tile_sizes [2, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
 # CHECK-NEXT:      transform.annotate %loops_5 "C/I" : !transform.any_op
@@ -71,18 +70,17 @@ print(f"CODE: {res}")
 # CHECK-NEXT:      transform.annotate %loops_7 "C/J" : !transform.any_op
 # CHECK-NEXT:      %tiled_linalg_op_8, %loops_9 = transform.structured.tile_using_for %tiled_linalg_op_6 tile_sizes [1, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
 # CHECK-NEXT:      transform.annotate %loops_9 "C/I0" : !transform.any_op
-# CHECK-NEXT:      %3 = transform.get_parent_op %loops_3 {isolated_from_above} : (!transform.any_op) -> !transform.any_op
 # CHECK-NEXT:      transform.include @_vecto failures(suppress) (%tiled_linalg_op_8) : (!transform.any_op) -> ()
-# CHECK-NEXT:      transform.apply_patterns to %3 {
+# CHECK-NEXT:      transform.loop.unroll %loops_9 {factor = 2 : i64} : !transform.any_op
+# CHECK-NEXT:      %2 = transform.get_parent_op %loops_3 {isolated_from_above} : (!transform.any_op) -> !transform.any_op
+# CHECK-NEXT:      transform.apply_patterns to %2 {
 # CHECK-NEXT:        transform.apply_patterns.vector.reduction_to_contract
 # CHECK-NEXT:        transform.apply_patterns.vector.transfer_permutation_patterns
 # CHECK-NEXT:      } : !transform.any_op
-# CHECK-NEXT:      transform.apply_patterns to %3 {
+# CHECK-NEXT:      transform.apply_patterns to %2 {
 # CHECK-NEXT:        transform.apply_patterns.vector.lower_outerproduct
 # CHECK-NEXT:        transform.apply_patterns.vector.lower_contraction
 # CHECK-NEXT:      } : !transform.any_op
-# CHECK-NEXT:      %4 = transform.structured.match attributes {"C/I0"} in %3 : (!transform.any_op) -> !transform.any_op
-# CHECK-NEXT:      transform.loop.unroll %loops_9 {factor = 2 : i64} : !transform.any_op
 # CHECK-NEXT:      transform.yield 
 # CHECK-NEXT:    }
 # CHECK-NEXT:  }
@@ -117,34 +115,30 @@ print(f"CODE: {res}")
 # CHECK-NEXT:          scf.for %arg5 = %c0 to %c32 step %c16 {
 # CHECK-NEXT:            %subview_5 = memref.subview %subview_1[0, %arg5] [1, 16] [1, 1] : memref<1x32xf32, strided<[32, 1], offset: ?>> to memref<1x16xf32, strided<[32, 1], offset: ?>>
 # CHECK-NEXT:            %subview_6 = memref.subview %subview_4[0, %arg5] [2, 16] [1, 1] : memref<2x32xf32, strided<[32, 1], offset: ?>> to memref<2x16xf32, strided<[32, 1], offset: ?>>
-# CHECK-NEXT:            %c2_7 = arith.constant 2 : index
-# CHECK-NEXT:            %subview_8 = memref.subview %subview_3[%c0, 0] [1, 1] [1, 1] : memref<2x1xf32, strided<[512, 1], offset: ?>> to memref<1x1xf32, strided<[512, 1], offset: ?>>
-# CHECK-NEXT:            %subview_9 = memref.subview %subview_6[%c0, 0] [1, 16] [1, 1] : memref<2x16xf32, strided<[32, 1], offset: ?>> to memref<1x16xf32, strided<[32, 1], offset: ?>>
-# CHECK-NEXT:            %1 = vector.transfer_read %subview_8[%c0, %c0], %0 {in_bounds = [true, true]} : memref<1x1xf32, strided<[512, 1], offset: ?>>, vector<1x1xf32>
+# CHECK-NEXT:            %subview_7 = memref.subview %subview_3[%c0, 0] [1, 1] [1, 1] : memref<2x1xf32, strided<[512, 1], offset: ?>> to memref<1x1xf32, strided<[512, 1], offset: ?>>
+# CHECK-NEXT:            %subview_8 = memref.subview %subview_6[%c0, 0] [1, 16] [1, 1] : memref<2x16xf32, strided<[32, 1], offset: ?>> to memref<1x16xf32, strided<[32, 1], offset: ?>>
+# CHECK-NEXT:            %1 = vector.transfer_read %subview_7[%c0, %c0], %0 {in_bounds = [true, true]} : memref<1x1xf32, strided<[512, 1], offset: ?>>, vector<1x1xf32>
 # CHECK-NEXT:            %2 = vector.transfer_read %subview_5[%c0, %c0], %0 {in_bounds = [true, true]} : memref<1x16xf32, strided<[32, 1], offset: ?>>, vector<1x16xf32>
-# CHECK-NEXT:            %3 = vector.transfer_read %subview_9[%c0, %c0], %0 {in_bounds = [true, true]} : memref<1x16xf32, strided<[32, 1], offset: ?>>, vector<1x16xf32>
+# CHECK-NEXT:            %3 = vector.transfer_read %subview_8[%c0, %c0], %0 {in_bounds = [true, true]} : memref<1x16xf32, strided<[32, 1], offset: ?>>, vector<1x16xf32>
 # CHECK-NEXT:            %4 = vector.extract %2[0] : vector<16xf32> from vector<1x16xf32>
 # CHECK-NEXT:            %5 = vector.extract %1[0, 0] : f32 from vector<1x1xf32>
 # CHECK-NEXT:            %6 = vector.broadcast %5 : f32 to vector<16xf32>
 # CHECK-NEXT:            %7 = vector.extract %3[0] : vector<16xf32> from vector<1x16xf32>
 # CHECK-NEXT:            %8 = vector.fma %6, %4, %7 : vector<16xf32>
 # CHECK-NEXT:            %9 = vector.insert %8, %cst [0] : vector<16xf32> into vector<1x16xf32>
-# CHECK-NEXT:            vector.transfer_write %9, %subview_9[%c0, %c0] {in_bounds = [true, true]} : vector<1x16xf32>, memref<1x16xf32, strided<[32, 1], offset: ?>>
-# CHECK-NEXT:            %c1_10 = arith.constant 1 : index
-# CHECK-NEXT:            %10 = arith.muli %c1, %c1_10 : index
-# CHECK-NEXT:            %11 = arith.addi %c0, %10 : index
-# CHECK-NEXT:            %subview_11 = memref.subview %subview_3[%11, 0] [1, 1] [1, 1] : memref<2x1xf32, strided<[512, 1], offset: ?>> to memref<1x1xf32, strided<[512, 1], offset: ?>>
-# CHECK-NEXT:            %subview_12 = memref.subview %subview_6[%11, 0] [1, 16] [1, 1] : memref<2x16xf32, strided<[32, 1], offset: ?>> to memref<1x16xf32, strided<[32, 1], offset: ?>>
-# CHECK-NEXT:            %12 = vector.transfer_read %subview_11[%c0, %c0], %0 {in_bounds = [true, true]} : memref<1x1xf32, strided<[512, 1], offset: ?>>, vector<1x1xf32>
-# CHECK-NEXT:            %13 = vector.transfer_read %subview_5[%c0, %c0], %0 {in_bounds = [true, true]} : memref<1x16xf32, strided<[32, 1], offset: ?>>, vector<1x16xf32>
-# CHECK-NEXT:            %14 = vector.transfer_read %subview_12[%c0, %c0], %0 {in_bounds = [true, true]} : memref<1x16xf32, strided<[32, 1], offset: ?>>, vector<1x16xf32>
-# CHECK-NEXT:            %15 = vector.extract %13[0] : vector<16xf32> from vector<1x16xf32>
-# CHECK-NEXT:            %16 = vector.extract %12[0, 0] : f32 from vector<1x1xf32>
-# CHECK-NEXT:            %17 = vector.broadcast %16 : f32 to vector<16xf32>
-# CHECK-NEXT:            %18 = vector.extract %14[0] : vector<16xf32> from vector<1x16xf32>
-# CHECK-NEXT:            %19 = vector.fma %17, %15, %18 : vector<16xf32>
-# CHECK-NEXT:            %20 = vector.insert %19, %cst [0] : vector<16xf32> into vector<1x16xf32>
-# CHECK-NEXT:            vector.transfer_write %20, %subview_12[%c0, %c0] {in_bounds = [true, true]} : vector<1x16xf32>, memref<1x16xf32, strided<[32, 1], offset: ?>>
+# CHECK-NEXT:            vector.transfer_write %9, %subview_8[%c0, %c0] {in_bounds = [true, true]} : vector<1x16xf32>, memref<1x16xf32, strided<[32, 1], offset: ?>>
+# CHECK-NEXT:            %subview_9 = memref.subview %subview_3[%c1, 0] [1, 1] [1, 1] : memref<2x1xf32, strided<[512, 1], offset: ?>> to memref<1x1xf32, strided<[512, 1], offset: ?>>
+# CHECK-NEXT:            %subview_10 = memref.subview %subview_6[%c1, 0] [1, 16] [1, 1] : memref<2x16xf32, strided<[32, 1], offset: ?>> to memref<1x16xf32, strided<[32, 1], offset: ?>>
+# CHECK-NEXT:            %10 = vector.transfer_read %subview_9[%c0, %c0], %0 {in_bounds = [true, true]} : memref<1x1xf32, strided<[512, 1], offset: ?>>, vector<1x1xf32>
+# CHECK-NEXT:            %11 = vector.transfer_read %subview_5[%c0, %c0], %0 {in_bounds = [true, true]} : memref<1x16xf32, strided<[32, 1], offset: ?>>, vector<1x16xf32>
+# CHECK-NEXT:            %12 = vector.transfer_read %subview_10[%c0, %c0], %0 {in_bounds = [true, true]} : memref<1x16xf32, strided<[32, 1], offset: ?>>, vector<1x16xf32>
+# CHECK-NEXT:            %13 = vector.extract %11[0] : vector<16xf32> from vector<1x16xf32>
+# CHECK-NEXT:            %14 = vector.extract %10[0, 0] : f32 from vector<1x1xf32>
+# CHECK-NEXT:            %15 = vector.broadcast %14 : f32 to vector<16xf32>
+# CHECK-NEXT:            %16 = vector.extract %12[0] : vector<16xf32> from vector<1x16xf32>
+# CHECK-NEXT:            %17 = vector.fma %15, %13, %16 : vector<16xf32>
+# CHECK-NEXT:            %18 = vector.insert %17, %cst [0] : vector<16xf32> into vector<1x16xf32>
+# CHECK-NEXT:            vector.transfer_write %18, %subview_10[%c0, %c0] {in_bounds = [true, true]} : vector<1x16xf32>, memref<1x16xf32, strided<[32, 1], offset: ?>>
 # CHECK-NEXT:          } {"C/J"}
 # CHECK-NEXT:        } {"C/I"}
 # CHECK-NEXT:      } {"C/K"}


### PR DESCRIPTION
# Motivation

The motivation of this PR is to have an MLIR backend more readable and maintainable, and a generated code slighlty simpler.

# Description

The refactoring focuses on MlirCompilerPasses (and impacts tests). From the perspective of the generated transform dialect, this removes redundant post-processing instructions on vectors, as well as match instructions whose results were not used.