### PR TITLE
ci: verify that PR does not contain merge commit

### DIFF
--- a/.github/workflows/xtc-tests.yml
+++ b/.github/workflows/xtc-tests.yml
@@ -8,7 +8,18 @@ jobs:
         os: [ubuntu-latest]
         python-version: ["3.12"]
     steps:
-      - uses: actions/checkout@v5
+      - name: Checkout XTC Repository
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+      - name: Ensure PR has linear history
+        if: github.event_name == 'pull_request'
+        run: |
+          MERGE_COMMITS="$(git rev-list --merges "$GITHUB_SHA^1..$GITHUB_SHA^2")"
+          if [ -n "$MERGE_COMMITS" ]; then
+            echo "::error::PR contains merges, always use rebase for updating branches: Merge commits: $MERGE_COMMITS" >&2
+            exit 1
+          fi
       - name: Install Distro Packages
         # Note: package cache with awalsh128/cache-apt-pkgs-action does not work correctly, use standard install.
         run: |


### PR DESCRIPTION
# Motivation

Disallow merge commit for PR. This avoids in particular typical errors such as updating the branch with a merge commit from main instead of rebasing.

# Description

This is a CI check, as there is no possibility to do it with github rules, inspired from solution proposed here: https://github.com/orgs/community/discussions/12032#discussioncomment-13210015

The github settings can't be set easily to forbid merge commit on the branch update button (ref there https://github.com/orgs/community/discussions/12032).

Also, anyway it would not check merge done manually by the user, hence a pre-merge check.

