### PR TITLE
readme,host_tools: some documentation and fixes for MacOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,12 @@ sudo dnf install libpfm-devel
 sudo sysctl kernel.perf_event_paranoid=1
 ```
 
+MacOS:
+```bash
+brew install libomp
+export DYLD_LIBRARY_PATH="/opt/homebrew/opt/libomp/lib:$DYLD_LIBRARY_PATH"
+```
+
 ### Installation
 
 **Python**: 3.10 to 3.14 inclusive
@@ -50,9 +56,13 @@ sudo sysctl kernel.perf_event_paranoid=1
 ```bash
 python3 -m venv .venv && source .venv/bin/activate
 pip3 install -e '.[dev]'
-pip3 install -r mlir_requirements.txt  # Optional: MLIR backend
-pip3 install -r tvm_requirements.txt   # Optional: TVM backend
-make test                              # Run minimal unit tests
+# Linux
+pip3 install -r mlir_requirements.txt        # Optional: MLIR backend
+pip3 install -r tvm_requirements.txt         # Optional: TVM backend
+# MacOS 
+pip3 install -r macos_mlir_requirements.txt  # Optional: MLIR backend
+pip3 install -r macos_tvm_requirements.txt   # Optional: TVM backend
+make test                                    # Run minimal unit tests
 ```
 
 ### Code quality

--- a/macos_mlir_requirements.txt
+++ b/macos_mlir_requirements.txt
@@ -1,0 +1,3 @@
+--index-url https://gitlab.inria.fr/api/v4/groups/corse/-/packages/pypi/simple
+mlir-python-bindings==19.1.7.2025011204+cd708029
+mlir==19.1.7.2025011204+cd708029

--- a/macos_tvm_requirements.txt
+++ b/macos_tvm_requirements.txt
@@ -1,0 +1,2 @@
+--index-url https://gitlab.inria.fr/api/v4/groups/corse/-/packages/pypi/simple
+tvm==0.19.0.2025010903+c4dc0c29

--- a/src/xtc/utils/host_tools.py
+++ b/src/xtc/utils/host_tools.py
@@ -5,6 +5,7 @@
 from pathlib import Path
 import subprocess
 import shlex
+import platform
 
 
 def target_arch(arch: str = "") -> str:
@@ -73,9 +74,12 @@ def disassemble(
         "--no-addresses",
         "--no-show-raw-insn",
     ]
-    jumps_opts = [
-        "--visualize-jumps",
-    ]
+    if platform.system() == "Darwin":
+        jumps_opts = []
+        disass_symbol_opt = ["--disassemble-symbols=ltmp0"]
+    else:
+        jumps_opts = []
+        disass_symbol_opt = [f"--disassemble={function}"]
     color_opts = [
         "--disassembler-color=on",
     ]
@@ -83,7 +87,7 @@ def disassemble(
     obj_path = Path(obj_path)
     args = [
         *base_opts,
-        *([f"--disassemble={function}"] if function else ["--disassemble"]),
+        *(disass_symbol_opt if function else ["--disassemble"]),
         *(jumps_opts if visualize_jumps else []),
         *(color_opts if color else []),
         str(obj_path),


### PR DESCRIPTION
# Motivation

Some changes/fixes necessary for running the marimo tutorial (PR: https://github.com/xtc-tools/xtc/pull/18) on MacOS.

# Description

Example of how the tutorial can be run on MacOS with said changes 
```bash
export DYLD_LIBRARY_PATH="/opt/homebrew/opt/libomp/lib:$DYLD_LIBRARY_PATH"
sudo -HE env PATH=$PATH PYTHONPATH=$PYTHONPATH DYLD_LIBRARY_PATH=$DYLD_LIBRARY_PATH marimo run docs/tutorials/cgo/xtc_101.py
```

# Commits

# Discussion


