### PR TITLE
search: fix sampling of strategies

### DIFF
--- a/src/xtc/search/strategies.py
+++ b/src/xtc/search/strategies.py
@@ -162,7 +162,10 @@ class BaseStrategy(Strategy):
         self, inds: list[list[list[int]]], num: int, rng: np.random.Generator
     ) -> list[VecSample]:
         draw = np.hstack(
-            [np.array(var)[rng.integers(len(var), size=num)] for var in inds]
+            [
+                np.array(var, dtype="int")[rng.integers(len(var), size=num)]
+                for var in inds
+            ]
         )
         return draw.tolist()
 

--- a/tests/filecheck/search/test_conv_pprprpvr_rnd.py
+++ b/tests/filecheck/search/test_conv_pprprpvr_rnd.py
@@ -1,0 +1,42 @@
+# RUN: python %s 2>&1 | filecheck %s
+"""
+Test strategy PPRPRPvr (Ansor like tiling, vectorized and constraints) on conv2d
+"""
+import utils
+from xtc.search.strategies import Strategy_PPRPRPvr as Strategy
+
+graph = utils.get_graph_conv2d()
+backend = utils.get_backend(graph)
+strategy = Strategy(
+    graph,
+    max_unroll=32,
+    threads=4,
+    vreg_num=4,
+    l1_size=1024,
+    l2_size=2*1024,
+)
+
+utils.print_random_samples(backend, strategy, 20)
+
+# CHECK:       sample 0: [1, 2, 1, 1, 1, 1, 1, 1, 2, 1, 1, 16, 1, 7, 1]
+# CHECK-NEXT:  sample 1: [1, 1, 1, 2, 1, 1, 1, 2, 1, 1, 2, 16, 1, 1, 1]
+# CHECK-NEXT:  sample 2: [1, 2, 1, 1, 2, 1, 2, 1, 1, 1, 1, 16, 1, 1, 3]
+# CHECK-NEXT:  sample 3: [2, 1, 1, 2, 1, 1, 2, 1, 1, 1, 1, 16, 1, 7, 1]
+# CHECK-NEXT:  sample 4: [1, 1, 2, 2, 1, 1, 2, 1, 1, 1, 1, 16, 1, 1, 3]
+# CHECK-NEXT:  sample 5: [1, 2, 1, 2, 1, 1, 1, 1, 2, 1, 1, 16, 1, 1, 1]
+# CHECK-NEXT:  sample 6: [1, 1, 2, 1, 1, 1, 1, 2, 1, 2, 1, 16, 1, 1, 1]
+# CHECK-NEXT:  sample 7: [1, 2, 1, 1, 2, 1, 1, 2, 1, 1, 1, 16, 1, 1, 1]
+# CHECK-NEXT:  sample 8: [1, 1, 2, 1, 1, 1, 2, 1, 1, 1, 1, 16, 7, 1, 1]
+# CHECK-NEXT:  sample 9: [1, 1, 1, 1, 1, 2, 2, 1, 1, 1, 2, 16, 1, 7, 1]
+# CHECK-NEXT:  sample 10: [1, 2, 1, 2, 1, 1, 1, 2, 1, 1, 1, 16, 1, 7, 1]
+# CHECK-NEXT:  sample 11: [1, 1, 1, 2, 1, 1, 2, 1, 1, 2, 1, 16, 1, 1, 1]
+# CHECK-NEXT:  sample 12: [2, 1, 1, 1, 1, 1, 2, 1, 1, 1, 2, 16, 1, 1, 3]
+# CHECK-NEXT:  sample 13: [1, 2, 1, 1, 2, 1, 2, 1, 1, 2, 1, 16, 1, 7, 1]
+# CHECK-NEXT:  sample 14: [1, 1, 1, 2, 1, 1, 1, 1, 2, 2, 1, 16, 1, 1, 1]
+# CHECK-NEXT:  sample 15: [1, 1, 1, 1, 1, 1, 1, 1, 2, 1, 1, 16, 7, 1, 1]
+# CHECK-NEXT:  sample 16: [1, 1, 1, 1, 2, 1, 1, 2, 1, 2, 1, 16, 7, 1, 1]
+# CHECK-NEXT:  sample 17: [1, 2, 1, 2, 1, 1, 2, 1, 1, 2, 1, 16, 1, 7, 1]
+# CHECK-NEXT:  sample 18: [1, 1, 2, 1, 1, 1, 1, 1, 1, 1, 2, 16, 7, 1, 1]
+# CHECK-NEXT:  sample 19: [1, 2, 1, 1, 2, 1, 2, 1, 1, 1, 1, 16, 1, 1, 1]
+# CHECK-NEXT:  stats {'filtered_l2': 5, 'filtered_l1': 5, 'filtered_reg': 6, 'filtered_vec': 6, 'filtered': 100}
+# CHECK-NEXT:  [MlirNodeSchedule(node_name='%2_0', node_ident='__xtc_id_%2_0_', dims=['b', 'h', 'w', 'f'], loop_stamps=[], splits={}, tiles={'b': {}, 'h': {}, 'w': {}, 'f': {}}, permutation={'.': ['./b', './h', './w', './f']}, vectorization=[], parallelization=[], unrolling={}), MlirNodeSchedule(node_name='%2', node_ident='__xtc_id_%2_', dims=['b', 'h', 'w', 'f', 'r', 's', 'c'], loop_stamps=[], splits={}, tiles={'b': {'./b1': 2, './b2': 2, './b3': 1}, 'h': {'./h1': 2, './h2': 2, './h3': 1}, 'w': {'./w1': 2, './w2': 1, './w3': 1}, 'f': {'./f1': 16, './f2': 16, './f3': 16}, 'r': {'./r1': 1}, 's': {'./s1': 1}, 'c': {'./c1': 1}}, permutation={'.': ['./b', './h', './w', './f', './b1', './h1', './w1', './f1', './r', './s', './c', './b2', './h2', './w2', './f2', './r1', './s1', './c1', './b3', './h3', './w3', './f3']}, vectorization=['./f3'], parallelization=['./b'], unrolling={'./f3': 16, './w3': 1, './h3': 1, './b3': 1, './c1': 1, './s1': 1, './r1': 1})]

