### PR TITLE
ci: add macos-15 build and tests

### DIFF
--- a/.github/workflows/xtc-tests.yml
+++ b/.github/workflows/xtc-tests.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest]
+        os: [ubuntu-latest, macos-15]
         python-version: ["3.12"]
     steps:
       - name: Checkout XTC Repository
@@ -28,9 +28,15 @@ jobs:
             exit 1
           fi
       - name: Install Distro Packages
+        if: runner.os == 'Linux'
         # Note: package cache with awalsh128/cache-apt-pkgs-action does not work correctly, use standard install.
         run: |
           sudo apt install -y build-essential libomp5 binutils-aarch64-linux-gnu binutils-x86-64-linux-gnu libpfm4-dev
+      - name: Install macOS Brew Packages
+        if: runner.os == 'macOs'
+        run: |
+          brew install libomp
+          export DYLD_LIBRARY_PATH="/opt/homebrew/opt/libomp/lib:$DYLD_LIBRARY_PATH"
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
         with:
@@ -44,14 +50,30 @@ jobs:
         run: |
           pip install -e .[dev]
       - name: Install TVM dependencies
+        if: runner.os == 'Linux'
         run: |
           pip install -r tvm_requirements.txt
       - name: Install MLIR dependencies
+        if: runner.os == 'Linux'
         run: |
           pip install -r mlir_requirements.txt
+      - name: Install macOS TVM dependencies
+        if: runner.os == 'macOS'
+        run: |
+          pip install -r macos_tvm_requirements.txt
+      - name: Install macOS MLIR dependencies
+        if: runner.os == 'macOS'
+        run: |
+          pip install -r macos_mlir_requirements.txt
       - name: List Python Packages
         run: |
           pip list
       - name: Run Checks
+        if: runner.os == 'Linux'
         run: |
           make check
+      - name: Run Basic macOS Tests
+        # make check if not passing as of now
+        if: runner.os == 'macOS'
+        run: |
+          make test


### PR DESCRIPTION
# Motivation

Add first builds and tests for macos in github actions.

# Description

Add installation and run test for macos-15

# Discussion

For now limitations are:
- support only macos-15 due to wheels being only available on this version
- make test is passing, make check must be debugged.

Though it is not the scope of this PR, we will handle these two issues later.
