### PR TITLE
runtime: remove dependency on mlir libs

### DIFF
--- a/src/xtc/runtimes/host/runtime.py
+++ b/src/xtc/runtimes/host/runtime.py
@@ -183,16 +183,16 @@ def _compile_runtime(out_dll: str, tdir: str, runtime_type: RuntimeType):
         assert p.returncode == 0, f"unable to compile runtime: {cmd}"
 
     # Link runtime
-    mlir_lib_dir = get_mlir_prefix() / "lib"
     if has_gpu:
+        mlir_lib_dir = get_mlir_prefix() / "lib"
         cuda_install_dir = get_cuda_prefix() / "lib64"
-        cuda_libs = f"-L{cuda_install_dir} -lgpu_runtime_extension -lmlir_cuda_runtime -lcupti -lcuda -lcudart"
+        cuda_libs = f"-L{mlir_lib_dir} -L{cuda_install_dir} -lgpu_runtime_extension -lmlir_cuda_runtime -lcupti -lcuda -lcudart"
     else:
         cuda_libs = ""
     cmd = (
         "c++ --shared -O2 -march=native -fPIC "
         f"-o {out_dll} {' '.join(obj_files)} "
-        f"-L{tdir} -L{mlir_lib_dir} "
+        f"-L{tdir} "
         f"{pfm_libs} "
         f"{cuda_libs} "
     )


### PR DESCRIPTION
# Motivation

Minor change in CPU runtime to remove dependency on MLIR libs which were introduced by the addition of the GPU runtime support.

Actually the base CPU runtime does not depend on mlir/tvm libraries for instance ndarrays/estimate_flops etc...

The effect was that without installing mlir dependencies, it was not possible anymore to import xtc runtime as the runtime is built on the fly.

For instance, this did not work from a fresh venv (with no mlir dependency):

    pip install .
    python -c 'import xtc.runtimes.host.runtime as rt; print(rt.evaluate_flops("float32"))'

# Description

Just fix the way the runtime is built in order to avoid link with mlir library when not necessary.

# Commits

Ref  to PR diff