--- a/tests/filecheck/search/test_conv_prp_rnd.py
+++ b/tests/filecheck/search/test_conv_prp_rnd.py
@@ -1,0 +1,42 @@
+# RUN: python %s 2>&1 | filecheck %s
+"""
+Test strategy PPRPRPvr (Ansor like tiling, vectorized and constraints) on conv2d
+"""
+import utils
+from xtc.search.strategies import Strategy_PRP as Strategy
+
+graph = utils.get_graph_conv2d()
+backend = utils.get_backend(graph)
+strategy = Strategy(
+    graph,
+    max_unroll=32,
+    threads=4,
+    vreg_num=4,
+    l1_size=1024,
+    l2_size=2*1024,
+)
+
+utils.print_random_samples(backend, strategy, 20)
+
+# CHECK:       sample 0: [2, 1, 1, 32]
+# CHECK-NEXT:  sample 1: [2, 2, 1, 16]
+# CHECK-NEXT:  sample 2: [1, 1, 1, 4]
+# CHECK-NEXT:  sample 3: [1, 1, 1, 32]
+# CHECK-NEXT:  sample 4: [1, 2, 2, 1]
+# CHECK-NEXT:  sample 5: [1, 2, 2, 8]
+# CHECK-NEXT:  sample 6: [1, 1, 2, 16]
+# CHECK-NEXT:  sample 7: [1, 2, 1, 32]
+# CHECK-NEXT:  sample 8: [2, 2, 2, 8]
+# CHECK-NEXT:  sample 9: [2, 2, 2, 4]
+# CHECK-NEXT:  sample 10: [2, 1, 1, 2]
+# CHECK-NEXT:  sample 11: [2, 1, 1, 4]
+# CHECK-NEXT:  sample 12: [2, 1, 2, 16]
+# CHECK-NEXT:  sample 13: [2, 2, 2, 32]
+# CHECK-NEXT:  sample 14: [2, 1, 1, 1]
+# CHECK-NEXT:  sample 15: [2, 1, 2, 32]
+# CHECK-NEXT:  sample 16: [2, 1, 2, 8]
+# CHECK-NEXT:  sample 17: [2, 1, 2, 4]
+# CHECK-NEXT:  sample 18: [2, 2, 1, 8]
+# CHECK-NEXT:  sample 19: [2, 2, 1, 4]
+# CHECK-NEXT:  stats {'filtered': 20}
+# CHECK-NEXT:  [MlirNodeSchedule(node_name='%2_0', node_ident='__xtc_id_%2_0_', dims=['b', 'h', 'w', 'f'], loop_stamps=[], splits={}, tiles={'b': {}, 'h': {}, 'w': {}, 'f': {}}, permutation={'.': ['./b', './h', './w', './f']}, vectorization=[], parallelization=[], unrolling={}), MlirNodeSchedule(node_name='%2', node_ident='__xtc_id_%2_', dims=['b', 'h', 'w', 'f', 'r', 's', 'c'], loop_stamps=[], splits={}, tiles={'b': {'./b1': 2}, 'h': {'./h1': 2}, 'w': {'./w1': 1}, 'f': {'./f1': 4}, 'r': {}, 's': {}, 'c': {}}, permutation={'.': ['./b', './h', './w', './f', './r', './s', './c', './b1', './h1', './w1', './f1']}, vectorization=['./f1'], parallelization=['./b'], unrolling={'./f1': 4, './w1': 1, './h1': 2, './b1': 2})]

