### PR TITLE
requirements: updated xdsl to version 0.57.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.2.dev1"
 license = { text = "BSD 3 Clause" }
 authors = [{ name = "Hugo Pompougnac", email = "hugo.pompougnac@inria.fr" }]
 classifiers = ["Programming Language :: Python :: 3"]
-dependencies = ['jinja2', 'matplotlib', 'numpy', 'ordered-set', 'py-cpuinfo', 'tqdm', 'typing_extensions', 'pyyaml','scikit-learn','lit','filecheck','xdsl~=0.54.0']
+dependencies = ['jinja2', 'matplotlib', 'numpy', 'ordered-set', 'py-cpuinfo', 'tqdm', 'typing_extensions', 'pyyaml','scikit-learn','lit','filecheck','xdsl~=0.57.1']
 requires-python = ">=3.10"
 
 [project.optional-dependencies]

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,6 @@ ordered-set
 py-cpuinfo
 tqdm
 typing_extensions
-xdsl~=0.50.0
+xdsl~=0.57.1
 pyyaml
 scikit-learn


### PR DESCRIPTION
### Motivation
I need `tensor.pad` for producer fusion in the mlir backend, for use in the [tensor support PR](https://github.com/xtc-tools/xtc/pull/45).

