### PR TITLE
doc: add github pages

### DIFF
--- a/.github/workflows/xtc-pages.yml
+++ b/.github/workflows/xtc-pages.yml
@@ -1,0 +1,54 @@
+name: XTC Deploy Pages
+
+# Runs on pushes targeting the pages branch and manual Actions tab
+on:
+  push:
+    branches: ["pages"]
+  workflow_dispatch:
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  # Single deploy job since we're just deploying
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: 3.12
+          cache: pip
+      - name: Display Python version
+        run: |
+          python -c "import sys; print(sys.version)"
+          pip list
+      - name: Install XTC Package in dev mode
+        run: |
+          pip install -e .[dev]
+      - name: Build Pages
+        # for github pages only: uses: actions/configure-pages@v5
+        run: |
+          cd docs/site
+          mkdocs build --clean --strict --site-dir ../../public
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: 'public'
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/xtc-tests.yml
+++ b/.github/workflows/xtc-tests.yml
@@ -1,5 +1,12 @@
-name: XTC Tests
-on: [push, pull_request]
+name: XTC Build and Tests
+
+# Runs on pushes targeting the main branch, pull request and manual Actions tab
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+  workflow_dispatch:
+
 jobs:
   build:
     runs-on: ${{ matrix.os }}

--- a/README.md
+++ b/README.md
@@ -4,9 +4,7 @@
 
 ## Links
 
-Refer to documentation at https://corse.gitlabpages.inria.fr/XTC
-
-Refer to installable python packages at: https://gitlab.inria.fr/corse/xtc/-/packages
+Refer to documentation at https://xtc-tools.github.io/xtc
 
 Refer to tutorials [here](docs/tutorials) and to additionnal developers documentation [here](docs/develop).
 

--- a/docs/site/mkdocs.yml
+++ b/docs/site/mkdocs.yml
@@ -1,5 +1,5 @@
 site_name: XTC
-site_url: https://corse.gitlabpages.inria.fr/XTC/
+site_url: https://xtc-tools.github.io/xtc/
 
 nav:
 - "Home": index.md


### PR DESCRIPTION
# Motivation

Add generation of github pages from the `pages` branch.

When pushing to the `pages` branch for instance the last xtc main version or a tag, the site on https://xtc-tools.github.io/xtc is updated with the documentation.

# Description

This runs the mkdocs script to generate the sites pages on push to pages and publish the github site.

# Discussion

**NOTE**: currently there is no way to actually test in advance from github in a PR the resulting site. Hence:
- one as to generate the doc locally and open the browser on `public\index.html`
- then only an admin of XTC can once the PR is merged, and if doc needs update, push to `pages` branch directly the corresponding `main` reference.