--- a/tests/filecheck/search/test_matmul_pprprpvr_rnd.py
+++ b/tests/filecheck/search/test_matmul_pprprpvr_rnd.py
@@ -1,0 +1,42 @@
+# RUN: python %s 2>&1 | filecheck %s
+"""
+Test strategy PPRPRPvr (Ansor like tiling, vectorized and constraints) on matmul
+"""
+import utils
+from xtc.search.strategies import Strategy_PPRPRPvr as Strategy
+
+graph = utils.get_graph_matmul()
+backend = utils.get_backend(graph)
+strategy = Strategy(
+    graph,
+    max_unroll=32,
+    threads=4,
+    vreg_num=4,
+    l1_size=1024,
+    l2_size=8*1024,
+)
+
+utils.print_random_samples(backend, strategy, 20)
+
+# CHECK:       sample 0: [1, 21, 1, 1, 1, 32, 3]
+# CHECK-NEXT:  sample 1: [7, 3, 1, 1, 1, 16, 2]
+# CHECK-NEXT:  sample 2: [7, 3, 1, 1, 2, 16, 1]
+# CHECK-NEXT:  sample 3: [7, 1, 1, 1, 1, 16, 2]
+# CHECK-NEXT:  sample 4: [7, 3, 1, 1, 1, 16, 1]
+# CHECK-NEXT:  sample 5: [21, 1, 1, 1, 1, 16, 1]
+# CHECK-NEXT:  sample 6: [3, 7, 1, 1, 1, 16, 2]
+# CHECK-NEXT:  sample 7: [21, 1, 1, 2, 1, 16, 12]
+# CHECK-NEXT:  sample 8: [7, 1, 1, 1, 1, 16, 6]
+# CHECK-NEXT:  sample 9: [1, 21, 1, 1, 2, 16, 3]
+# CHECK-NEXT:  sample 10: [3, 1, 1, 1, 1, 16, 4]
+# CHECK-NEXT:  sample 11: [3, 1, 1, 1, 2, 16, 4]
+# CHECK-NEXT:  sample 12: [7, 1, 1, 2, 1, 16, 2]
+# CHECK-NEXT:  sample 13: [1, 7, 3, 2, 1, 16, 4]
+# CHECK-NEXT:  sample 14: [3, 1, 1, 1, 2, 16, 1]
+# CHECK-NEXT:  sample 15: [1, 21, 1, 1, 1, 16, 1]
+# CHECK-NEXT:  sample 16: [3, 1, 1, 1, 1, 16, 12]
+# CHECK-NEXT:  sample 17: [1, 3, 1, 2, 1, 16, 2]
+# CHECK-NEXT:  sample 18: [1, 1, 1, 1, 2, 16, 3]
+# CHECK-NEXT:  sample 19: [7, 1, 3, 1, 1, 16, 2]
+# CHECK-NEXT:  stats {'filtered_l2': 2, 'filtered_l1': 2, 'filtered_reg': 3, 'filtered_vec': 3, 'filtered': 70}
+# CHECK-NEXT:  [MlirNodeSchedule(node_name='%2_0', node_ident='__xtc_id_%2_0_', dims=['i', 'j'], loop_stamps=[], splits={}, tiles={'i': {}, 'j': {}}, permutation={'.': ['./i', './j']}, vectorization=[], parallelization=[], unrolling={}), MlirNodeSchedule(node_name='%2', node_ident='__xtc_id_%2_', dims=['i', 'j', 'k'], loop_stamps=[], splits={}, tiles={'i': {'./i1': 21, './i2': 3, './i3': 3}, 'j': {'./j1': 16, './j2': 16, './j3': 16}, 'k': {'./k1': 2}}, permutation={'.': ['./i', './j', './i1', './j1', './k', './i2', './j2', './k1', './i3', './j3']}, vectorization=['./j3'], parallelization=['./i'], unrolling={'./j3': 16, './i3': 3, './k1': 2})]

