### PR TITLE
explore: added iterative search and random forest optimizer

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.2.dev1"
 license = { text = "BSD 3 Clause" }
 authors = [{ name = "Hugo Pompougnac", email = "hugo.pompougnac@inria.fr" }]
 classifiers = ["Programming Language :: Python :: 3"]
-dependencies = ['jinja2', 'matplotlib', 'numpy', 'ordered-set', 'py-cpuinfo', 'tqdm', 'typing_extensions', 'pyyaml','lit','filecheck','xdsl~=0.54.0']
+dependencies = ['jinja2', 'matplotlib', 'numpy', 'ordered-set', 'py-cpuinfo', 'tqdm', 'typing_extensions', 'pyyaml','scikit-learn','lit','filecheck','xdsl~=0.54.0']
 requires-python = ">=3.10"
 
 [project.optional-dependencies]
@@ -19,6 +19,7 @@ dev = [
     "pytest",
     "pytest-xdist",
     "pyright==1.1.407",
+    "types-PyYAML",
     "marimo==0.14.16",
     "ruff==0.14.10",
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ tqdm
 typing_extensions
 xdsl~=0.50.0
 pyyaml
+scikit-learn

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -9,4 +9,5 @@ mypy==1.15.0
 pytest
 pytest-xdist
 pyright==1.1.407
+types-PyYAML
 ruff==0.14.10

--- a/scripts/explore/run-explore-optimizers.sh
+++ b/scripts/explore/run-explore-optimizers.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+outdir="${1-.}"
+BACKENDS="${BACKENDS:-tvm}"
+TRIALS="${TRIALS:-100}"
+SEEDS="${SEEDS:- 1 2 3 4 5}"
+STRATEGY="${STRATEGY:-tile_ppwrprp}"
+OPTIMIZERS="${OPTIMIZERS:-random random-forest-aggressive}"
+PROBLEM="${PROBLEM:-ResNet18_01}"
+OPERATOR="${OPERATOR:-conv2d}"
+
+mkdir -p "$outdir"
+rm -f "$outdir/*.csv"
+
+for b in $BACKENDS; do
+    echo "using backend $b"
+    for o in $OPTIMIZERS; do
+        for s in $SEEDS; do
+            echo "Testing optimizer $o on $PROBLEM with seed $s ..." 
+            (
+            set -x
+            loop-explore \
+              --backends "$b" \
+              --search iterative \
+              --optimizer "$o" \
+              --operator "$OPERATOR"
+              --op-name "$PROBLEM" \
+              --jobs 1 \
+              --seed $s \
+              --strategy "$STRATEGY" \
+              --output "$outdir/results.b$b.prob$PROBLEM.strat$STRATEGY.seed$s.csv"
+            )
+        done
+    done
+done

--- a/src/xtc/itf/search/optimizer.py
+++ b/src/xtc/itf/search/optimizer.py
@@ -1,0 +1,60 @@
+#
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2024-2026 The XTC Project Authors
+#
+from abc import ABC, abstractmethod
+from typing import TypeAlias
+
+VecSample: TypeAlias = list[int]
+
+
+class Optimizer(ABC):
+    """Base abstract class for implementing an optimizer
+
+    An Optimizer is used in iterative evaluation during loop-explore to
+    suggest samples for each batch using observations from previous batch.
+    """
+
+    @abstractmethod
+    def suggest(self) -> list[VecSample]:
+        """Suggests a new batch of samples to be evaluated.
+
+        It gets a large sample of size batch_candidates, and then from that
+        either returns random choices or uses a model to pick the predicted best samples.
+
+        Returns:
+            A list of samples representing a new batch of samples.
+        """
+        ...
+
+    @abstractmethod
+    def observe(self, x: list[VecSample], y: list[float]):
+        """Observes the result of the batch evaluation and updates the model.
+
+        The model is first fit after update_first samples are observed
+        and is subsequently refit every update_period additional samples.
+
+        Args:
+            x: the batch of samples that were evaluated
+            y: the evaluation result for each sample in the batch
+        """
+        ...
+
+    @abstractmethod
+    def finished(self):
+        """Gets called when the evaluation for all iterations has been completed
+
+        Used for cleaner logging
+        """
+        ...
+
+    @abstractmethod
+    def _sample_batch(self) -> list[VecSample]:
+        """Uses the sampler to get a large sample from the strategy sampler.
+
+        Used by suggest() to get a sample of candidates to choose from.
+
+        Returns:
+            A list of samples of size batch_candidates
+        """
+        ...

--- a/src/xtc/search/optimizers.py
+++ b/src/xtc/search/optimizers.py
@@ -1,0 +1,254 @@
+#
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2024-2026 The XTC Project Authors
+#
+import random
+import numpy as np
+import logging
+import yaml
+from collections.abc import Sequence, Iterator
+from sklearn.ensemble import RandomForestRegressor
+from typing import Callable, TypeAlias, cast, Any, ClassVar
+from typing_extensions import override
+from xtc.itf.search.optimizer import Optimizer
+
+VecSample: TypeAlias = list[int]
+
+logger = logging.getLogger(__name__)
+
+
+class BaseOptimizer(Optimizer):
+    def __init__(
+        self,
+        sample_fn: Callable[[int, int], Iterator[VecSample]],
+        batch: int,
+        seed: int,
+        batch_candidates: int,
+    ):
+        self.sample_fn = sample_fn
+        self.batch = batch
+        self.batch_candidates = batch_candidates
+        self.rng = random.Random(seed)
+
+    @override
+    def suggest(self) -> list[VecSample]:
+        raise NotImplementedError
+
+    @override
+    def observe(self, x: list[VecSample], y: list[float]):
+        pass
+
+    @override
+    def finished(self):
+        pass
+
+    @override
+    def _sample_batch(self) -> list[VecSample]:
+        seed = self.rng.randint(0, 2**32 - 1)
+        return list(self.sample_fn(self.batch_candidates, seed))
+
+
+class RandomOptimizer(BaseOptimizer):
+    def __init__(
+        self,
+        sample_fn: Callable[[int, int], Iterator[VecSample]],
+        batch: int,
+        seed: int,
+        batch_candidates: int = 1000,
+    ):
+        super().__init__(
+            sample_fn=sample_fn,
+            batch=batch,
+            seed=seed,
+            batch_candidates=batch_candidates,
+        )
+
+    @override
+    def suggest(self):
+        candidates = self._sample_batch()
+        return self.rng.choices(candidates, k=self.batch)
+
+
+class RandomForestOptimizer(BaseOptimizer):
+    def __init__(
+        self,
+        sample_fn: Callable[[int, int], Iterator[VecSample]],
+        batch: int,
+        seed: int,
+        batch_candidates: int,
+        beta: float,
+        alpha: float,
+        update_first: int,
+        update_period: int,
+        n_estimators: int,
+        max_depth: int,
+        min_samples_leaf: int,
+        max_features: float,
+    ):
+        super().__init__(sample_fn, batch, seed, batch_candidates)
+        self.update_first = update_first if update_first else batch
+        self.update_period = update_period if update_period else batch
+        self.beta = beta
+        self.seed = seed
+        self.alpha = alpha
+        self.beta_min = 0.05
+        self.update_last = 0
+
+        self.X: list[VecSample] = []
+        self.y: list[float] = []
+        self.rf = RandomForestRegressor(
+            n_estimators=n_estimators,
+            n_jobs=1,
+            max_depth=max_depth,
+            min_samples_leaf=min_samples_leaf,
+            min_samples_split=min_samples_leaf * 2,
+            max_features=max_features,
+            random_state=seed,
+        )
+        self.best_y: float = 0.0
+        self.best_x: VecSample = []
+        # logging
+        self.last_beta = None
+        self.log_str = ""
+
+    @override
+    def suggest(self):
+        candidates = self._sample_batch()
+        if len(self.X) < self.update_first:
+            return self.rng.choices(candidates, k=self.batch)
+
+        preds = np.stack([t.predict(candidates) for t in self.rf.estimators_])
+        mean = preds.mean(axis=0)
+        std = preds.std(axis=0)
+
+        # UCB acquisition modified with improvement and inverse time beta decay
+        beta = max(self.beta_min, self.beta / (len(self.y) ** self.alpha))
+        improvement = mean - self.best_y
+        scores = improvement + beta * std
+        top_idx = np.argpartition(scores, -self.batch)[-self.batch :]
+        top_candidates = [candidates[i] for i in top_idx]
+
+        self.last_beta = beta
+        return top_candidates
+
+    @override
+    def observe(self, x: list[VecSample], y: list[float]):
+        self.X += x
+        self.y += y
+        for i in range(0, self.batch):
+            if y[i] > self.best_y:
+                self.best_x = x[i]
+                self.best_y = y[i]
+
+        self.log_str += f"trial: {len(self.X)} best_y: {self.best_y} y: {y} last_beta: {self.last_beta}\n"
+
+        if len(self.X) < self.update_first:
+            return
+
+        steps_since_first = (len(self.X) - self.update_first) // self.update_period
+        update_n = self.update_first + steps_since_first * self.update_period
+
+        if update_n > self.update_last:
+            self.rf.fit(self.X[:update_n], self.y[:update_n])
+            self.update_last = update_n
+
+    @override
+    def finished(self):
+        logger.info("finished!")
+        logger.info(self.log_str)
+
+
+class RandomForestOptimizer_Explore(RandomForestOptimizer):
+    def __init__(
+        self,
+        sample_fn: Callable[[int, int], Iterator[VecSample]],
+        batch: int,
+        seed: int,
+    ):
+        preset = {
+            "batch_candidates": 1000,
+            "beta": 5,
+            "alpha": 0.6,
+            "update_first": None,
+            "update_period": None,
+            "n_estimators": 300,
+            "max_depth": 8,
+            "min_samples_leaf": 3,
+            "max_features": 0.9,
+        }
+        super().__init__(sample_fn, batch, seed, **cast(dict[str, Any], preset))
+
+
+class RandomForestOptimizer_Default(RandomForestOptimizer):
+    def __init__(
+        self,
+        sample_fn: Callable[[int, int], Iterator[VecSample]],
+        batch: int,
+        seed: int,
+    ):
+        preset = {
+            "batch_candidates": 1000,
+            "beta": 2.5,
+            "alpha": 0.7,
+            "update_first": None,
+            "update_period": None,
+            "n_estimators": 300,
+            "max_depth": 12,
+            "min_samples_leaf": 5,
+            "max_features": 0.8,
+        }
+        super().__init__(sample_fn, batch, seed, **cast(dict[str, Any], preset))
+
+
+class RandomForestOptimizer_Aggressive(RandomForestOptimizer):
+    def __init__(
+        self,
+        sample_fn: Callable[[int, int], Iterator[VecSample]],
+        batch: int,
+        seed: int,
+    ):
+        preset = {
+            "batch_candidates": 1000,
+            "beta": 2,
+            "alpha": 0.8,
+            "update_first": None,
+            "update_period": None,
+            "n_estimators": 200,
+            "max_depth": 8,
+            "min_samples_leaf": 5,
+            "max_features": 0.7,
+        }
+        super().__init__(sample_fn, batch, seed, **cast(dict[str, Any], preset))
+
+
+class RandomForestOptimizer_Custom(RandomForestOptimizer):
+    def __init__(
+        self,
+        sample_fn: Callable[[int, int], Iterator[VecSample]],
+        batch: int,
+        seed: int,
+        config_file: str,
+    ):
+        with open(config_file, "r") as f:
+            custom = yaml.safe_load(f)
+            super().__init__(sample_fn, batch, seed, **custom)
+
+
+class Optimizers:
+    @classmethod
+    def names(cls) -> Sequence[str]:
+        return list(cls._map.keys())
+
+    @classmethod
+    def from_name(cls, name: str) -> type[BaseOptimizer]:
+        if name not in cls._map:
+            raise ValueError(f"unknown optimizer name: {name}")
+        return cls._map[name]
+
+    _map: ClassVar[dict[str, type[BaseOptimizer]]] = {
+        "random": RandomOptimizer,
+        "random-forest-explore": RandomForestOptimizer_Explore,
+        "random-forest-default": RandomForestOptimizer_Default,
+        "random-forest-aggressive": RandomForestOptimizer_Aggressive,
+        "random-forest-custom": RandomForestOptimizer_Custom,
+    }


### PR DESCRIPTION
# Motivation

The goal is to improve peak performance of loop-explore results by learning from sample results instead of pure random sampling.

# Description

This adds an iterative search to loop-explore that executes batches of samples sequentially instead of all at once, in order to support optimizers that learn from executing sample batches. I added a random forest optimizer in the utils directory that observes batches of samples and suggests samples for the next batch.
This adds an "iterative" option for the search in loop-explore, along with optional args:
`--batch` to set the batch size of the iterative evaluation.
`--optimizer` for selecting a preset optimizer config, or to use a custom config
`--optimizer-config` to provide a yaml config file to set the random forest model parameters.
`--debug-optimizer` to see model specifics for each batch

# Discussion

There isn't a way to dump preset optimizer configurations into a yaml file. I'm not sure if this is good practice or not and didn't want to add more args to loop-explore so I didn't include it its also easy to just write a yaml file.
It seems like squash merging isnt enabled for this repo, but I can also squash them manually.

# TODO
- [x] squash commits
