### PR TITLE
check: fix ruff format

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ format: format-license format-ruff
 check-format: check-format-ruff check-license
 
 check-format-ruff:
-	ruff format --check
+	scripts/ruff/format.sh --check
 
 check-license:
 	scripts/licensing/licensing.py --check
@@ -55,7 +55,7 @@ check-pytest:
 	scripts/pytest/run_pytest.sh -v
 
 format-ruff:
-	ruff format
+	scripts/ruff/format.sh
 
 format-license:
 	scripts/licensing/licensing.py --apply

--- a/scripts/ruff/format.sh
+++ b/scripts/ruff/format.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ruff="ruff"
+ruff_opts="--force-exclude"
+git ls-files -z '*.py' | xargs -0 "$ruff" format $ruff_opts "$@"


### PR DESCRIPTION
Use dedicated script to ruff format only git tracked files.

# Motivation

Without this change, ruff processes all files which is no convenient as exclusion is not sufficient to avoid all cases.

# Description

Add a `scripts/ruff/format.sh` script which list tracked git files and apply ruff to it.

The only change is the list of checked files, there is no change compared to the bare ruff invocation in the projet appart from this. Hence one can still use `ruff` directly on specific files for instance.

Note that the `pyproject.toml` settings are still honored if there are exclusions there, for instance `tests` and `docs` are excluded. The `--force-exclude` option in the script is used for this (i.e. honor excludes specified in the `pyproject.toml` even if the files are listed on the command line).

Usage: `scripts/ruff/format.sh [ruff format options...]`, for instance:

    scripts/ruff/format.sh --check   # for check
    scripts/ruff/format.sh --diff       # for diff
    scripts/ruff/format.sh               # for actual format

For checking specific files file, still use ruff directly:

    ruff format --check <files...>

# Commits

Ref commits changes

# Discussion

none