--- a/tests/filecheck/search/test_matmul_prp_rnd.py
+++ b/tests/filecheck/search/test_matmul_prp_rnd.py
@@ -1,0 +1,42 @@
+# RUN: python %s 2>&1 | filecheck %s
+"""
+Test strategy PPRPRPvr (Ansor like tiling, vectorized and constraints) on matmul
+"""
+import utils
+from xtc.search.strategies import Strategy_PRP as Strategy
+
+graph = utils.get_graph_matmul()
+backend = utils.get_backend(graph)
+strategy = Strategy(
+    graph,
+    max_unroll=32,
+    threads=4,
+    vreg_num=4,
+    l1_size=1024,
+    l2_size=8*1024,
+)
+
+utils.print_random_samples(backend, strategy, 20)
+
+# CHECK:       sample 0: [21, 2]
+# CHECK-NEXT:  sample 1: [7, 16]
+# CHECK-NEXT:  sample 2: [3, 1]
+# CHECK-NEXT:  sample 3: [3, 4]
+# CHECK-NEXT:  sample 4: [1, 32]
+# CHECK-NEXT:  sample 5: [1, 8]
+# CHECK-NEXT:  sample 6: [1, 1]
+# CHECK-NEXT:  sample 7: [1, 16]
+# CHECK-NEXT:  sample 8: [21, 16]
+# CHECK-NEXT:  sample 9: [7, 32]
+# CHECK-NEXT:  sample 10: [7, 1]
+# CHECK-NEXT:  sample 11: [21, 1]
+# CHECK-NEXT:  sample 12: [7, 8]
+# CHECK-NEXT:  sample 13: [7, 2]
+# CHECK-NEXT:  sample 14: [7, 4]
+# CHECK-NEXT:  sample 15: [21, 4]
+# CHECK-NEXT:  sample 16: [3, 32]
+# CHECK-NEXT:  sample 17: [1, 4]
+# CHECK-NEXT:  sample 18: [3, 2]
+# CHECK-NEXT:  sample 19: [21, 8]
+# CHECK-NEXT:  stats {'filtered': 19}
+# CHECK-NEXT:  [MlirNodeSchedule(node_name='%2_0', node_ident='__xtc_id_%2_0_', dims=['i', 'j'], loop_stamps=[], splits={}, tiles={'i': {}, 'j': {}}, permutation={'.': ['./i', './j']}, vectorization=[], parallelization=[], unrolling={}), MlirNodeSchedule(node_name='%2', node_ident='__xtc_id_%2_', dims=['i', 'j', 'k'], loop_stamps=[], splits={}, tiles={'i': {'./i1': 21}, 'j': {'./j1': 8}, 'k': {}}, permutation={'.': ['./i', './j', './k', './i1', './j1']}, vectorization=['./j1'], parallelization=['./i'], unrolling={'./j1': 8, './i1': 21})]

--- a/tests/filecheck/search/utils.py
+++ b/tests/filecheck/search/utils.py
@@ -56,3 +56,14 @@ def print_exhaustive_samples(backend: Backend, strategy: Strategy, num: int|None
     sch = backend.get_scheduler()
     strategy.generate(sch, sample)
     print(sch.schedule())
+
+def print_random_samples(backend: Backend, strategy: Strategy, num: int):
+    generator = strategy.sample(num=num)
+    sample = []
+    for idx, sample in enumerate(generator):
+        print(f"sample {idx}: {sample}")
+    if hasattr(strategy, "stats"):
+        print("stats", getattr(strategy, "stats"))
+    sch = backend.get_scheduler()
+    strategy.generate(sch, sample)
+    print(sch.schedule())


### PR DESCRIPTION
Random sampling was converting int sample to floats due to
conversion to numpy array (float by default).

This generated float values for tile sizes which generated
errors in some vectorization cases for the tvm backend.

# Motivation

Fixes a bug, for instance in explore script which ended into an assertion:

    TypeError: unsupported operand type(s) for &: 'float' and 'float'


# Description

Fix the bug by forcing `int` dtype on np array.

Added new tests to check the random sampler which actually was not covered as the tests only used the exhaustive generator.

