### PR TITLE
[Mlir] Skip default schedule for linalg.fill

### DIFF
--- a/src/xtc/backends/mlir/MlirCompilerPasses.py
+++ b/src/xtc/backends/mlir/MlirCompilerPasses.py
@@ -189,6 +189,9 @@ class MlirProgramInsertTransformPass:
         assert self._named_sequence is not None
         handle = None
         for schedule in self._nodes_schedules:
+            # Skip linalg.fill
+            if schedule.node_name[-1] == "0":  # identify with naming convention
+                continue
             self._create_sdist_meshes(schedule)
             handle = structured_match(
                 results_=transform.AnyOpType.get(),

--- a/src/xtc/backends/mlir/MlirCompilerPasses.py
+++ b/src/xtc/backends/mlir/MlirCompilerPasses.py
@@ -219,6 +219,9 @@ class MlirProgramInsertTransformPass:
         for schedule in self._nodes_schedules:
             if schedule.node_ident in unscheduled_handles:
                 continue
+            # Skip linalg.fill
+            if schedule.node_name[-1] == "0":  # identify with naming convention
+                continue
             self._create_sdist_meshes(schedule)
             handle = structured_match(
                 results_=transform.AnyOpType.get(),

--- a/tests/filecheck/backends/padding/test_gen_pad_dict_conv2d_mlir.py
+++ b/tests/filecheck/backends/padding/test_gen_pad_dict_conv2d_mlir.py
@@ -58,7 +58,7 @@ print(f"CODE: {res}")
 # CHECK-NEXT:      transform.yield 
 # CHECK-NEXT:    }
 # CHECK-NEXT:    transform.named_sequence @__transform_main(%arg0: !transform.any_op {transform.readonly}) {
-# CHECK-NEXT:      %0 = transform.structured.match attributes {__xtc_id_pad_0_} in %arg0 : (!transform.any_op) -> !transform.any_op
+# CHECK-NEXT:      %0 = transform.structured.match attributes {__xtc_id_pad_} in %arg0 : (!transform.any_op) -> !transform.any_op
 # CHECK-NEXT:      %tiled_linalg_op, %loops = transform.structured.tile_using_for %0 tile_sizes [1, 0, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
 # CHECK-NEXT:      transform.annotate %loops "./i" : !transform.any_op
 # CHECK-NEXT:      %tiled_linalg_op_0, %loops_1 = transform.structured.tile_using_for %tiled_linalg_op tile_sizes [0, 1, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
@@ -67,39 +67,21 @@ print(f"CODE: {res}")
 # CHECK-NEXT:      transform.annotate %loops_3 "./k" : !transform.any_op
 # CHECK-NEXT:      %tiled_linalg_op_4, %loops_5 = transform.structured.tile_using_for %tiled_linalg_op_2 tile_sizes [0, 0, 0, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
 # CHECK-NEXT:      transform.annotate %loops_5 "./l" : !transform.any_op
-# CHECK-NEXT:      %1 = transform.structured.match attributes {__xtc_id_pad_} in %arg0 : (!transform.any_op) -> !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_6, %loops_7 = transform.structured.tile_using_for %1 tile_sizes [1, 0, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_7 "./i" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_8, %loops_9 = transform.structured.tile_using_for %tiled_linalg_op_6 tile_sizes [0, 1, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_9 "./j" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_10, %loops_11 = transform.structured.tile_using_for %tiled_linalg_op_8 tile_sizes [0, 0, 1, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_11 "./k" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_12, %loops_13 = transform.structured.tile_using_for %tiled_linalg_op_10 tile_sizes [0, 0, 0, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_13 "./l" : !transform.any_op
-# CHECK-NEXT:      %2 = transform.structured.match attributes {__xtc_id_conv_0_} in %arg0 : (!transform.any_op) -> !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_14, %loops_15 = transform.structured.tile_using_for %2 tile_sizes [1, 0, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_15 "./b" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_16, %loops_17 = transform.structured.tile_using_for %tiled_linalg_op_14 tile_sizes [0, 1, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_17 "./h" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_18, %loops_19 = transform.structured.tile_using_for %tiled_linalg_op_16 tile_sizes [0, 0, 1, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_19 "./w" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_20, %loops_21 = transform.structured.tile_using_for %tiled_linalg_op_18 tile_sizes [0, 0, 0, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_21 "./f" : !transform.any_op
-# CHECK-NEXT:      %3 = transform.structured.match attributes {__xtc_id_conv_} in %arg0 : (!transform.any_op) -> !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_22, %loops_23 = transform.structured.tile_using_for %3 tile_sizes [1, 0, 0, 0, 0, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_23 "./b" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_24, %loops_25 = transform.structured.tile_using_for %tiled_linalg_op_22 tile_sizes [0, 1, 0, 0, 0, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_25 "./h" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_26, %loops_27 = transform.structured.tile_using_for %tiled_linalg_op_24 tile_sizes [0, 0, 1, 0, 0, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_27 "./w" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_28, %loops_29 = transform.structured.tile_using_for %tiled_linalg_op_26 tile_sizes [0, 0, 0, 1, 0, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_29 "./f" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_30, %loops_31 = transform.structured.tile_using_for %tiled_linalg_op_28 tile_sizes [0, 0, 0, 0, 1, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_31 "./r" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_32, %loops_33 = transform.structured.tile_using_for %tiled_linalg_op_30 tile_sizes [0, 0, 0, 0, 0, 1, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_33 "./s" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_34, %loops_35 = transform.structured.tile_using_for %tiled_linalg_op_32 tile_sizes [0, 0, 0, 0, 0, 0, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_35 "./c" : !transform.any_op
+# CHECK-NEXT:      %1 = transform.structured.match attributes {__xtc_id_conv_} in %arg0 : (!transform.any_op) -> !transform.any_op
+# CHECK-NEXT:      %tiled_linalg_op_6, %loops_7 = transform.structured.tile_using_for %1 tile_sizes [1, 0, 0, 0, 0, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      transform.annotate %loops_7 "./b" : !transform.any_op
+# CHECK-NEXT:      %tiled_linalg_op_8, %loops_9 = transform.structured.tile_using_for %tiled_linalg_op_6 tile_sizes [0, 1, 0, 0, 0, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      transform.annotate %loops_9 "./h" : !transform.any_op
+# CHECK-NEXT:      %tiled_linalg_op_10, %loops_11 = transform.structured.tile_using_for %tiled_linalg_op_8 tile_sizes [0, 0, 1, 0, 0, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      transform.annotate %loops_11 "./w" : !transform.any_op
+# CHECK-NEXT:      %tiled_linalg_op_12, %loops_13 = transform.structured.tile_using_for %tiled_linalg_op_10 tile_sizes [0, 0, 0, 1, 0, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      transform.annotate %loops_13 "./f" : !transform.any_op
+# CHECK-NEXT:      %tiled_linalg_op_14, %loops_15 = transform.structured.tile_using_for %tiled_linalg_op_12 tile_sizes [0, 0, 0, 0, 1, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      transform.annotate %loops_15 "./r" : !transform.any_op
+# CHECK-NEXT:      %tiled_linalg_op_16, %loops_17 = transform.structured.tile_using_for %tiled_linalg_op_14 tile_sizes [0, 0, 0, 0, 0, 1, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      transform.annotate %loops_17 "./s" : !transform.any_op
+# CHECK-NEXT:      %tiled_linalg_op_18, %loops_19 = transform.structured.tile_using_for %tiled_linalg_op_16 tile_sizes [0, 0, 0, 0, 0, 0, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      transform.annotate %loops_19 "./c" : !transform.any_op
 # CHECK-NEXT:      transform.yield 
 # CHECK-NEXT:    }
 # CHECK-NEXT:  }
@@ -113,141 +95,93 @@ print(f"CODE: {res}")
 # CHECK-NEXT:    func.func @pad_conv2d_nhwc_mini(%arg0: memref<1x8x8x3xf32> {llvm.noalias}, %arg1: memref<5x5x3x16xf32> {llvm.noalias}, %arg2: memref<1x4x4x16xf32> {llvm.noalias}) {
 # CHECK-NEXT:      %alloca = memref.alloca() {alignment = 256 : i64} : memref<1x12x12x3xf32>
 # CHECK-NEXT:      %cst = arith.constant 0.000000e+00 : f32
+# CHECK-NEXT:      linalg.fill {__xtc_id_pad_0_} ins(%cst : f32) outs(%alloca : memref<1x12x12x3xf32>)
+# CHECK-NEXT:      %subview = memref.subview %alloca[0, 2, 2, 0] [1, 8, 8, 3] [1, 1, 1, 1] : memref<1x12x12x3xf32> to memref<1x8x8x3xf32, strided<[432, 36, 3, 1], offset: 78>>
 # CHECK-NEXT:      %c0 = arith.constant 0 : index
 # CHECK-NEXT:      %c1 = arith.constant 1 : index
 # CHECK-NEXT:      %c1_0 = arith.constant 1 : index
 # CHECK-NEXT:      scf.for %arg3 = %c0 to %c1 step %c1_0 {
-# CHECK-NEXT:        %subview_11 = memref.subview %alloca[%arg3, 0, 0, 0] [1, 12, 12, 3] [1, 1, 1, 1] : memref<1x12x12x3xf32> to memref<1x12x12x3xf32, strided<[432, 36, 3, 1], offset: ?>>
-# CHECK-NEXT:        %c0_12 = arith.constant 0 : index
-# CHECK-NEXT:        %c12 = arith.constant 12 : index
-# CHECK-NEXT:        %c1_13 = arith.constant 1 : index
-# CHECK-NEXT:        scf.for %arg4 = %c0_12 to %c12 step %c1_13 {
-# CHECK-NEXT:          %subview_14 = memref.subview %subview_11[0, %arg4, 0, 0] [1, 1, 12, 3] [1, 1, 1, 1] : memref<1x12x12x3xf32, strided<[432, 36, 3, 1], offset: ?>> to memref<1x1x12x3xf32, strided<[432, 36, 3, 1], offset: ?>>
-# CHECK-NEXT:          %c0_15 = arith.constant 0 : index
-# CHECK-NEXT:          %c12_16 = arith.constant 12 : index
-# CHECK-NEXT:          %c1_17 = arith.constant 1 : index
-# CHECK-NEXT:          scf.for %arg5 = %c0_15 to %c12_16 step %c1_17 {
-# CHECK-NEXT:            %subview_18 = memref.subview %subview_14[0, 0, %arg5, 0] [1, 1, 1, 3] [1, 1, 1, 1] : memref<1x1x12x3xf32, strided<[432, 36, 3, 1], offset: ?>> to memref<1x1x1x3xf32, strided<[432, 36, 3, 1], offset: ?>>
-# CHECK-NEXT:            %c0_19 = arith.constant 0 : index
-# CHECK-NEXT:            %c3 = arith.constant 3 : index
-# CHECK-NEXT:            %c1_20 = arith.constant 1 : index
-# CHECK-NEXT:            scf.for %arg6 = %c0_19 to %c3 step %c1_20 {
-# CHECK-NEXT:              %subview_21 = memref.subview %subview_18[0, 0, 0, %arg6] [1, 1, 1, 1] [1, 1, 1, 1] : memref<1x1x1x3xf32, strided<[432, 36, 3, 1], offset: ?>> to memref<1x1x1x1xf32, strided<[432, 36, 3, 1], offset: ?>>
-# CHECK-NEXT:              linalg.fill {__xtc_id_pad_0_} ins(%cst : f32) outs(%subview_21 : memref<1x1x1x1xf32, strided<[432, 36, 3, 1], offset: ?>>)
-# CHECK-NEXT:            } {"./l"}
-# CHECK-NEXT:          } {"./k"}
-# CHECK-NEXT:        } {"./j"}
-# CHECK-NEXT:      } {"./i"}
-# CHECK-NEXT:      %subview = memref.subview %alloca[0, 2, 2, 0] [1, 8, 8, 3] [1, 1, 1, 1] : memref<1x12x12x3xf32> to memref<1x8x8x3xf32, strided<[432, 36, 3, 1], offset: 78>>
-# CHECK-NEXT:      %c0_1 = arith.constant 0 : index
-# CHECK-NEXT:      %c1_2 = arith.constant 1 : index
-# CHECK-NEXT:      %c1_3 = arith.constant 1 : index
-# CHECK-NEXT:      scf.for %arg3 = %c0_1 to %c1_2 step %c1_3 {
-# CHECK-NEXT:        %subview_11 = memref.subview %arg0[%arg3, 0, 0, 0] [1, 8, 8, 3] [1, 1, 1, 1] : memref<1x8x8x3xf32> to memref<1x8x8x3xf32, strided<[192, 24, 3, 1], offset: ?>>
-# CHECK-NEXT:        %subview_12 = memref.subview %subview[%arg3, 0, 0, 0] [1, 8, 8, 3] [1, 1, 1, 1] : memref<1x8x8x3xf32, strided<[432, 36, 3, 1], offset: 78>> to memref<1x8x8x3xf32, strided<[432, 36, 3, 1], offset: ?>>
-# CHECK-NEXT:        %c0_13 = arith.constant 0 : index
+# CHECK-NEXT:        %subview_5 = memref.subview %arg0[%arg3, 0, 0, 0] [1, 8, 8, 3] [1, 1, 1, 1] : memref<1x8x8x3xf32> to memref<1x8x8x3xf32, strided<[192, 24, 3, 1], offset: ?>>
+# CHECK-NEXT:        %subview_6 = memref.subview %subview[%arg3, 0, 0, 0] [1, 8, 8, 3] [1, 1, 1, 1] : memref<1x8x8x3xf32, strided<[432, 36, 3, 1], offset: 78>> to memref<1x8x8x3xf32, strided<[432, 36, 3, 1], offset: ?>>
+# CHECK-NEXT:        %c0_7 = arith.constant 0 : index
 # CHECK-NEXT:        %c8 = arith.constant 8 : index
-# CHECK-NEXT:        %c1_14 = arith.constant 1 : index
-# CHECK-NEXT:        scf.for %arg4 = %c0_13 to %c8 step %c1_14 {
-# CHECK-NEXT:          %subview_15 = memref.subview %subview_11[0, %arg4, 0, 0] [1, 1, 8, 3] [1, 1, 1, 1] : memref<1x8x8x3xf32, strided<[192, 24, 3, 1], offset: ?>> to memref<1x1x8x3xf32, strided<[192, 24, 3, 1], offset: ?>>
-# CHECK-NEXT:          %subview_16 = memref.subview %subview_12[0, %arg4, 0, 0] [1, 1, 8, 3] [1, 1, 1, 1] : memref<1x8x8x3xf32, strided<[432, 36, 3, 1], offset: ?>> to memref<1x1x8x3xf32, strided<[432, 36, 3, 1], offset: ?>>
-# CHECK-NEXT:          %c0_17 = arith.constant 0 : index
-# CHECK-NEXT:          %c8_18 = arith.constant 8 : index
-# CHECK-NEXT:          %c1_19 = arith.constant 1 : index
-# CHECK-NEXT:          scf.for %arg5 = %c0_17 to %c8_18 step %c1_19 {
-# CHECK-NEXT:            %subview_20 = memref.subview %subview_15[0, 0, %arg5, 0] [1, 1, 1, 3] [1, 1, 1, 1] : memref<1x1x8x3xf32, strided<[192, 24, 3, 1], offset: ?>> to memref<1x1x1x3xf32, strided<[192, 24, 3, 1], offset: ?>>
-# CHECK-NEXT:            %subview_21 = memref.subview %subview_16[0, 0, %arg5, 0] [1, 1, 1, 3] [1, 1, 1, 1] : memref<1x1x8x3xf32, strided<[432, 36, 3, 1], offset: ?>> to memref<1x1x1x3xf32, strided<[432, 36, 3, 1], offset: ?>>
-# CHECK-NEXT:            %c0_22 = arith.constant 0 : index
+# CHECK-NEXT:        %c1_8 = arith.constant 1 : index
+# CHECK-NEXT:        scf.for %arg4 = %c0_7 to %c8 step %c1_8 {
+# CHECK-NEXT:          %subview_9 = memref.subview %subview_5[0, %arg4, 0, 0] [1, 1, 8, 3] [1, 1, 1, 1] : memref<1x8x8x3xf32, strided<[192, 24, 3, 1], offset: ?>> to memref<1x1x8x3xf32, strided<[192, 24, 3, 1], offset: ?>>
+# CHECK-NEXT:          %subview_10 = memref.subview %subview_6[0, %arg4, 0, 0] [1, 1, 8, 3] [1, 1, 1, 1] : memref<1x8x8x3xf32, strided<[432, 36, 3, 1], offset: ?>> to memref<1x1x8x3xf32, strided<[432, 36, 3, 1], offset: ?>>
+# CHECK-NEXT:          %c0_11 = arith.constant 0 : index
+# CHECK-NEXT:          %c8_12 = arith.constant 8 : index
+# CHECK-NEXT:          %c1_13 = arith.constant 1 : index
+# CHECK-NEXT:          scf.for %arg5 = %c0_11 to %c8_12 step %c1_13 {
+# CHECK-NEXT:            %subview_14 = memref.subview %subview_9[0, 0, %arg5, 0] [1, 1, 1, 3] [1, 1, 1, 1] : memref<1x1x8x3xf32, strided<[192, 24, 3, 1], offset: ?>> to memref<1x1x1x3xf32, strided<[192, 24, 3, 1], offset: ?>>
+# CHECK-NEXT:            %subview_15 = memref.subview %subview_10[0, 0, %arg5, 0] [1, 1, 1, 3] [1, 1, 1, 1] : memref<1x1x8x3xf32, strided<[432, 36, 3, 1], offset: ?>> to memref<1x1x1x3xf32, strided<[432, 36, 3, 1], offset: ?>>
+# CHECK-NEXT:            %c0_16 = arith.constant 0 : index
 # CHECK-NEXT:            %c3 = arith.constant 3 : index
-# CHECK-NEXT:            %c1_23 = arith.constant 1 : index
-# CHECK-NEXT:            scf.for %arg6 = %c0_22 to %c3 step %c1_23 {
-# CHECK-NEXT:              %subview_24 = memref.subview %subview_20[0, 0, 0, %arg6] [1, 1, 1, 1] [1, 1, 1, 1] : memref<1x1x1x3xf32, strided<[192, 24, 3, 1], offset: ?>> to memref<1x1x1x1xf32, strided<[192, 24, 3, 1], offset: ?>>
-# CHECK-NEXT:              %subview_25 = memref.subview %subview_21[0, 0, 0, %arg6] [1, 1, 1, 1] [1, 1, 1, 1] : memref<1x1x1x3xf32, strided<[432, 36, 3, 1], offset: ?>> to memref<1x1x1x1xf32, strided<[432, 36, 3, 1], offset: ?>>
-# CHECK-NEXT:              linalg.copy {__xtc_id_pad_} ins(%subview_24 : memref<1x1x1x1xf32, strided<[192, 24, 3, 1], offset: ?>>) outs(%subview_25 : memref<1x1x1x1xf32, strided<[432, 36, 3, 1], offset: ?>>)
+# CHECK-NEXT:            %c1_17 = arith.constant 1 : index
+# CHECK-NEXT:            scf.for %arg6 = %c0_16 to %c3 step %c1_17 {
+# CHECK-NEXT:              %subview_18 = memref.subview %subview_14[0, 0, 0, %arg6] [1, 1, 1, 1] [1, 1, 1, 1] : memref<1x1x1x3xf32, strided<[192, 24, 3, 1], offset: ?>> to memref<1x1x1x1xf32, strided<[192, 24, 3, 1], offset: ?>>
+# CHECK-NEXT:              %subview_19 = memref.subview %subview_15[0, 0, 0, %arg6] [1, 1, 1, 1] [1, 1, 1, 1] : memref<1x1x1x3xf32, strided<[432, 36, 3, 1], offset: ?>> to memref<1x1x1x1xf32, strided<[432, 36, 3, 1], offset: ?>>
+# CHECK-NEXT:              linalg.copy {__xtc_id_pad_} ins(%subview_18 : memref<1x1x1x1xf32, strided<[192, 24, 3, 1], offset: ?>>) outs(%subview_19 : memref<1x1x1x1xf32, strided<[432, 36, 3, 1], offset: ?>>)
 # CHECK-NEXT:            } {"./l"}
 # CHECK-NEXT:          } {"./k"}
 # CHECK-NEXT:        } {"./j"}
 # CHECK-NEXT:      } {"./i"}
-# CHECK-NEXT:      %cst_4 = arith.constant 0.000000e+00 : f32
-# CHECK-NEXT:      %c0_5 = arith.constant 0 : index
-# CHECK-NEXT:      %c1_6 = arith.constant 1 : index
-# CHECK-NEXT:      %c1_7 = arith.constant 1 : index
-# CHECK-NEXT:      scf.for %arg3 = %c0_5 to %c1_6 step %c1_7 {
-# CHECK-NEXT:        %subview_11 = memref.subview %arg2[%arg3, 0, 0, 0] [1, 4, 4, 16] [1, 1, 1, 1] : memref<1x4x4x16xf32> to memref<1x4x4x16xf32, strided<[256, 64, 16, 1], offset: ?>>
-# CHECK-NEXT:        %c0_12 = arith.constant 0 : index
+# CHECK-NEXT:      %cst_1 = arith.constant 0.000000e+00 : f32
+# CHECK-NEXT:      linalg.fill {__xtc_id_conv_0_} ins(%cst_1 : f32) outs(%arg2 : memref<1x4x4x16xf32>)
+# CHECK-NEXT:      %c0_2 = arith.constant 0 : index
+# CHECK-NEXT:      %c1_3 = arith.constant 1 : index
+# CHECK-NEXT:      %c1_4 = arith.constant 1 : index
+# CHECK-NEXT:      scf.for %arg3 = %c0_2 to %c1_3 step %c1_4 {
+# CHECK-NEXT:        %subview_5 = memref.subview %alloca[%arg3, 0, 0, 0] [1, 11, 11, 3] [1, 1, 1, 1] : memref<1x12x12x3xf32> to memref<1x11x11x3xf32, strided<[432, 36, 3, 1], offset: ?>>
+# CHECK-NEXT:        %subview_6 = memref.subview %arg1[0, 0, 0, 0] [5, 5, 3, 16] [1, 1, 1, 1] : memref<5x5x3x16xf32> to memref<5x5x3x16xf32, strided<[240, 48, 16, 1]>>
+# CHECK-NEXT:        %subview_7 = memref.subview %arg2[%arg3, 0, 0, 0] [1, 4, 4, 16] [1, 1, 1, 1] : memref<1x4x4x16xf32> to memref<1x4x4x16xf32, strided<[256, 64, 16, 1], offset: ?>>
+# CHECK-NEXT:        %c0_8 = arith.constant 0 : index
 # CHECK-NEXT:        %c4 = arith.constant 4 : index
-# CHECK-NEXT:        %c1_13 = arith.constant 1 : index
-# CHECK-NEXT:        scf.for %arg4 = %c0_12 to %c4 step %c1_13 {
-# CHECK-NEXT:          %subview_14 = memref.subview %subview_11[0, %arg4, 0, 0] [1, 1, 4, 16] [1, 1, 1, 1] : memref<1x4x4x16xf32, strided<[256, 64, 16, 1], offset: ?>> to memref<1x1x4x16xf32, strided<[256, 64, 16, 1], offset: ?>>
-# CHECK-NEXT:          %c0_15 = arith.constant 0 : index
-# CHECK-NEXT:          %c4_16 = arith.constant 4 : index
-# CHECK-NEXT:          %c1_17 = arith.constant 1 : index
-# CHECK-NEXT:          scf.for %arg5 = %c0_15 to %c4_16 step %c1_17 {
-# CHECK-NEXT:            %subview_18 = memref.subview %subview_14[0, 0, %arg5, 0] [1, 1, 1, 16] [1, 1, 1, 1] : memref<1x1x4x16xf32, strided<[256, 64, 16, 1], offset: ?>> to memref<1x1x1x16xf32, strided<[256, 64, 16, 1], offset: ?>>
+# CHECK-NEXT:        %c1_9 = arith.constant 1 : index
+# CHECK-NEXT:        scf.for %arg4 = %c0_8 to %c4 step %c1_9 {
+# CHECK-NEXT:          %0 = affine.apply #map(%arg4)
+# CHECK-NEXT:          %subview_10 = memref.subview %subview_5[0, %0, 0, 0] [1, 5, 11, 3] [1, 1, 1, 1] : memref<1x11x11x3xf32, strided<[432, 36, 3, 1], offset: ?>> to memref<1x5x11x3xf32, strided<[432, 36, 3, 1], offset: ?>>
+# CHECK-NEXT:          %subview_11 = memref.subview %subview_6[0, 0, 0, 0] [5, 5, 3, 16] [1, 1, 1, 1] : memref<5x5x3x16xf32, strided<[240, 48, 16, 1]>> to memref<5x5x3x16xf32, strided<[240, 48, 16, 1]>>
+# CHECK-NEXT:          %subview_12 = memref.subview %subview_7[0, %arg4, 0, 0] [1, 1, 4, 16] [1, 1, 1, 1] : memref<1x4x4x16xf32, strided<[256, 64, 16, 1], offset: ?>> to memref<1x1x4x16xf32, strided<[256, 64, 16, 1], offset: ?>>
+# CHECK-NEXT:          %c0_13 = arith.constant 0 : index
+# CHECK-NEXT:          %c4_14 = arith.constant 4 : index
+# CHECK-NEXT:          %c1_15 = arith.constant 1 : index
+# CHECK-NEXT:          scf.for %arg5 = %c0_13 to %c4_14 step %c1_15 {
+# CHECK-NEXT:            %1 = affine.apply #map(%arg5)
+# CHECK-NEXT:            %subview_16 = memref.subview %subview_10[0, 0, %1, 0] [1, 5, 5, 3] [1, 1, 1, 1] : memref<1x5x11x3xf32, strided<[432, 36, 3, 1], offset: ?>> to memref<1x5x5x3xf32, strided<[432, 36, 3, 1], offset: ?>>
+# CHECK-NEXT:            %subview_17 = memref.subview %subview_11[0, 0, 0, 0] [5, 5, 3, 16] [1, 1, 1, 1] : memref<5x5x3x16xf32, strided<[240, 48, 16, 1]>> to memref<5x5x3x16xf32, strided<[240, 48, 16, 1]>>
+# CHECK-NEXT:            %subview_18 = memref.subview %subview_12[0, 0, %arg5, 0] [1, 1, 1, 16] [1, 1, 1, 1] : memref<1x1x4x16xf32, strided<[256, 64, 16, 1], offset: ?>> to memref<1x1x1x16xf32, strided<[256, 64, 16, 1], offset: ?>>
 # CHECK-NEXT:            %c0_19 = arith.constant 0 : index
 # CHECK-NEXT:            %c16 = arith.constant 16 : index
 # CHECK-NEXT:            %c1_20 = arith.constant 1 : index
 # CHECK-NEXT:            scf.for %arg6 = %c0_19 to %c16 step %c1_20 {
-# CHECK-NEXT:              %subview_21 = memref.subview %subview_18[0, 0, 0, %arg6] [1, 1, 1, 1] [1, 1, 1, 1] : memref<1x1x1x16xf32, strided<[256, 64, 16, 1], offset: ?>> to memref<1x1x1x1xf32, strided<[256, 64, 16, 1], offset: ?>>
-# CHECK-NEXT:              linalg.fill {__xtc_id_conv_0_} ins(%cst_4 : f32) outs(%subview_21 : memref<1x1x1x1xf32, strided<[256, 64, 16, 1], offset: ?>>)
-# CHECK-NEXT:            } {"./f"}
-# CHECK-NEXT:          } {"./w"}
-# CHECK-NEXT:        } {"./h"}
-# CHECK-NEXT:      } {"./b"}
-# CHECK-NEXT:      %c0_8 = arith.constant 0 : index
-# CHECK-NEXT:      %c1_9 = arith.constant 1 : index
-# CHECK-NEXT:      %c1_10 = arith.constant 1 : index
-# CHECK-NEXT:      scf.for %arg3 = %c0_8 to %c1_9 step %c1_10 {
-# CHECK-NEXT:        %subview_11 = memref.subview %alloca[%arg3, 0, 0, 0] [1, 11, 11, 3] [1, 1, 1, 1] : memref<1x12x12x3xf32> to memref<1x11x11x3xf32, strided<[432, 36, 3, 1], offset: ?>>
-# CHECK-NEXT:        %subview_12 = memref.subview %arg1[0, 0, 0, 0] [5, 5, 3, 16] [1, 1, 1, 1] : memref<5x5x3x16xf32> to memref<5x5x3x16xf32, strided<[240, 48, 16, 1]>>
-# CHECK-NEXT:        %subview_13 = memref.subview %arg2[%arg3, 0, 0, 0] [1, 4, 4, 16] [1, 1, 1, 1] : memref<1x4x4x16xf32> to memref<1x4x4x16xf32, strided<[256, 64, 16, 1], offset: ?>>
-# CHECK-NEXT:        %c0_14 = arith.constant 0 : index
-# CHECK-NEXT:        %c4 = arith.constant 4 : index
-# CHECK-NEXT:        %c1_15 = arith.constant 1 : index
-# CHECK-NEXT:        scf.for %arg4 = %c0_14 to %c4 step %c1_15 {
-# CHECK-NEXT:          %0 = affine.apply #map(%arg4)
-# CHECK-NEXT:          %subview_16 = memref.subview %subview_11[0, %0, 0, 0] [1, 5, 11, 3] [1, 1, 1, 1] : memref<1x11x11x3xf32, strided<[432, 36, 3, 1], offset: ?>> to memref<1x5x11x3xf32, strided<[432, 36, 3, 1], offset: ?>>
-# CHECK-NEXT:          %subview_17 = memref.subview %subview_12[0, 0, 0, 0] [5, 5, 3, 16] [1, 1, 1, 1] : memref<5x5x3x16xf32, strided<[240, 48, 16, 1]>> to memref<5x5x3x16xf32, strided<[240, 48, 16, 1]>>
-# CHECK-NEXT:          %subview_18 = memref.subview %subview_13[0, %arg4, 0, 0] [1, 1, 4, 16] [1, 1, 1, 1] : memref<1x4x4x16xf32, strided<[256, 64, 16, 1], offset: ?>> to memref<1x1x4x16xf32, strided<[256, 64, 16, 1], offset: ?>>
-# CHECK-NEXT:          %c0_19 = arith.constant 0 : index
-# CHECK-NEXT:          %c4_20 = arith.constant 4 : index
-# CHECK-NEXT:          %c1_21 = arith.constant 1 : index
-# CHECK-NEXT:          scf.for %arg5 = %c0_19 to %c4_20 step %c1_21 {
-# CHECK-NEXT:            %1 = affine.apply #map(%arg5)
-# CHECK-NEXT:            %subview_22 = memref.subview %subview_16[0, 0, %1, 0] [1, 5, 5, 3] [1, 1, 1, 1] : memref<1x5x11x3xf32, strided<[432, 36, 3, 1], offset: ?>> to memref<1x5x5x3xf32, strided<[432, 36, 3, 1], offset: ?>>
-# CHECK-NEXT:            %subview_23 = memref.subview %subview_17[0, 0, 0, 0] [5, 5, 3, 16] [1, 1, 1, 1] : memref<5x5x3x16xf32, strided<[240, 48, 16, 1]>> to memref<5x5x3x16xf32, strided<[240, 48, 16, 1]>>
-# CHECK-NEXT:            %subview_24 = memref.subview %subview_18[0, 0, %arg5, 0] [1, 1, 1, 16] [1, 1, 1, 1] : memref<1x1x4x16xf32, strided<[256, 64, 16, 1], offset: ?>> to memref<1x1x1x16xf32, strided<[256, 64, 16, 1], offset: ?>>
-# CHECK-NEXT:            %c0_25 = arith.constant 0 : index
-# CHECK-NEXT:            %c16 = arith.constant 16 : index
-# CHECK-NEXT:            %c1_26 = arith.constant 1 : index
-# CHECK-NEXT:            scf.for %arg6 = %c0_25 to %c16 step %c1_26 {
-# CHECK-NEXT:              %subview_27 = memref.subview %subview_22[0, 0, 0, 0] [1, 5, 5, 3] [1, 1, 1, 1] : memref<1x5x5x3xf32, strided<[432, 36, 3, 1], offset: ?>> to memref<1x5x5x3xf32, strided<[432, 36, 3, 1], offset: ?>>
-# CHECK-NEXT:              %subview_28 = memref.subview %subview_23[0, 0, 0, %arg6] [5, 5, 3, 1] [1, 1, 1, 1] : memref<5x5x3x16xf32, strided<[240, 48, 16, 1]>> to memref<5x5x3x1xf32, strided<[240, 48, 16, 1], offset: ?>>
-# CHECK-NEXT:              %subview_29 = memref.subview %subview_24[0, 0, 0, %arg6] [1, 1, 1, 1] [1, 1, 1, 1] : memref<1x1x1x16xf32, strided<[256, 64, 16, 1], offset: ?>> to memref<1x1x1x1xf32, strided<[256, 64, 16, 1], offset: ?>>
-# CHECK-NEXT:              %c0_30 = arith.constant 0 : index
+# CHECK-NEXT:              %subview_21 = memref.subview %subview_16[0, 0, 0, 0] [1, 5, 5, 3] [1, 1, 1, 1] : memref<1x5x5x3xf32, strided<[432, 36, 3, 1], offset: ?>> to memref<1x5x5x3xf32, strided<[432, 36, 3, 1], offset: ?>>
+# CHECK-NEXT:              %subview_22 = memref.subview %subview_17[0, 0, 0, %arg6] [5, 5, 3, 1] [1, 1, 1, 1] : memref<5x5x3x16xf32, strided<[240, 48, 16, 1]>> to memref<5x5x3x1xf32, strided<[240, 48, 16, 1], offset: ?>>
+# CHECK-NEXT:              %subview_23 = memref.subview %subview_18[0, 0, 0, %arg6] [1, 1, 1, 1] [1, 1, 1, 1] : memref<1x1x1x16xf32, strided<[256, 64, 16, 1], offset: ?>> to memref<1x1x1x1xf32, strided<[256, 64, 16, 1], offset: ?>>
+# CHECK-NEXT:              %c0_24 = arith.constant 0 : index
 # CHECK-NEXT:              %c5 = arith.constant 5 : index
-# CHECK-NEXT:              %c1_31 = arith.constant 1 : index
-# CHECK-NEXT:              scf.for %arg7 = %c0_30 to %c5 step %c1_31 {
-# CHECK-NEXT:                %subview_32 = memref.subview %subview_27[0, %arg7, 0, 0] [1, 1, 5, 3] [1, 1, 1, 1] : memref<1x5x5x3xf32, strided<[432, 36, 3, 1], offset: ?>> to memref<1x1x5x3xf32, strided<[432, 36, 3, 1], offset: ?>>
-# CHECK-NEXT:                %subview_33 = memref.subview %subview_28[%arg7, 0, 0, 0] [1, 5, 3, 1] [1, 1, 1, 1] : memref<5x5x3x1xf32, strided<[240, 48, 16, 1], offset: ?>> to memref<1x5x3x1xf32, strided<[240, 48, 16, 1], offset: ?>>
-# CHECK-NEXT:                %subview_34 = memref.subview %subview_29[0, 0, 0, 0] [1, 1, 1, 1] [1, 1, 1, 1] : memref<1x1x1x1xf32, strided<[256, 64, 16, 1], offset: ?>> to memref<1x1x1x1xf32, strided<[256, 64, 16, 1], offset: ?>>
-# CHECK-NEXT:                %c0_35 = arith.constant 0 : index
-# CHECK-NEXT:                %c5_36 = arith.constant 5 : index
-# CHECK-NEXT:                %c1_37 = arith.constant 1 : index
-# CHECK-NEXT:                scf.for %arg8 = %c0_35 to %c5_36 step %c1_37 {
-# CHECK-NEXT:                  %subview_38 = memref.subview %subview_32[0, 0, %arg8, 0] [1, 1, 1, 3] [1, 1, 1, 1] : memref<1x1x5x3xf32, strided<[432, 36, 3, 1], offset: ?>> to memref<1x1x1x3xf32, strided<[432, 36, 3, 1], offset: ?>>
-# CHECK-NEXT:                  %subview_39 = memref.subview %subview_33[0, %arg8, 0, 0] [1, 1, 3, 1] [1, 1, 1, 1] : memref<1x5x3x1xf32, strided<[240, 48, 16, 1], offset: ?>> to memref<1x1x3x1xf32, strided<[240, 48, 16, 1], offset: ?>>
-# CHECK-NEXT:                  %subview_40 = memref.subview %subview_34[0, 0, 0, 0] [1, 1, 1, 1] [1, 1, 1, 1] : memref<1x1x1x1xf32, strided<[256, 64, 16, 1], offset: ?>> to memref<1x1x1x1xf32, strided<[256, 64, 16, 1], offset: ?>>
-# CHECK-NEXT:                  %c0_41 = arith.constant 0 : index
+# CHECK-NEXT:              %c1_25 = arith.constant 1 : index
+# CHECK-NEXT:              scf.for %arg7 = %c0_24 to %c5 step %c1_25 {
+# CHECK-NEXT:                %subview_26 = memref.subview %subview_21[0, %arg7, 0, 0] [1, 1, 5, 3] [1, 1, 1, 1] : memref<1x5x5x3xf32, strided<[432, 36, 3, 1], offset: ?>> to memref<1x1x5x3xf32, strided<[432, 36, 3, 1], offset: ?>>
+# CHECK-NEXT:                %subview_27 = memref.subview %subview_22[%arg7, 0, 0, 0] [1, 5, 3, 1] [1, 1, 1, 1] : memref<5x5x3x1xf32, strided<[240, 48, 16, 1], offset: ?>> to memref<1x5x3x1xf32, strided<[240, 48, 16, 1], offset: ?>>
+# CHECK-NEXT:                %subview_28 = memref.subview %subview_23[0, 0, 0, 0] [1, 1, 1, 1] [1, 1, 1, 1] : memref<1x1x1x1xf32, strided<[256, 64, 16, 1], offset: ?>> to memref<1x1x1x1xf32, strided<[256, 64, 16, 1], offset: ?>>
+# CHECK-NEXT:                %c0_29 = arith.constant 0 : index
+# CHECK-NEXT:                %c5_30 = arith.constant 5 : index
+# CHECK-NEXT:                %c1_31 = arith.constant 1 : index
+# CHECK-NEXT:                scf.for %arg8 = %c0_29 to %c5_30 step %c1_31 {
+# CHECK-NEXT:                  %subview_32 = memref.subview %subview_26[0, 0, %arg8, 0] [1, 1, 1, 3] [1, 1, 1, 1] : memref<1x1x5x3xf32, strided<[432, 36, 3, 1], offset: ?>> to memref<1x1x1x3xf32, strided<[432, 36, 3, 1], offset: ?>>
+# CHECK-NEXT:                  %subview_33 = memref.subview %subview_27[0, %arg8, 0, 0] [1, 1, 3, 1] [1, 1, 1, 1] : memref<1x5x3x1xf32, strided<[240, 48, 16, 1], offset: ?>> to memref<1x1x3x1xf32, strided<[240, 48, 16, 1], offset: ?>>
+# CHECK-NEXT:                  %subview_34 = memref.subview %subview_28[0, 0, 0, 0] [1, 1, 1, 1] [1, 1, 1, 1] : memref<1x1x1x1xf32, strided<[256, 64, 16, 1], offset: ?>> to memref<1x1x1x1xf32, strided<[256, 64, 16, 1], offset: ?>>
+# CHECK-NEXT:                  %c0_35 = arith.constant 0 : index
 # CHECK-NEXT:                  %c3 = arith.constant 3 : index
-# CHECK-NEXT:                  %c1_42 = arith.constant 1 : index
-# CHECK-NEXT:                  scf.for %arg9 = %c0_41 to %c3 step %c1_42 {
-# CHECK-NEXT:                    %subview_43 = memref.subview %subview_38[0, 0, 0, %arg9] [1, 1, 1, 1] [1, 1, 1, 1] : memref<1x1x1x3xf32, strided<[432, 36, 3, 1], offset: ?>> to memref<1x1x1x1xf32, strided<[432, 36, 3, 1], offset: ?>>
-# CHECK-NEXT:                    %subview_44 = memref.subview %subview_39[0, 0, %arg9, 0] [1, 1, 1, 1] [1, 1, 1, 1] : memref<1x1x3x1xf32, strided<[240, 48, 16, 1], offset: ?>> to memref<1x1x1x1xf32, strided<[240, 48, 16, 1], offset: ?>>
-# CHECK-NEXT:                    %subview_45 = memref.subview %subview_40[0, 0, 0, 0] [1, 1, 1, 1] [1, 1, 1, 1] : memref<1x1x1x1xf32, strided<[256, 64, 16, 1], offset: ?>> to memref<1x1x1x1xf32, strided<[256, 64, 16, 1], offset: ?>>
-# CHECK-NEXT:                    linalg.generic {indexing_maps = [#map1, #map2, #map3], iterator_types = ["parallel", "parallel", "parallel", "parallel", "reduction", "reduction", "reduction"]} ins(%subview_43, %subview_44 : memref<1x1x1x1xf32, strided<[432, 36, 3, 1], offset: ?>>, memref<1x1x1x1xf32, strided<[240, 48, 16, 1], offset: ?>>) outs(%subview_45 : memref<1x1x1x1xf32, strided<[256, 64, 16, 1], offset: ?>>) attrs =  {__xtc_id_conv_} {
-# CHECK-NEXT:                    ^bb0(%in: f32, %in_46: f32, %out: f32):
-# CHECK-NEXT:                      %2 = arith.mulf %in, %in_46 : f32
+# CHECK-NEXT:                  %c1_36 = arith.constant 1 : index
+# CHECK-NEXT:                  scf.for %arg9 = %c0_35 to %c3 step %c1_36 {
+# CHECK-NEXT:                    %subview_37 = memref.subview %subview_32[0, 0, 0, %arg9] [1, 1, 1, 1] [1, 1, 1, 1] : memref<1x1x1x3xf32, strided<[432, 36, 3, 1], offset: ?>> to memref<1x1x1x1xf32, strided<[432, 36, 3, 1], offset: ?>>
+# CHECK-NEXT:                    %subview_38 = memref.subview %subview_33[0, 0, %arg9, 0] [1, 1, 1, 1] [1, 1, 1, 1] : memref<1x1x3x1xf32, strided<[240, 48, 16, 1], offset: ?>> to memref<1x1x1x1xf32, strided<[240, 48, 16, 1], offset: ?>>
+# CHECK-NEXT:                    %subview_39 = memref.subview %subview_34[0, 0, 0, 0] [1, 1, 1, 1] [1, 1, 1, 1] : memref<1x1x1x1xf32, strided<[256, 64, 16, 1], offset: ?>> to memref<1x1x1x1xf32, strided<[256, 64, 16, 1], offset: ?>>
+# CHECK-NEXT:                    linalg.generic {indexing_maps = [#map1, #map2, #map3], iterator_types = ["parallel", "parallel", "parallel", "parallel", "reduction", "reduction", "reduction"]} ins(%subview_37, %subview_38 : memref<1x1x1x1xf32, strided<[432, 36, 3, 1], offset: ?>>, memref<1x1x1x1xf32, strided<[240, 48, 16, 1], offset: ?>>) outs(%subview_39 : memref<1x1x1x1xf32, strided<[256, 64, 16, 1], offset: ?>>) attrs =  {__xtc_id_conv_} {
+# CHECK-NEXT:                    ^bb0(%in: f32, %in_40: f32, %out: f32):
+# CHECK-NEXT:                      %2 = arith.mulf %in, %in_40 : f32
 # CHECK-NEXT:                      %3 = arith.addf %out, %2 : f32
 # CHECK-NEXT:                      linalg.yield %3 : f32
 # CHECK-NEXT:                    }
@@ -270,7 +204,7 @@ print(f"CODE: {res}")
 # CHECK-NEXT:    outputs:
 # CHECK-NEXT:    - %3 : 1x4x4x16xfloat32
 # CHECK-NEXT:    nodes:
-# CHECK-NEXT:   - %2: pad(%0, padding={1: (2, 2), 2: (2, 2)}, constant_value=0) {name = 'pad'} : [1x8x8x3xfloat32] -> [1x12x12x3xfloat32] 
+# CHECK-NEXT:    - %2: pad(%0, padding={1: (2, 2), 2: (2, 2)}, constant_value=0) {name = 'pad'} : [1x8x8x3xfloat32] -> [1x12x12x3xfloat32]
 # CHECK-NEXT:    - %3: conv2d(%2, %1, stride=(2, 2)) {name = 'conv'} : [1x12x12x3xfloat32, 5x5x3x16xfloat32] -> [1x4x4x16xfloat32]
 # CHECK-NEXT:  
 # CHECK-NEXT:  CODE: 0

--- a/tests/filecheck/backends/padding/test_gen_pad_dict_conv2d_mlir.py
+++ b/tests/filecheck/backends/padding/test_gen_pad_dict_conv2d_mlir.py
@@ -58,7 +58,7 @@ print(f"CODE: {res}")
 # CHECK-NEXT:      transform.yield 
 # CHECK-NEXT:    }
 # CHECK-NEXT:    transform.named_sequence @__transform_main(%arg0: !transform.any_op {transform.readonly}) {
-# CHECK-NEXT:      %0 = transform.structured.match attributes {__xtc_id_pad_0_} in %arg0 : (!transform.any_op) -> !transform.any_op
+# CHECK-NEXT:      %0 = transform.structured.match attributes {__xtc_id_pad_} in %arg0 : (!transform.any_op) -> !transform.any_op
 # CHECK-NEXT:      %tiled_linalg_op, %loops = transform.structured.tile_using_for %0 tile_sizes [1, 0, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
 # CHECK-NEXT:      transform.annotate %loops "./i" : !transform.any_op
 # CHECK-NEXT:      %tiled_linalg_op_0, %loops_1 = transform.structured.tile_using_for %tiled_linalg_op tile_sizes [0, 1, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
@@ -67,39 +67,21 @@ print(f"CODE: {res}")
 # CHECK-NEXT:      transform.annotate %loops_3 "./k" : !transform.any_op
 # CHECK-NEXT:      %tiled_linalg_op_4, %loops_5 = transform.structured.tile_using_for %tiled_linalg_op_2 tile_sizes [0, 0, 0, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
 # CHECK-NEXT:      transform.annotate %loops_5 "./l" : !transform.any_op
-# CHECK-NEXT:      %1 = transform.structured.match attributes {__xtc_id_pad_} in %arg0 : (!transform.any_op) -> !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_6, %loops_7 = transform.structured.tile_using_for %1 tile_sizes [1, 0, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_7 "./i" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_8, %loops_9 = transform.structured.tile_using_for %tiled_linalg_op_6 tile_sizes [0, 1, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_9 "./j" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_10, %loops_11 = transform.structured.tile_using_for %tiled_linalg_op_8 tile_sizes [0, 0, 1, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_11 "./k" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_12, %loops_13 = transform.structured.tile_using_for %tiled_linalg_op_10 tile_sizes [0, 0, 0, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_13 "./l" : !transform.any_op
-# CHECK-NEXT:      %2 = transform.structured.match attributes {__xtc_id_conv_0_} in %arg0 : (!transform.any_op) -> !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_14, %loops_15 = transform.structured.tile_using_for %2 tile_sizes [1, 0, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_15 "./b" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_16, %loops_17 = transform.structured.tile_using_for %tiled_linalg_op_14 tile_sizes [0, 1, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_17 "./h" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_18, %loops_19 = transform.structured.tile_using_for %tiled_linalg_op_16 tile_sizes [0, 0, 1, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_19 "./w" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_20, %loops_21 = transform.structured.tile_using_for %tiled_linalg_op_18 tile_sizes [0, 0, 0, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_21 "./f" : !transform.any_op
-# CHECK-NEXT:      %3 = transform.structured.match attributes {__xtc_id_conv_} in %arg0 : (!transform.any_op) -> !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_22, %loops_23 = transform.structured.tile_using_for %3 tile_sizes [1, 0, 0, 0, 0, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_23 "./b" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_24, %loops_25 = transform.structured.tile_using_for %tiled_linalg_op_22 tile_sizes [0, 1, 0, 0, 0, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_25 "./h" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_26, %loops_27 = transform.structured.tile_using_for %tiled_linalg_op_24 tile_sizes [0, 0, 1, 0, 0, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_27 "./w" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_28, %loops_29 = transform.structured.tile_using_for %tiled_linalg_op_26 tile_sizes [0, 0, 0, 1, 0, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_29 "./f" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_30, %loops_31 = transform.structured.tile_using_for %tiled_linalg_op_28 tile_sizes [0, 0, 0, 0, 1, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_31 "./r" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_32, %loops_33 = transform.structured.tile_using_for %tiled_linalg_op_30 tile_sizes [0, 0, 0, 0, 0, 1, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_33 "./s" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_34, %loops_35 = transform.structured.tile_using_for %tiled_linalg_op_32 tile_sizes [0, 0, 0, 0, 0, 0, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_35 "./c" : !transform.any_op
+# CHECK-NEXT:      %1 = transform.structured.match attributes {__xtc_id_conv_} in %arg0 : (!transform.any_op) -> !transform.any_op
+# CHECK-NEXT:      %tiled_linalg_op_6, %loops_7 = transform.structured.tile_using_for %1 tile_sizes [1, 0, 0, 0, 0, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      transform.annotate %loops_7 "./b" : !transform.any_op
+# CHECK-NEXT:      %tiled_linalg_op_8, %loops_9 = transform.structured.tile_using_for %tiled_linalg_op_6 tile_sizes [0, 1, 0, 0, 0, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      transform.annotate %loops_9 "./h" : !transform.any_op
+# CHECK-NEXT:      %tiled_linalg_op_10, %loops_11 = transform.structured.tile_using_for %tiled_linalg_op_8 tile_sizes [0, 0, 1, 0, 0, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      transform.annotate %loops_11 "./w" : !transform.any_op
+# CHECK-NEXT:      %tiled_linalg_op_12, %loops_13 = transform.structured.tile_using_for %tiled_linalg_op_10 tile_sizes [0, 0, 0, 1, 0, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      transform.annotate %loops_13 "./f" : !transform.any_op
+# CHECK-NEXT:      %tiled_linalg_op_14, %loops_15 = transform.structured.tile_using_for %tiled_linalg_op_12 tile_sizes [0, 0, 0, 0, 1, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      transform.annotate %loops_15 "./r" : !transform.any_op
+# CHECK-NEXT:      %tiled_linalg_op_16, %loops_17 = transform.structured.tile_using_for %tiled_linalg_op_14 tile_sizes [0, 0, 0, 0, 0, 1, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      transform.annotate %loops_17 "./s" : !transform.any_op
+# CHECK-NEXT:      %tiled_linalg_op_18, %loops_19 = transform.structured.tile_using_for %tiled_linalg_op_16 tile_sizes [0, 0, 0, 0, 0, 0, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      transform.annotate %loops_19 "./c" : !transform.any_op
 # CHECK-NEXT:      transform.yield 
 # CHECK-NEXT:    }
 # CHECK-NEXT:  }
@@ -113,141 +95,93 @@ print(f"CODE: {res}")
 # CHECK-NEXT:    func.func @pad_conv2d_nhwc_mini(%arg0: memref<1x8x8x3xf32> {llvm.noalias}, %arg1: memref<5x5x3x16xf32> {llvm.noalias}, %arg2: memref<1x4x4x16xf32> {llvm.noalias}) {
 # CHECK-NEXT:      %alloca = memref.alloca() {alignment = 256 : i64} : memref<1x12x12x3xf32>
 # CHECK-NEXT:      %cst = arith.constant 0.000000e+00 : f32
+# CHECK-NEXT:      linalg.fill {__xtc_id_pad_0_} ins(%cst : f32) outs(%alloca : memref<1x12x12x3xf32>)
+# CHECK-NEXT:      %subview = memref.subview %alloca[0, 2, 2, 0] [1, 8, 8, 3] [1, 1, 1, 1] : memref<1x12x12x3xf32> to memref<1x8x8x3xf32, strided<[432, 36, 3, 1], offset: 78>>
 # CHECK-NEXT:      %c0 = arith.constant 0 : index
 # CHECK-NEXT:      %c1 = arith.constant 1 : index
 # CHECK-NEXT:      %c1_0 = arith.constant 1 : index
 # CHECK-NEXT:      scf.for %arg3 = %c0 to %c1 step %c1_0 {
-# CHECK-NEXT:        %subview_11 = memref.subview %alloca[%arg3, 0, 0, 0] [1, 12, 12, 3] [1, 1, 1, 1] : memref<1x12x12x3xf32> to memref<1x12x12x3xf32, strided<[432, 36, 3, 1], offset: ?>>
-# CHECK-NEXT:        %c0_12 = arith.constant 0 : index
-# CHECK-NEXT:        %c12 = arith.constant 12 : index
-# CHECK-NEXT:        %c1_13 = arith.constant 1 : index
-# CHECK-NEXT:        scf.for %arg4 = %c0_12 to %c12 step %c1_13 {
-# CHECK-NEXT:          %subview_14 = memref.subview %subview_11[0, %arg4, 0, 0] [1, 1, 12, 3] [1, 1, 1, 1] : memref<1x12x12x3xf32, strided<[432, 36, 3, 1], offset: ?>> to memref<1x1x12x3xf32, strided<[432, 36, 3, 1], offset: ?>>
-# CHECK-NEXT:          %c0_15 = arith.constant 0 : index
-# CHECK-NEXT:          %c12_16 = arith.constant 12 : index
-# CHECK-NEXT:          %c1_17 = arith.constant 1 : index
-# CHECK-NEXT:          scf.for %arg5 = %c0_15 to %c12_16 step %c1_17 {
-# CHECK-NEXT:            %subview_18 = memref.subview %subview_14[0, 0, %arg5, 0] [1, 1, 1, 3] [1, 1, 1, 1] : memref<1x1x12x3xf32, strided<[432, 36, 3, 1], offset: ?>> to memref<1x1x1x3xf32, strided<[432, 36, 3, 1], offset: ?>>
-# CHECK-NEXT:            %c0_19 = arith.constant 0 : index
-# CHECK-NEXT:            %c3 = arith.constant 3 : index
-# CHECK-NEXT:            %c1_20 = arith.constant 1 : index
-# CHECK-NEXT:            scf.for %arg6 = %c0_19 to %c3 step %c1_20 {
-# CHECK-NEXT:              %subview_21 = memref.subview %subview_18[0, 0, 0, %arg6] [1, 1, 1, 1] [1, 1, 1, 1] : memref<1x1x1x3xf32, strided<[432, 36, 3, 1], offset: ?>> to memref<1x1x1x1xf32, strided<[432, 36, 3, 1], offset: ?>>
-# CHECK-NEXT:              linalg.fill {__xtc_id_pad_0_} ins(%cst : f32) outs(%subview_21 : memref<1x1x1x1xf32, strided<[432, 36, 3, 1], offset: ?>>)
-# CHECK-NEXT:            } {"./l"}
-# CHECK-NEXT:          } {"./k"}
-# CHECK-NEXT:        } {"./j"}
-# CHECK-NEXT:      } {"./i"}
-# CHECK-NEXT:      %subview = memref.subview %alloca[0, 2, 2, 0] [1, 8, 8, 3] [1, 1, 1, 1] : memref<1x12x12x3xf32> to memref<1x8x8x3xf32, strided<[432, 36, 3, 1], offset: 78>>
-# CHECK-NEXT:      %c0_1 = arith.constant 0 : index
-# CHECK-NEXT:      %c1_2 = arith.constant 1 : index
-# CHECK-NEXT:      %c1_3 = arith.constant 1 : index
-# CHECK-NEXT:      scf.for %arg3 = %c0_1 to %c1_2 step %c1_3 {
-# CHECK-NEXT:        %subview_11 = memref.subview %arg0[%arg3, 0, 0, 0] [1, 8, 8, 3] [1, 1, 1, 1] : memref<1x8x8x3xf32> to memref<1x8x8x3xf32, strided<[192, 24, 3, 1], offset: ?>>
-# CHECK-NEXT:        %subview_12 = memref.subview %subview[%arg3, 0, 0, 0] [1, 8, 8, 3] [1, 1, 1, 1] : memref<1x8x8x3xf32, strided<[432, 36, 3, 1], offset: 78>> to memref<1x8x8x3xf32, strided<[432, 36, 3, 1], offset: ?>>
-# CHECK-NEXT:        %c0_13 = arith.constant 0 : index
+# CHECK-NEXT:        %subview_5 = memref.subview %arg0[%arg3, 0, 0, 0] [1, 8, 8, 3] [1, 1, 1, 1] : memref<1x8x8x3xf32> to memref<1x8x8x3xf32, strided<[192, 24, 3, 1], offset: ?>>
+# CHECK-NEXT:        %subview_6 = memref.subview %subview[%arg3, 0, 0, 0] [1, 8, 8, 3] [1, 1, 1, 1] : memref<1x8x8x3xf32, strided<[432, 36, 3, 1], offset: 78>> to memref<1x8x8x3xf32, strided<[432, 36, 3, 1], offset: ?>>
+# CHECK-NEXT:        %c0_7 = arith.constant 0 : index
 # CHECK-NEXT:        %c8 = arith.constant 8 : index
-# CHECK-NEXT:        %c1_14 = arith.constant 1 : index
-# CHECK-NEXT:        scf.for %arg4 = %c0_13 to %c8 step %c1_14 {
-# CHECK-NEXT:          %subview_15 = memref.subview %subview_11[0, %arg4, 0, 0] [1, 1, 8, 3] [1, 1, 1, 1] : memref<1x8x8x3xf32, strided<[192, 24, 3, 1], offset: ?>> to memref<1x1x8x3xf32, strided<[192, 24, 3, 1], offset: ?>>
-# CHECK-NEXT:          %subview_16 = memref.subview %subview_12[0, %arg4, 0, 0] [1, 1, 8, 3] [1, 1, 1, 1] : memref<1x8x8x3xf32, strided<[432, 36, 3, 1], offset: ?>> to memref<1x1x8x3xf32, strided<[432, 36, 3, 1], offset: ?>>
-# CHECK-NEXT:          %c0_17 = arith.constant 0 : index
-# CHECK-NEXT:          %c8_18 = arith.constant 8 : index
-# CHECK-NEXT:          %c1_19 = arith.constant 1 : index
-# CHECK-NEXT:          scf.for %arg5 = %c0_17 to %c8_18 step %c1_19 {
-# CHECK-NEXT:            %subview_20 = memref.subview %subview_15[0, 0, %arg5, 0] [1, 1, 1, 3] [1, 1, 1, 1] : memref<1x1x8x3xf32, strided<[192, 24, 3, 1], offset: ?>> to memref<1x1x1x3xf32, strided<[192, 24, 3, 1], offset: ?>>
-# CHECK-NEXT:            %subview_21 = memref.subview %subview_16[0, 0, %arg5, 0] [1, 1, 1, 3] [1, 1, 1, 1] : memref<1x1x8x3xf32, strided<[432, 36, 3, 1], offset: ?>> to memref<1x1x1x3xf32, strided<[432, 36, 3, 1], offset: ?>>
-# CHECK-NEXT:            %c0_22 = arith.constant 0 : index
+# CHECK-NEXT:        %c1_8 = arith.constant 1 : index
+# CHECK-NEXT:        scf.for %arg4 = %c0_7 to %c8 step %c1_8 {
+# CHECK-NEXT:          %subview_9 = memref.subview %subview_5[0, %arg4, 0, 0] [1, 1, 8, 3] [1, 1, 1, 1] : memref<1x8x8x3xf32, strided<[192, 24, 3, 1], offset: ?>> to memref<1x1x8x3xf32, strided<[192, 24, 3, 1], offset: ?>>
+# CHECK-NEXT:          %subview_10 = memref.subview %subview_6[0, %arg4, 0, 0] [1, 1, 8, 3] [1, 1, 1, 1] : memref<1x8x8x3xf32, strided<[432, 36, 3, 1], offset: ?>> to memref<1x1x8x3xf32, strided<[432, 36, 3, 1], offset: ?>>
+# CHECK-NEXT:          %c0_11 = arith.constant 0 : index
+# CHECK-NEXT:          %c8_12 = arith.constant 8 : index
+# CHECK-NEXT:          %c1_13 = arith.constant 1 : index
+# CHECK-NEXT:          scf.for %arg5 = %c0_11 to %c8_12 step %c1_13 {
+# CHECK-NEXT:            %subview_14 = memref.subview %subview_9[0, 0, %arg5, 0] [1, 1, 1, 3] [1, 1, 1, 1] : memref<1x1x8x3xf32, strided<[192, 24, 3, 1], offset: ?>> to memref<1x1x1x3xf32, strided<[192, 24, 3, 1], offset: ?>>
+# CHECK-NEXT:            %subview_15 = memref.subview %subview_10[0, 0, %arg5, 0] [1, 1, 1, 3] [1, 1, 1, 1] : memref<1x1x8x3xf32, strided<[432, 36, 3, 1], offset: ?>> to memref<1x1x1x3xf32, strided<[432, 36, 3, 1], offset: ?>>
+# CHECK-NEXT:            %c0_16 = arith.constant 0 : index
 # CHECK-NEXT:            %c3 = arith.constant 3 : index
-# CHECK-NEXT:            %c1_23 = arith.constant 1 : index
-# CHECK-NEXT:            scf.for %arg6 = %c0_22 to %c3 step %c1_23 {
-# CHECK-NEXT:              %subview_24 = memref.subview %subview_20[0, 0, 0, %arg6] [1, 1, 1, 1] [1, 1, 1, 1] : memref<1x1x1x3xf32, strided<[192, 24, 3, 1], offset: ?>> to memref<1x1x1x1xf32, strided<[192, 24, 3, 1], offset: ?>>
-# CHECK-NEXT:              %subview_25 = memref.subview %subview_21[0, 0, 0, %arg6] [1, 1, 1, 1] [1, 1, 1, 1] : memref<1x1x1x3xf32, strided<[432, 36, 3, 1], offset: ?>> to memref<1x1x1x1xf32, strided<[432, 36, 3, 1], offset: ?>>
-# CHECK-NEXT:              linalg.copy {__xtc_id_pad_} ins(%subview_24 : memref<1x1x1x1xf32, strided<[192, 24, 3, 1], offset: ?>>) outs(%subview_25 : memref<1x1x1x1xf32, strided<[432, 36, 3, 1], offset: ?>>)
+# CHECK-NEXT:            %c1_17 = arith.constant 1 : index
+# CHECK-NEXT:            scf.for %arg6 = %c0_16 to %c3 step %c1_17 {
+# CHECK-NEXT:              %subview_18 = memref.subview %subview_14[0, 0, 0, %arg6] [1, 1, 1, 1] [1, 1, 1, 1] : memref<1x1x1x3xf32, strided<[192, 24, 3, 1], offset: ?>> to memref<1x1x1x1xf32, strided<[192, 24, 3, 1], offset: ?>>
+# CHECK-NEXT:              %subview_19 = memref.subview %subview_15[0, 0, 0, %arg6] [1, 1, 1, 1] [1, 1, 1, 1] : memref<1x1x1x3xf32, strided<[432, 36, 3, 1], offset: ?>> to memref<1x1x1x1xf32, strided<[432, 36, 3, 1], offset: ?>>
+# CHECK-NEXT:              linalg.copy {__xtc_id_pad_} ins(%subview_18 : memref<1x1x1x1xf32, strided<[192, 24, 3, 1], offset: ?>>) outs(%subview_19 : memref<1x1x1x1xf32, strided<[432, 36, 3, 1], offset: ?>>)
 # CHECK-NEXT:            } {"./l"}
 # CHECK-NEXT:          } {"./k"}
 # CHECK-NEXT:        } {"./j"}
 # CHECK-NEXT:      } {"./i"}
-# CHECK-NEXT:      %cst_4 = arith.constant 0.000000e+00 : f32
-# CHECK-NEXT:      %c0_5 = arith.constant 0 : index
-# CHECK-NEXT:      %c1_6 = arith.constant 1 : index
-# CHECK-NEXT:      %c1_7 = arith.constant 1 : index
-# CHECK-NEXT:      scf.for %arg3 = %c0_5 to %c1_6 step %c1_7 {
-# CHECK-NEXT:        %subview_11 = memref.subview %arg2[%arg3, 0, 0, 0] [1, 4, 4, 16] [1, 1, 1, 1] : memref<1x4x4x16xf32> to memref<1x4x4x16xf32, strided<[256, 64, 16, 1], offset: ?>>
-# CHECK-NEXT:        %c0_12 = arith.constant 0 : index
+# CHECK-NEXT:      %cst_1 = arith.constant 0.000000e+00 : f32
+# CHECK-NEXT:      linalg.fill {__xtc_id_conv_0_} ins(%cst_1 : f32) outs(%arg2 : memref<1x4x4x16xf32>)
+# CHECK-NEXT:      %c0_2 = arith.constant 0 : index
+# CHECK-NEXT:      %c1_3 = arith.constant 1 : index
+# CHECK-NEXT:      %c1_4 = arith.constant 1 : index
+# CHECK-NEXT:      scf.for %arg3 = %c0_2 to %c1_3 step %c1_4 {
+# CHECK-NEXT:        %subview_5 = memref.subview %alloca[%arg3, 0, 0, 0] [1, 11, 11, 3] [1, 1, 1, 1] : memref<1x12x12x3xf32> to memref<1x11x11x3xf32, strided<[432, 36, 3, 1], offset: ?>>
+# CHECK-NEXT:        %subview_6 = memref.subview %arg1[0, 0, 0, 0] [5, 5, 3, 16] [1, 1, 1, 1] : memref<5x5x3x16xf32> to memref<5x5x3x16xf32, strided<[240, 48, 16, 1]>>
+# CHECK-NEXT:        %subview_7 = memref.subview %arg2[%arg3, 0, 0, 0] [1, 4, 4, 16] [1, 1, 1, 1] : memref<1x4x4x16xf32> to memref<1x4x4x16xf32, strided<[256, 64, 16, 1], offset: ?>>
+# CHECK-NEXT:        %c0_8 = arith.constant 0 : index
 # CHECK-NEXT:        %c4 = arith.constant 4 : index
-# CHECK-NEXT:        %c1_13 = arith.constant 1 : index
-# CHECK-NEXT:        scf.for %arg4 = %c0_12 to %c4 step %c1_13 {
-# CHECK-NEXT:          %subview_14 = memref.subview %subview_11[0, %arg4, 0, 0] [1, 1, 4, 16] [1, 1, 1, 1] : memref<1x4x4x16xf32, strided<[256, 64, 16, 1], offset: ?>> to memref<1x1x4x16xf32, strided<[256, 64, 16, 1], offset: ?>>
-# CHECK-NEXT:          %c0_15 = arith.constant 0 : index
-# CHECK-NEXT:          %c4_16 = arith.constant 4 : index
-# CHECK-NEXT:          %c1_17 = arith.constant 1 : index
-# CHECK-NEXT:          scf.for %arg5 = %c0_15 to %c4_16 step %c1_17 {
-# CHECK-NEXT:            %subview_18 = memref.subview %subview_14[0, 0, %arg5, 0] [1, 1, 1, 16] [1, 1, 1, 1] : memref<1x1x4x16xf32, strided<[256, 64, 16, 1], offset: ?>> to memref<1x1x1x16xf32, strided<[256, 64, 16, 1], offset: ?>>
+# CHECK-NEXT:        %c1_9 = arith.constant 1 : index
+# CHECK-NEXT:        scf.for %arg4 = %c0_8 to %c4 step %c1_9 {
+# CHECK-NEXT:          %0 = affine.apply #map(%arg4)
+# CHECK-NEXT:          %subview_10 = memref.subview %subview_5[0, %0, 0, 0] [1, 5, 11, 3] [1, 1, 1, 1] : memref<1x11x11x3xf32, strided<[432, 36, 3, 1], offset: ?>> to memref<1x5x11x3xf32, strided<[432, 36, 3, 1], offset: ?>>
+# CHECK-NEXT:          %subview_11 = memref.subview %subview_6[0, 0, 0, 0] [5, 5, 3, 16] [1, 1, 1, 1] : memref<5x5x3x16xf32, strided<[240, 48, 16, 1]>> to memref<5x5x3x16xf32, strided<[240, 48, 16, 1]>>
+# CHECK-NEXT:          %subview_12 = memref.subview %subview_7[0, %arg4, 0, 0] [1, 1, 4, 16] [1, 1, 1, 1] : memref<1x4x4x16xf32, strided<[256, 64, 16, 1], offset: ?>> to memref<1x1x4x16xf32, strided<[256, 64, 16, 1], offset: ?>>
+# CHECK-NEXT:          %c0_13 = arith.constant 0 : index
+# CHECK-NEXT:          %c4_14 = arith.constant 4 : index
+# CHECK-NEXT:          %c1_15 = arith.constant 1 : index
+# CHECK-NEXT:          scf.for %arg5 = %c0_13 to %c4_14 step %c1_15 {
+# CHECK-NEXT:            %1 = affine.apply #map(%arg5)
+# CHECK-NEXT:            %subview_16 = memref.subview %subview_10[0, 0, %1, 0] [1, 5, 5, 3] [1, 1, 1, 1] : memref<1x5x11x3xf32, strided<[432, 36, 3, 1], offset: ?>> to memref<1x5x5x3xf32, strided<[432, 36, 3, 1], offset: ?>>
+# CHECK-NEXT:            %subview_17 = memref.subview %subview_11[0, 0, 0, 0] [5, 5, 3, 16] [1, 1, 1, 1] : memref<5x5x3x16xf32, strided<[240, 48, 16, 1]>> to memref<5x5x3x16xf32, strided<[240, 48, 16, 1]>>
+# CHECK-NEXT:            %subview_18 = memref.subview %subview_12[0, 0, %arg5, 0] [1, 1, 1, 16] [1, 1, 1, 1] : memref<1x1x4x16xf32, strided<[256, 64, 16, 1], offset: ?>> to memref<1x1x1x16xf32, strided<[256, 64, 16, 1], offset: ?>>
 # CHECK-NEXT:            %c0_19 = arith.constant 0 : index
 # CHECK-NEXT:            %c16 = arith.constant 16 : index
 # CHECK-NEXT:            %c1_20 = arith.constant 1 : index
 # CHECK-NEXT:            scf.for %arg6 = %c0_19 to %c16 step %c1_20 {
-# CHECK-NEXT:              %subview_21 = memref.subview %subview_18[0, 0, 0, %arg6] [1, 1, 1, 1] [1, 1, 1, 1] : memref<1x1x1x16xf32, strided<[256, 64, 16, 1], offset: ?>> to memref<1x1x1x1xf32, strided<[256, 64, 16, 1], offset: ?>>
-# CHECK-NEXT:              linalg.fill {__xtc_id_conv_0_} ins(%cst_4 : f32) outs(%subview_21 : memref<1x1x1x1xf32, strided<[256, 64, 16, 1], offset: ?>>)
-# CHECK-NEXT:            } {"./f"}
-# CHECK-NEXT:          } {"./w"}
-# CHECK-NEXT:        } {"./h"}
-# CHECK-NEXT:      } {"./b"}
-# CHECK-NEXT:      %c0_8 = arith.constant 0 : index
-# CHECK-NEXT:      %c1_9 = arith.constant 1 : index
-# CHECK-NEXT:      %c1_10 = arith.constant 1 : index
-# CHECK-NEXT:      scf.for %arg3 = %c0_8 to %c1_9 step %c1_10 {
-# CHECK-NEXT:        %subview_11 = memref.subview %alloca[%arg3, 0, 0, 0] [1, 11, 11, 3] [1, 1, 1, 1] : memref<1x12x12x3xf32> to memref<1x11x11x3xf32, strided<[432, 36, 3, 1], offset: ?>>
-# CHECK-NEXT:        %subview_12 = memref.subview %arg1[0, 0, 0, 0] [5, 5, 3, 16] [1, 1, 1, 1] : memref<5x5x3x16xf32> to memref<5x5x3x16xf32, strided<[240, 48, 16, 1]>>
-# CHECK-NEXT:        %subview_13 = memref.subview %arg2[%arg3, 0, 0, 0] [1, 4, 4, 16] [1, 1, 1, 1] : memref<1x4x4x16xf32> to memref<1x4x4x16xf32, strided<[256, 64, 16, 1], offset: ?>>
-# CHECK-NEXT:        %c0_14 = arith.constant 0 : index
-# CHECK-NEXT:        %c4 = arith.constant 4 : index
-# CHECK-NEXT:        %c1_15 = arith.constant 1 : index
-# CHECK-NEXT:        scf.for %arg4 = %c0_14 to %c4 step %c1_15 {
-# CHECK-NEXT:          %0 = affine.apply #map(%arg4)
-# CHECK-NEXT:          %subview_16 = memref.subview %subview_11[0, %0, 0, 0] [1, 5, 11, 3] [1, 1, 1, 1] : memref<1x11x11x3xf32, strided<[432, 36, 3, 1], offset: ?>> to memref<1x5x11x3xf32, strided<[432, 36, 3, 1], offset: ?>>
-# CHECK-NEXT:          %subview_17 = memref.subview %subview_12[0, 0, 0, 0] [5, 5, 3, 16] [1, 1, 1, 1] : memref<5x5x3x16xf32, strided<[240, 48, 16, 1]>> to memref<5x5x3x16xf32, strided<[240, 48, 16, 1]>>
-# CHECK-NEXT:          %subview_18 = memref.subview %subview_13[0, %arg4, 0, 0] [1, 1, 4, 16] [1, 1, 1, 1] : memref<1x4x4x16xf32, strided<[256, 64, 16, 1], offset: ?>> to memref<1x1x4x16xf32, strided<[256, 64, 16, 1], offset: ?>>
-# CHECK-NEXT:          %c0_19 = arith.constant 0 : index
-# CHECK-NEXT:          %c4_20 = arith.constant 4 : index
-# CHECK-NEXT:          %c1_21 = arith.constant 1 : index
-# CHECK-NEXT:          scf.for %arg5 = %c0_19 to %c4_20 step %c1_21 {
-# CHECK-NEXT:            %1 = affine.apply #map(%arg5)
-# CHECK-NEXT:            %subview_22 = memref.subview %subview_16[0, 0, %1, 0] [1, 5, 5, 3] [1, 1, 1, 1] : memref<1x5x11x3xf32, strided<[432, 36, 3, 1], offset: ?>> to memref<1x5x5x3xf32, strided<[432, 36, 3, 1], offset: ?>>
-# CHECK-NEXT:            %subview_23 = memref.subview %subview_17[0, 0, 0, 0] [5, 5, 3, 16] [1, 1, 1, 1] : memref<5x5x3x16xf32, strided<[240, 48, 16, 1]>> to memref<5x5x3x16xf32, strided<[240, 48, 16, 1]>>
-# CHECK-NEXT:            %subview_24 = memref.subview %subview_18[0, 0, %arg5, 0] [1, 1, 1, 16] [1, 1, 1, 1] : memref<1x1x4x16xf32, strided<[256, 64, 16, 1], offset: ?>> to memref<1x1x1x16xf32, strided<[256, 64, 16, 1], offset: ?>>
-# CHECK-NEXT:            %c0_25 = arith.constant 0 : index
-# CHECK-NEXT:            %c16 = arith.constant 16 : index
-# CHECK-NEXT:            %c1_26 = arith.constant 1 : index
-# CHECK-NEXT:            scf.for %arg6 = %c0_25 to %c16 step %c1_26 {
-# CHECK-NEXT:              %subview_27 = memref.subview %subview_22[0, 0, 0, 0] [1, 5, 5, 3] [1, 1, 1, 1] : memref<1x5x5x3xf32, strided<[432, 36, 3, 1], offset: ?>> to memref<1x5x5x3xf32, strided<[432, 36, 3, 1], offset: ?>>
-# CHECK-NEXT:              %subview_28 = memref.subview %subview_23[0, 0, 0, %arg6] [5, 5, 3, 1] [1, 1, 1, 1] : memref<5x5x3x16xf32, strided<[240, 48, 16, 1]>> to memref<5x5x3x1xf32, strided<[240, 48, 16, 1], offset: ?>>
-# CHECK-NEXT:              %subview_29 = memref.subview %subview_24[0, 0, 0, %arg6] [1, 1, 1, 1] [1, 1, 1, 1] : memref<1x1x1x16xf32, strided<[256, 64, 16, 1], offset: ?>> to memref<1x1x1x1xf32, strided<[256, 64, 16, 1], offset: ?>>
-# CHECK-NEXT:              %c0_30 = arith.constant 0 : index
+# CHECK-NEXT:              %subview_21 = memref.subview %subview_16[0, 0, 0, 0] [1, 5, 5, 3] [1, 1, 1, 1] : memref<1x5x5x3xf32, strided<[432, 36, 3, 1], offset: ?>> to memref<1x5x5x3xf32, strided<[432, 36, 3, 1], offset: ?>>
+# CHECK-NEXT:              %subview_22 = memref.subview %subview_17[0, 0, 0, %arg6] [5, 5, 3, 1] [1, 1, 1, 1] : memref<5x5x3x16xf32, strided<[240, 48, 16, 1]>> to memref<5x5x3x1xf32, strided<[240, 48, 16, 1], offset: ?>>
+# CHECK-NEXT:              %subview_23 = memref.subview %subview_18[0, 0, 0, %arg6] [1, 1, 1, 1] [1, 1, 1, 1] : memref<1x1x1x16xf32, strided<[256, 64, 16, 1], offset: ?>> to memref<1x1x1x1xf32, strided<[256, 64, 16, 1], offset: ?>>
+# CHECK-NEXT:              %c0_24 = arith.constant 0 : index
 # CHECK-NEXT:              %c5 = arith.constant 5 : index
-# CHECK-NEXT:              %c1_31 = arith.constant 1 : index
-# CHECK-NEXT:              scf.for %arg7 = %c0_30 to %c5 step %c1_31 {
-# CHECK-NEXT:                %subview_32 = memref.subview %subview_27[0, %arg7, 0, 0] [1, 1, 5, 3] [1, 1, 1, 1] : memref<1x5x5x3xf32, strided<[432, 36, 3, 1], offset: ?>> to memref<1x1x5x3xf32, strided<[432, 36, 3, 1], offset: ?>>
-# CHECK-NEXT:                %subview_33 = memref.subview %subview_28[%arg7, 0, 0, 0] [1, 5, 3, 1] [1, 1, 1, 1] : memref<5x5x3x1xf32, strided<[240, 48, 16, 1], offset: ?>> to memref<1x5x3x1xf32, strided<[240, 48, 16, 1], offset: ?>>
-# CHECK-NEXT:                %subview_34 = memref.subview %subview_29[0, 0, 0, 0] [1, 1, 1, 1] [1, 1, 1, 1] : memref<1x1x1x1xf32, strided<[256, 64, 16, 1], offset: ?>> to memref<1x1x1x1xf32, strided<[256, 64, 16, 1], offset: ?>>
-# CHECK-NEXT:                %c0_35 = arith.constant 0 : index
-# CHECK-NEXT:                %c5_36 = arith.constant 5 : index
-# CHECK-NEXT:                %c1_37 = arith.constant 1 : index
-# CHECK-NEXT:                scf.for %arg8 = %c0_35 to %c5_36 step %c1_37 {
-# CHECK-NEXT:                  %subview_38 = memref.subview %subview_32[0, 0, %arg8, 0] [1, 1, 1, 3] [1, 1, 1, 1] : memref<1x1x5x3xf32, strided<[432, 36, 3, 1], offset: ?>> to memref<1x1x1x3xf32, strided<[432, 36, 3, 1], offset: ?>>
-# CHECK-NEXT:                  %subview_39 = memref.subview %subview_33[0, %arg8, 0, 0] [1, 1, 3, 1] [1, 1, 1, 1] : memref<1x5x3x1xf32, strided<[240, 48, 16, 1], offset: ?>> to memref<1x1x3x1xf32, strided<[240, 48, 16, 1], offset: ?>>
-# CHECK-NEXT:                  %subview_40 = memref.subview %subview_34[0, 0, 0, 0] [1, 1, 1, 1] [1, 1, 1, 1] : memref<1x1x1x1xf32, strided<[256, 64, 16, 1], offset: ?>> to memref<1x1x1x1xf32, strided<[256, 64, 16, 1], offset: ?>>
-# CHECK-NEXT:                  %c0_41 = arith.constant 0 : index
+# CHECK-NEXT:              %c1_25 = arith.constant 1 : index
+# CHECK-NEXT:              scf.for %arg7 = %c0_24 to %c5 step %c1_25 {
+# CHECK-NEXT:                %subview_26 = memref.subview %subview_21[0, %arg7, 0, 0] [1, 1, 5, 3] [1, 1, 1, 1] : memref<1x5x5x3xf32, strided<[432, 36, 3, 1], offset: ?>> to memref<1x1x5x3xf32, strided<[432, 36, 3, 1], offset: ?>>
+# CHECK-NEXT:                %subview_27 = memref.subview %subview_22[%arg7, 0, 0, 0] [1, 5, 3, 1] [1, 1, 1, 1] : memref<5x5x3x1xf32, strided<[240, 48, 16, 1], offset: ?>> to memref<1x5x3x1xf32, strided<[240, 48, 16, 1], offset: ?>>
+# CHECK-NEXT:                %subview_28 = memref.subview %subview_23[0, 0, 0, 0] [1, 1, 1, 1] [1, 1, 1, 1] : memref<1x1x1x1xf32, strided<[256, 64, 16, 1], offset: ?>> to memref<1x1x1x1xf32, strided<[256, 64, 16, 1], offset: ?>>
+# CHECK-NEXT:                %c0_29 = arith.constant 0 : index
+# CHECK-NEXT:                %c5_30 = arith.constant 5 : index
+# CHECK-NEXT:                %c1_31 = arith.constant 1 : index
+# CHECK-NEXT:                scf.for %arg8 = %c0_29 to %c5_30 step %c1_31 {
+# CHECK-NEXT:                  %subview_32 = memref.subview %subview_26[0, 0, %arg8, 0] [1, 1, 1, 3] [1, 1, 1, 1] : memref<1x1x5x3xf32, strided<[432, 36, 3, 1], offset: ?>> to memref<1x1x1x3xf32, strided<[432, 36, 3, 1], offset: ?>>
+# CHECK-NEXT:                  %subview_33 = memref.subview %subview_27[0, %arg8, 0, 0] [1, 1, 3, 1] [1, 1, 1, 1] : memref<1x5x3x1xf32, strided<[240, 48, 16, 1], offset: ?>> to memref<1x1x3x1xf32, strided<[240, 48, 16, 1], offset: ?>>
+# CHECK-NEXT:                  %subview_34 = memref.subview %subview_28[0, 0, 0, 0] [1, 1, 1, 1] [1, 1, 1, 1] : memref<1x1x1x1xf32, strided<[256, 64, 16, 1], offset: ?>> to memref<1x1x1x1xf32, strided<[256, 64, 16, 1], offset: ?>>
+# CHECK-NEXT:                  %c0_35 = arith.constant 0 : index
 # CHECK-NEXT:                  %c3 = arith.constant 3 : index
-# CHECK-NEXT:                  %c1_42 = arith.constant 1 : index
-# CHECK-NEXT:                  scf.for %arg9 = %c0_41 to %c3 step %c1_42 {
-# CHECK-NEXT:                    %subview_43 = memref.subview %subview_38[0, 0, 0, %arg9] [1, 1, 1, 1] [1, 1, 1, 1] : memref<1x1x1x3xf32, strided<[432, 36, 3, 1], offset: ?>> to memref<1x1x1x1xf32, strided<[432, 36, 3, 1], offset: ?>>
-# CHECK-NEXT:                    %subview_44 = memref.subview %subview_39[0, 0, %arg9, 0] [1, 1, 1, 1] [1, 1, 1, 1] : memref<1x1x3x1xf32, strided<[240, 48, 16, 1], offset: ?>> to memref<1x1x1x1xf32, strided<[240, 48, 16, 1], offset: ?>>
-# CHECK-NEXT:                    %subview_45 = memref.subview %subview_40[0, 0, 0, 0] [1, 1, 1, 1] [1, 1, 1, 1] : memref<1x1x1x1xf32, strided<[256, 64, 16, 1], offset: ?>> to memref<1x1x1x1xf32, strided<[256, 64, 16, 1], offset: ?>>
-# CHECK-NEXT:                    linalg.generic {indexing_maps = [#map1, #map2, #map3], iterator_types = ["parallel", "parallel", "parallel", "parallel", "reduction", "reduction", "reduction"]} ins(%subview_43, %subview_44 : memref<1x1x1x1xf32, strided<[432, 36, 3, 1], offset: ?>>, memref<1x1x1x1xf32, strided<[240, 48, 16, 1], offset: ?>>) outs(%subview_45 : memref<1x1x1x1xf32, strided<[256, 64, 16, 1], offset: ?>>) attrs =  {__xtc_id_conv_} {
-# CHECK-NEXT:                    ^bb0(%in: f32, %in_46: f32, %out: f32):
-# CHECK-NEXT:                      %2 = arith.mulf %in, %in_46 fastmath<fast> : f32
+# CHECK-NEXT:                  %c1_36 = arith.constant 1 : index
+# CHECK-NEXT:                  scf.for %arg9 = %c0_35 to %c3 step %c1_36 {
+# CHECK-NEXT:                    %subview_37 = memref.subview %subview_32[0, 0, 0, %arg9] [1, 1, 1, 1] [1, 1, 1, 1] : memref<1x1x1x3xf32, strided<[432, 36, 3, 1], offset: ?>> to memref<1x1x1x1xf32, strided<[432, 36, 3, 1], offset: ?>>
+# CHECK-NEXT:                    %subview_38 = memref.subview %subview_33[0, 0, %arg9, 0] [1, 1, 1, 1] [1, 1, 1, 1] : memref<1x1x3x1xf32, strided<[240, 48, 16, 1], offset: ?>> to memref<1x1x1x1xf32, strided<[240, 48, 16, 1], offset: ?>>
+# CHECK-NEXT:                    %subview_39 = memref.subview %subview_34[0, 0, 0, 0] [1, 1, 1, 1] [1, 1, 1, 1] : memref<1x1x1x1xf32, strided<[256, 64, 16, 1], offset: ?>> to memref<1x1x1x1xf32, strided<[256, 64, 16, 1], offset: ?>>
+# CHECK-NEXT:                    linalg.generic {indexing_maps = [#map1, #map2, #map3], iterator_types = ["parallel", "parallel", "parallel", "parallel", "reduction", "reduction", "reduction"]} ins(%subview_37, %subview_38 : memref<1x1x1x1xf32, strided<[432, 36, 3, 1], offset: ?>>, memref<1x1x1x1xf32, strided<[240, 48, 16, 1], offset: ?>>) outs(%subview_39 : memref<1x1x1x1xf32, strided<[256, 64, 16, 1], offset: ?>>) attrs =  {__xtc_id_conv_} {
+# CHECK-NEXT:                    ^bb0(%in: f32, %in_40: f32, %out: f32):
+# CHECK-NEXT:                      %2 = arith.mulf %in, %in_40 fastmath<fast> : f32
 # CHECK-NEXT:                      %3 = arith.addf %out, %2 fastmath<fast> : f32
 # CHECK-NEXT:                      linalg.yield %3 : f32
 # CHECK-NEXT:                    }

--- a/tests/filecheck/backends/padding/test_gen_pad_int_matmul_unpad_mlir.py
+++ b/tests/filecheck/backends/padding/test_gen_pad_int_matmul_unpad_mlir.py
@@ -57,43 +57,28 @@ print(f"CODE: {res}")
 # CHECK-NEXT:      transform.yield 
 # CHECK-NEXT:    }
 # CHECK-NEXT:    transform.named_sequence @__transform_main(%arg0: !transform.any_op {transform.readonly}) {
-# CHECK-NEXT:      %0 = transform.structured.match attributes {__xtc_id_A_pad_0_} in %arg0 : (!transform.any_op) -> !transform.any_op
+# CHECK-NEXT:      %0 = transform.structured.match attributes {__xtc_id_A_pad_} in %arg0 : (!transform.any_op) -> !transform.any_op
 # CHECK-NEXT:      %tiled_linalg_op, %loops = transform.structured.tile_using_for %0 tile_sizes [1, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
 # CHECK-NEXT:      transform.annotate %loops "./i" : !transform.any_op
 # CHECK-NEXT:      %tiled_linalg_op_0, %loops_1 = transform.structured.tile_using_for %tiled_linalg_op tile_sizes [0, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
 # CHECK-NEXT:      transform.annotate %loops_1 "./j" : !transform.any_op
-# CHECK-NEXT:      %1 = transform.structured.match attributes {__xtc_id_A_pad_} in %arg0 : (!transform.any_op) -> !transform.any_op
+# CHECK-NEXT:      %1 = transform.structured.match attributes {__xtc_id_B_pad_} in %arg0 : (!transform.any_op) -> !transform.any_op
 # CHECK-NEXT:      %tiled_linalg_op_2, %loops_3 = transform.structured.tile_using_for %1 tile_sizes [1, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
 # CHECK-NEXT:      transform.annotate %loops_3 "./i" : !transform.any_op
 # CHECK-NEXT:      %tiled_linalg_op_4, %loops_5 = transform.structured.tile_using_for %tiled_linalg_op_2 tile_sizes [0, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
 # CHECK-NEXT:      transform.annotate %loops_5 "./j" : !transform.any_op
-# CHECK-NEXT:      %2 = transform.structured.match attributes {__xtc_id_B_pad_0_} in %arg0 : (!transform.any_op) -> !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_6, %loops_7 = transform.structured.tile_using_for %2 tile_sizes [1, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      %2 = transform.structured.match attributes {__xtc_id_matmul_padded_} in %arg0 : (!transform.any_op) -> !transform.any_op
+# CHECK-NEXT:      %tiled_linalg_op_6, %loops_7 = transform.structured.tile_using_for %2 tile_sizes [1, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
 # CHECK-NEXT:      transform.annotate %loops_7 "./i" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_8, %loops_9 = transform.structured.tile_using_for %tiled_linalg_op_6 tile_sizes [0, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      %tiled_linalg_op_8, %loops_9 = transform.structured.tile_using_for %tiled_linalg_op_6 tile_sizes [0, 1, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
 # CHECK-NEXT:      transform.annotate %loops_9 "./j" : !transform.any_op
-# CHECK-NEXT:      %3 = transform.structured.match attributes {__xtc_id_B_pad_} in %arg0 : (!transform.any_op) -> !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_10, %loops_11 = transform.structured.tile_using_for %3 tile_sizes [1, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_11 "./i" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_12, %loops_13 = transform.structured.tile_using_for %tiled_linalg_op_10 tile_sizes [0, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_13 "./j" : !transform.any_op
-# CHECK-NEXT:      %4 = transform.structured.match attributes {__xtc_id_matmul_padded_0_} in %arg0 : (!transform.any_op) -> !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_14, %loops_15 = transform.structured.tile_using_for %4 tile_sizes [1, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_15 "./i" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_16, %loops_17 = transform.structured.tile_using_for %tiled_linalg_op_14 tile_sizes [0, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_17 "./j" : !transform.any_op
-# CHECK-NEXT:      %5 = transform.structured.match attributes {__xtc_id_matmul_padded_} in %arg0 : (!transform.any_op) -> !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_18, %loops_19 = transform.structured.tile_using_for %5 tile_sizes [1, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_19 "./i" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_20, %loops_21 = transform.structured.tile_using_for %tiled_linalg_op_18 tile_sizes [0, 1, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_21 "./j" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_22, %loops_23 = transform.structured.tile_using_for %tiled_linalg_op_20 tile_sizes [0, 0, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_23 "./k" : !transform.any_op
-# CHECK-NEXT:      %6 = transform.structured.match attributes {__xtc_id_C_} in %arg0 : (!transform.any_op) -> !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_24, %loops_25 = transform.structured.tile_using_for %6 tile_sizes [1, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_25 "./i" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_26, %loops_27 = transform.structured.tile_using_for %tiled_linalg_op_24 tile_sizes [0, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_27 "./j" : !transform.any_op
+# CHECK-NEXT:      %tiled_linalg_op_10, %loops_11 = transform.structured.tile_using_for %tiled_linalg_op_8 tile_sizes [0, 0, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      transform.annotate %loops_11 "./k" : !transform.any_op
+# CHECK-NEXT:      %3 = transform.structured.match attributes {__xtc_id_C_} in %arg0 : (!transform.any_op) -> !transform.any_op
+# CHECK-NEXT:      %tiled_linalg_op_12, %loops_13 = transform.structured.tile_using_for %3 tile_sizes [1, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      transform.annotate %loops_13 "./i" : !transform.any_op
+# CHECK-NEXT:      %tiled_linalg_op_14, %loops_15 = transform.structured.tile_using_for %tiled_linalg_op_12 tile_sizes [0, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      transform.annotate %loops_15 "./j" : !transform.any_op
 # CHECK-NEXT:      transform.yield 
 # CHECK-NEXT:    }
 # CHECK-NEXT:  }
@@ -103,120 +88,84 @@ print(f"CODE: {res}")
 # CHECK-NEXT:    func.func @pad_matmul_unpad(%arg0: memref<14x14xf32> {llvm.noalias}, %arg1: memref<14x14xf32> {llvm.noalias}, %arg2: memref<14x14xf32> {llvm.noalias}) {
 # CHECK-NEXT:      %alloca = memref.alloca() {alignment = 256 : i64} : memref<18x18xf32>
 # CHECK-NEXT:      %cst = arith.constant 0.000000e+00 : f32
-# CHECK-NEXT:      %c0 = arith.constant 0 : index
-# CHECK-NEXT:      %c18 = arith.constant 18 : index
-# CHECK-NEXT:      %c1 = arith.constant 1 : index
-# CHECK-NEXT:      scf.for %arg3 = %c0 to %c18 step %c1 {
-# CHECK-NEXT:        %subview_23 = memref.subview %alloca[%arg3, 0] [1, 18] [1, 1] : memref<18x18xf32> to memref<1x18xf32, strided<[18, 1], offset: ?>>
-# CHECK-NEXT:        %c0_24 = arith.constant 0 : index
-# CHECK-NEXT:        %c18_25 = arith.constant 18 : index
-# CHECK-NEXT:        %c1_26 = arith.constant 1 : index
-# CHECK-NEXT:        scf.for %arg4 = %c0_24 to %c18_25 step %c1_26 {
-# CHECK-NEXT:          %subview_27 = memref.subview %subview_23[0, %arg4] [1, 1] [1, 1] : memref<1x18xf32, strided<[18, 1], offset: ?>> to memref<1x1xf32, strided<[18, 1], offset: ?>>
-# CHECK-NEXT:          linalg.fill {__xtc_id_A_pad_0_} ins(%cst : f32) outs(%subview_27 : memref<1x1xf32, strided<[18, 1], offset: ?>>)
-# CHECK-NEXT:        } {"./j"}
-# CHECK-NEXT:      } {"./i"}
+# CHECK-NEXT:      linalg.fill {__xtc_id_A_pad_0_} ins(%cst : f32) outs(%alloca : memref<18x18xf32>)
 # CHECK-NEXT:      %subview = memref.subview %alloca[2, 2] [14, 14] [1, 1] : memref<18x18xf32> to memref<14x14xf32, strided<[18, 1], offset: 38>>
-# CHECK-NEXT:      %c0_0 = arith.constant 0 : index
+# CHECK-NEXT:      %c0 = arith.constant 0 : index
 # CHECK-NEXT:      %c14 = arith.constant 14 : index
-# CHECK-NEXT:      %c1_1 = arith.constant 1 : index
-# CHECK-NEXT:      scf.for %arg3 = %c0_0 to %c14 step %c1_1 {
-# CHECK-NEXT:        %subview_23 = memref.subview %arg0[%arg3, 0] [1, 14] [1, 1] : memref<14x14xf32> to memref<1x14xf32, strided<[14, 1], offset: ?>>
-# CHECK-NEXT:        %subview_24 = memref.subview %subview[%arg3, 0] [1, 14] [1, 1] : memref<14x14xf32, strided<[18, 1], offset: 38>> to memref<1x14xf32, strided<[18, 1], offset: ?>>
-# CHECK-NEXT:        %c0_25 = arith.constant 0 : index
-# CHECK-NEXT:        %c14_26 = arith.constant 14 : index
-# CHECK-NEXT:        %c1_27 = arith.constant 1 : index
-# CHECK-NEXT:        scf.for %arg4 = %c0_25 to %c14_26 step %c1_27 {
-# CHECK-NEXT:          %subview_28 = memref.subview %subview_23[0, %arg4] [1, 1] [1, 1] : memref<1x14xf32, strided<[14, 1], offset: ?>> to memref<1x1xf32, strided<[14, 1], offset: ?>>
-# CHECK-NEXT:          %subview_29 = memref.subview %subview_24[0, %arg4] [1, 1] [1, 1] : memref<1x14xf32, strided<[18, 1], offset: ?>> to memref<1x1xf32, strided<[18, 1], offset: ?>>
-# CHECK-NEXT:          linalg.copy {__xtc_id_A_pad_} ins(%subview_28 : memref<1x1xf32, strided<[14, 1], offset: ?>>) outs(%subview_29 : memref<1x1xf32, strided<[18, 1], offset: ?>>)
+# CHECK-NEXT:      %c1 = arith.constant 1 : index
+# CHECK-NEXT:      scf.for %arg3 = %c0 to %c14 step %c1 {
+# CHECK-NEXT:        %subview_14 = memref.subview %arg0[%arg3, 0] [1, 14] [1, 1] : memref<14x14xf32> to memref<1x14xf32, strided<[14, 1], offset: ?>>
+# CHECK-NEXT:        %subview_15 = memref.subview %subview[%arg3, 0] [1, 14] [1, 1] : memref<14x14xf32, strided<[18, 1], offset: 38>> to memref<1x14xf32, strided<[18, 1], offset: ?>>
+# CHECK-NEXT:        %c0_16 = arith.constant 0 : index
+# CHECK-NEXT:        %c14_17 = arith.constant 14 : index
+# CHECK-NEXT:        %c1_18 = arith.constant 1 : index
+# CHECK-NEXT:        scf.for %arg4 = %c0_16 to %c14_17 step %c1_18 {
+# CHECK-NEXT:          %subview_19 = memref.subview %subview_14[0, %arg4] [1, 1] [1, 1] : memref<1x14xf32, strided<[14, 1], offset: ?>> to memref<1x1xf32, strided<[14, 1], offset: ?>>
+# CHECK-NEXT:          %subview_20 = memref.subview %subview_15[0, %arg4] [1, 1] [1, 1] : memref<1x14xf32, strided<[18, 1], offset: ?>> to memref<1x1xf32, strided<[18, 1], offset: ?>>
+# CHECK-NEXT:          linalg.copy {__xtc_id_A_pad_} ins(%subview_19 : memref<1x1xf32, strided<[14, 1], offset: ?>>) outs(%subview_20 : memref<1x1xf32, strided<[18, 1], offset: ?>>)
 # CHECK-NEXT:        } {"./j"}
 # CHECK-NEXT:      } {"./i"}
-# CHECK-NEXT:      %alloca_2 = memref.alloca() {alignment = 256 : i64} : memref<18x18xf32>
-# CHECK-NEXT:      %cst_3 = arith.constant 0.000000e+00 : f32
-# CHECK-NEXT:      %c0_4 = arith.constant 0 : index
-# CHECK-NEXT:      %c18_5 = arith.constant 18 : index
-# CHECK-NEXT:      %c1_6 = arith.constant 1 : index
-# CHECK-NEXT:      scf.for %arg3 = %c0_4 to %c18_5 step %c1_6 {
-# CHECK-NEXT:        %subview_23 = memref.subview %alloca_2[%arg3, 0] [1, 18] [1, 1] : memref<18x18xf32> to memref<1x18xf32, strided<[18, 1], offset: ?>>
-# CHECK-NEXT:        %c0_24 = arith.constant 0 : index
-# CHECK-NEXT:        %c18_25 = arith.constant 18 : index
-# CHECK-NEXT:        %c1_26 = arith.constant 1 : index
-# CHECK-NEXT:        scf.for %arg4 = %c0_24 to %c18_25 step %c1_26 {
-# CHECK-NEXT:          %subview_27 = memref.subview %subview_23[0, %arg4] [1, 1] [1, 1] : memref<1x18xf32, strided<[18, 1], offset: ?>> to memref<1x1xf32, strided<[18, 1], offset: ?>>
-# CHECK-NEXT:          linalg.fill {__xtc_id_B_pad_0_} ins(%cst_3 : f32) outs(%subview_27 : memref<1x1xf32, strided<[18, 1], offset: ?>>)
+# CHECK-NEXT:      %alloca_0 = memref.alloca() {alignment = 256 : i64} : memref<18x18xf32>
+# CHECK-NEXT:      %cst_1 = arith.constant 0.000000e+00 : f32
+# CHECK-NEXT:      linalg.fill {__xtc_id_B_pad_0_} ins(%cst_1 : f32) outs(%alloca_0 : memref<18x18xf32>)
+# CHECK-NEXT:      %subview_2 = memref.subview %alloca_0[2, 2] [14, 14] [1, 1] : memref<18x18xf32> to memref<14x14xf32, strided<[18, 1], offset: 38>>
+# CHECK-NEXT:      %c0_3 = arith.constant 0 : index
+# CHECK-NEXT:      %c14_4 = arith.constant 14 : index
+# CHECK-NEXT:      %c1_5 = arith.constant 1 : index
+# CHECK-NEXT:      scf.for %arg3 = %c0_3 to %c14_4 step %c1_5 {
+# CHECK-NEXT:        %subview_14 = memref.subview %arg1[%arg3, 0] [1, 14] [1, 1] : memref<14x14xf32> to memref<1x14xf32, strided<[14, 1], offset: ?>>
+# CHECK-NEXT:        %subview_15 = memref.subview %subview_2[%arg3, 0] [1, 14] [1, 1] : memref<14x14xf32, strided<[18, 1], offset: 38>> to memref<1x14xf32, strided<[18, 1], offset: ?>>
+# CHECK-NEXT:        %c0_16 = arith.constant 0 : index
+# CHECK-NEXT:        %c14_17 = arith.constant 14 : index
+# CHECK-NEXT:        %c1_18 = arith.constant 1 : index
+# CHECK-NEXT:        scf.for %arg4 = %c0_16 to %c14_17 step %c1_18 {
+# CHECK-NEXT:          %subview_19 = memref.subview %subview_14[0, %arg4] [1, 1] [1, 1] : memref<1x14xf32, strided<[14, 1], offset: ?>> to memref<1x1xf32, strided<[14, 1], offset: ?>>
+# CHECK-NEXT:          %subview_20 = memref.subview %subview_15[0, %arg4] [1, 1] [1, 1] : memref<1x14xf32, strided<[18, 1], offset: ?>> to memref<1x1xf32, strided<[18, 1], offset: ?>>
+# CHECK-NEXT:          linalg.copy {__xtc_id_B_pad_} ins(%subview_19 : memref<1x1xf32, strided<[14, 1], offset: ?>>) outs(%subview_20 : memref<1x1xf32, strided<[18, 1], offset: ?>>)
 # CHECK-NEXT:        } {"./j"}
 # CHECK-NEXT:      } {"./i"}
-# CHECK-NEXT:      %subview_7 = memref.subview %alloca_2[2, 2] [14, 14] [1, 1] : memref<18x18xf32> to memref<14x14xf32, strided<[18, 1], offset: 38>>
+# CHECK-NEXT:      %alloca_6 = memref.alloca() {alignment = 256 : i64} : memref<18x18xf32>
+# CHECK-NEXT:      %cst_7 = arith.constant 0.000000e+00 : f32
+# CHECK-NEXT:      linalg.fill {__xtc_id_matmul_padded_0_} ins(%cst_7 : f32) outs(%alloca_6 : memref<18x18xf32>)
 # CHECK-NEXT:      %c0_8 = arith.constant 0 : index
-# CHECK-NEXT:      %c14_9 = arith.constant 14 : index
-# CHECK-NEXT:      %c1_10 = arith.constant 1 : index
-# CHECK-NEXT:      scf.for %arg3 = %c0_8 to %c14_9 step %c1_10 {
-# CHECK-NEXT:        %subview_23 = memref.subview %arg1[%arg3, 0] [1, 14] [1, 1] : memref<14x14xf32> to memref<1x14xf32, strided<[14, 1], offset: ?>>
-# CHECK-NEXT:        %subview_24 = memref.subview %subview_7[%arg3, 0] [1, 14] [1, 1] : memref<14x14xf32, strided<[18, 1], offset: 38>> to memref<1x14xf32, strided<[18, 1], offset: ?>>
-# CHECK-NEXT:        %c0_25 = arith.constant 0 : index
-# CHECK-NEXT:        %c14_26 = arith.constant 14 : index
-# CHECK-NEXT:        %c1_27 = arith.constant 1 : index
-# CHECK-NEXT:        scf.for %arg4 = %c0_25 to %c14_26 step %c1_27 {
-# CHECK-NEXT:          %subview_28 = memref.subview %subview_23[0, %arg4] [1, 1] [1, 1] : memref<1x14xf32, strided<[14, 1], offset: ?>> to memref<1x1xf32, strided<[14, 1], offset: ?>>
-# CHECK-NEXT:          %subview_29 = memref.subview %subview_24[0, %arg4] [1, 1] [1, 1] : memref<1x14xf32, strided<[18, 1], offset: ?>> to memref<1x1xf32, strided<[18, 1], offset: ?>>
-# CHECK-NEXT:          linalg.copy {__xtc_id_B_pad_} ins(%subview_28 : memref<1x1xf32, strided<[14, 1], offset: ?>>) outs(%subview_29 : memref<1x1xf32, strided<[18, 1], offset: ?>>)
-# CHECK-NEXT:        } {"./j"}
-# CHECK-NEXT:      } {"./i"}
-# CHECK-NEXT:      %alloca_11 = memref.alloca() {alignment = 256 : i64} : memref<18x18xf32>
-# CHECK-NEXT:      %cst_12 = arith.constant 0.000000e+00 : f32
-# CHECK-NEXT:      %c0_13 = arith.constant 0 : index
-# CHECK-NEXT:      %c18_14 = arith.constant 18 : index
-# CHECK-NEXT:      %c1_15 = arith.constant 1 : index
-# CHECK-NEXT:      scf.for %arg3 = %c0_13 to %c18_14 step %c1_15 {
-# CHECK-NEXT:        %subview_23 = memref.subview %alloca_11[%arg3, 0] [1, 18] [1, 1] : memref<18x18xf32> to memref<1x18xf32, strided<[18, 1], offset: ?>>
-# CHECK-NEXT:        %c0_24 = arith.constant 0 : index
-# CHECK-NEXT:        %c18_25 = arith.constant 18 : index
-# CHECK-NEXT:        %c1_26 = arith.constant 1 : index
-# CHECK-NEXT:        scf.for %arg4 = %c0_24 to %c18_25 step %c1_26 {
-# CHECK-NEXT:          %subview_27 = memref.subview %subview_23[0, %arg4] [1, 1] [1, 1] : memref<1x18xf32, strided<[18, 1], offset: ?>> to memref<1x1xf32, strided<[18, 1], offset: ?>>
-# CHECK-NEXT:          linalg.fill {__xtc_id_matmul_padded_0_} ins(%cst_12 : f32) outs(%subview_27 : memref<1x1xf32, strided<[18, 1], offset: ?>>)
-# CHECK-NEXT:        } {"./j"}
-# CHECK-NEXT:      } {"./i"}
-# CHECK-NEXT:      %c0_16 = arith.constant 0 : index
-# CHECK-NEXT:      %c18_17 = arith.constant 18 : index
-# CHECK-NEXT:      %c1_18 = arith.constant 1 : index
-# CHECK-NEXT:      scf.for %arg3 = %c0_16 to %c18_17 step %c1_18 {
-# CHECK-NEXT:        %subview_23 = memref.subview %alloca[%arg3, 0] [1, 18] [1, 1] : memref<18x18xf32> to memref<1x18xf32, strided<[18, 1], offset: ?>>
-# CHECK-NEXT:        %subview_24 = memref.subview %alloca_2[0, 0] [18, 18] [1, 1] : memref<18x18xf32> to memref<18x18xf32, strided<[18, 1]>>
-# CHECK-NEXT:        %subview_25 = memref.subview %alloca_11[%arg3, 0] [1, 18] [1, 1] : memref<18x18xf32> to memref<1x18xf32, strided<[18, 1], offset: ?>>
-# CHECK-NEXT:        %c0_26 = arith.constant 0 : index
-# CHECK-NEXT:        %c18_27 = arith.constant 18 : index
-# CHECK-NEXT:        %c1_28 = arith.constant 1 : index
-# CHECK-NEXT:        scf.for %arg4 = %c0_26 to %c18_27 step %c1_28 {
-# CHECK-NEXT:          %subview_29 = memref.subview %subview_23[0, 0] [1, 18] [1, 1] : memref<1x18xf32, strided<[18, 1], offset: ?>> to memref<1x18xf32, strided<[18, 1], offset: ?>>
-# CHECK-NEXT:          %subview_30 = memref.subview %subview_24[0, %arg4] [18, 1] [1, 1] : memref<18x18xf32, strided<[18, 1]>> to memref<18x1xf32, strided<[18, 1], offset: ?>>
-# CHECK-NEXT:          %subview_31 = memref.subview %subview_25[0, %arg4] [1, 1] [1, 1] : memref<1x18xf32, strided<[18, 1], offset: ?>> to memref<1x1xf32, strided<[18, 1], offset: ?>>
-# CHECK-NEXT:          %c0_32 = arith.constant 0 : index
-# CHECK-NEXT:          %c18_33 = arith.constant 18 : index
-# CHECK-NEXT:          %c1_34 = arith.constant 1 : index
-# CHECK-NEXT:          scf.for %arg5 = %c0_32 to %c18_33 step %c1_34 {
-# CHECK-NEXT:            %subview_35 = memref.subview %subview_29[0, %arg5] [1, 1] [1, 1] : memref<1x18xf32, strided<[18, 1], offset: ?>> to memref<1x1xf32, strided<[18, 1], offset: ?>>
-# CHECK-NEXT:            %subview_36 = memref.subview %subview_30[%arg5, 0] [1, 1] [1, 1] : memref<18x1xf32, strided<[18, 1], offset: ?>> to memref<1x1xf32, strided<[18, 1], offset: ?>>
-# CHECK-NEXT:            %subview_37 = memref.subview %subview_31[0, 0] [1, 1] [1, 1] : memref<1x1xf32, strided<[18, 1], offset: ?>> to memref<1x1xf32, strided<[18, 1], offset: ?>>
-# CHECK-NEXT:            linalg.matmul {__xtc_id_matmul_padded_} ins(%subview_35, %subview_36 : memref<1x1xf32, strided<[18, 1], offset: ?>>, memref<1x1xf32, strided<[18, 1], offset: ?>>) outs(%subview_37 : memref<1x1xf32, strided<[18, 1], offset: ?>>)
+# CHECK-NEXT:      %c18 = arith.constant 18 : index
+# CHECK-NEXT:      %c1_9 = arith.constant 1 : index
+# CHECK-NEXT:      scf.for %arg3 = %c0_8 to %c18 step %c1_9 {
+# CHECK-NEXT:        %subview_14 = memref.subview %alloca[%arg3, 0] [1, 18] [1, 1] : memref<18x18xf32> to memref<1x18xf32, strided<[18, 1], offset: ?>>
+# CHECK-NEXT:        %subview_15 = memref.subview %alloca_0[0, 0] [18, 18] [1, 1] : memref<18x18xf32> to memref<18x18xf32, strided<[18, 1]>>
+# CHECK-NEXT:        %subview_16 = memref.subview %alloca_6[%arg3, 0] [1, 18] [1, 1] : memref<18x18xf32> to memref<1x18xf32, strided<[18, 1], offset: ?>>
+# CHECK-NEXT:        %c0_17 = arith.constant 0 : index
+# CHECK-NEXT:        %c18_18 = arith.constant 18 : index
+# CHECK-NEXT:        %c1_19 = arith.constant 1 : index
+# CHECK-NEXT:        scf.for %arg4 = %c0_17 to %c18_18 step %c1_19 {
+# CHECK-NEXT:          %subview_20 = memref.subview %subview_14[0, 0] [1, 18] [1, 1] : memref<1x18xf32, strided<[18, 1], offset: ?>> to memref<1x18xf32, strided<[18, 1], offset: ?>>
+# CHECK-NEXT:          %subview_21 = memref.subview %subview_15[0, %arg4] [18, 1] [1, 1] : memref<18x18xf32, strided<[18, 1]>> to memref<18x1xf32, strided<[18, 1], offset: ?>>
+# CHECK-NEXT:          %subview_22 = memref.subview %subview_16[0, %arg4] [1, 1] [1, 1] : memref<1x18xf32, strided<[18, 1], offset: ?>> to memref<1x1xf32, strided<[18, 1], offset: ?>>
+# CHECK-NEXT:          %c0_23 = arith.constant 0 : index
+# CHECK-NEXT:          %c18_24 = arith.constant 18 : index
+# CHECK-NEXT:          %c1_25 = arith.constant 1 : index
+# CHECK-NEXT:          scf.for %arg5 = %c0_23 to %c18_24 step %c1_25 {
+# CHECK-NEXT:            %subview_26 = memref.subview %subview_20[0, %arg5] [1, 1] [1, 1] : memref<1x18xf32, strided<[18, 1], offset: ?>> to memref<1x1xf32, strided<[18, 1], offset: ?>>
+# CHECK-NEXT:            %subview_27 = memref.subview %subview_21[%arg5, 0] [1, 1] [1, 1] : memref<18x1xf32, strided<[18, 1], offset: ?>> to memref<1x1xf32, strided<[18, 1], offset: ?>>
+# CHECK-NEXT:            %subview_28 = memref.subview %subview_22[0, 0] [1, 1] [1, 1] : memref<1x1xf32, strided<[18, 1], offset: ?>> to memref<1x1xf32, strided<[18, 1], offset: ?>>
+# CHECK-NEXT:            linalg.matmul {__xtc_id_matmul_padded_} ins(%subview_26, %subview_27 : memref<1x1xf32, strided<[18, 1], offset: ?>>, memref<1x1xf32, strided<[18, 1], offset: ?>>) outs(%subview_28 : memref<1x1xf32, strided<[18, 1], offset: ?>>)
 # CHECK-NEXT:          } {"./k"}
 # CHECK-NEXT:        } {"./j"}
 # CHECK-NEXT:      } {"./i"}
-# CHECK-NEXT:      %subview_19 = memref.subview %alloca_11[2, 2] [14, 14] [1, 1] : memref<18x18xf32> to memref<14x14xf32, strided<[18, 1], offset: 38>>
-# CHECK-NEXT:      %c0_20 = arith.constant 0 : index
-# CHECK-NEXT:      %c14_21 = arith.constant 14 : index
-# CHECK-NEXT:      %c1_22 = arith.constant 1 : index
-# CHECK-NEXT:      scf.for %arg3 = %c0_20 to %c14_21 step %c1_22 {
-# CHECK-NEXT:        %subview_23 = memref.subview %subview_19[%arg3, 0] [1, 14] [1, 1] : memref<14x14xf32, strided<[18, 1], offset: 38>> to memref<1x14xf32, strided<[18, 1], offset: ?>>
-# CHECK-NEXT:        %subview_24 = memref.subview %arg2[%arg3, 0] [1, 14] [1, 1] : memref<14x14xf32> to memref<1x14xf32, strided<[14, 1], offset: ?>>
-# CHECK-NEXT:        %c0_25 = arith.constant 0 : index
-# CHECK-NEXT:        %c14_26 = arith.constant 14 : index
-# CHECK-NEXT:        %c1_27 = arith.constant 1 : index
-# CHECK-NEXT:        scf.for %arg4 = %c0_25 to %c14_26 step %c1_27 {
-# CHECK-NEXT:          %subview_28 = memref.subview %subview_23[0, %arg4] [1, 1] [1, 1] : memref<1x14xf32, strided<[18, 1], offset: ?>> to memref<1x1xf32, strided<[18, 1], offset: ?>>
-# CHECK-NEXT:          %subview_29 = memref.subview %subview_24[0, %arg4] [1, 1] [1, 1] : memref<1x14xf32, strided<[14, 1], offset: ?>> to memref<1x1xf32, strided<[14, 1], offset: ?>>
-# CHECK-NEXT:          linalg.copy {__xtc_id_C_} ins(%subview_28 : memref<1x1xf32, strided<[18, 1], offset: ?>>) outs(%subview_29 : memref<1x1xf32, strided<[14, 1], offset: ?>>)
+# CHECK-NEXT:      %subview_10 = memref.subview %alloca_6[2, 2] [14, 14] [1, 1] : memref<18x18xf32> to memref<14x14xf32, strided<[18, 1], offset: 38>>
+# CHECK-NEXT:      %c0_11 = arith.constant 0 : index
+# CHECK-NEXT:      %c14_12 = arith.constant 14 : index
+# CHECK-NEXT:      %c1_13 = arith.constant 1 : index
+# CHECK-NEXT:      scf.for %arg3 = %c0_11 to %c14_12 step %c1_13 {
+# CHECK-NEXT:        %subview_14 = memref.subview %subview_10[%arg3, 0] [1, 14] [1, 1] : memref<14x14xf32, strided<[18, 1], offset: 38>> to memref<1x14xf32, strided<[18, 1], offset: ?>>
+# CHECK-NEXT:        %subview_15 = memref.subview %arg2[%arg3, 0] [1, 14] [1, 1] : memref<14x14xf32> to memref<1x14xf32, strided<[14, 1], offset: ?>>
+# CHECK-NEXT:        %c0_16 = arith.constant 0 : index
+# CHECK-NEXT:        %c14_17 = arith.constant 14 : index
+# CHECK-NEXT:        %c1_18 = arith.constant 1 : index
+# CHECK-NEXT:        scf.for %arg4 = %c0_16 to %c14_17 step %c1_18 {
+# CHECK-NEXT:          %subview_19 = memref.subview %subview_14[0, %arg4] [1, 1] [1, 1] : memref<1x14xf32, strided<[18, 1], offset: ?>> to memref<1x1xf32, strided<[18, 1], offset: ?>>
+# CHECK-NEXT:          %subview_20 = memref.subview %subview_15[0, %arg4] [1, 1] [1, 1] : memref<1x14xf32, strided<[14, 1], offset: ?>> to memref<1x1xf32, strided<[14, 1], offset: ?>>
+# CHECK-NEXT:          linalg.copy {__xtc_id_C_} ins(%subview_19 : memref<1x1xf32, strided<[18, 1], offset: ?>>) outs(%subview_20 : memref<1x1xf32, strided<[14, 1], offset: ?>>)
 # CHECK-NEXT:        } {"./j"}
 # CHECK-NEXT:      } {"./i"}
 # CHECK-NEXT:      return

--- a/tests/filecheck/backends/padding/test_gen_pad_tuple_conv2d_mlir.py
+++ b/tests/filecheck/backends/padding/test_gen_pad_tuple_conv2d_mlir.py
@@ -57,7 +57,7 @@ print(f"CODE: {res}")
 # CHECK-NEXT:      transform.yield 
 # CHECK-NEXT:    }
 # CHECK-NEXT:    transform.named_sequence @__transform_main(%arg0: !transform.any_op {transform.readonly}) {
-# CHECK-NEXT:      %0 = transform.structured.match attributes {__xtc_id_pad_0_} in %arg0 : (!transform.any_op) -> !transform.any_op
+# CHECK-NEXT:      %0 = transform.structured.match attributes {__xtc_id_pad_} in %arg0 : (!transform.any_op) -> !transform.any_op
 # CHECK-NEXT:      %tiled_linalg_op, %loops = transform.structured.tile_using_for %0 tile_sizes [1, 0, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
 # CHECK-NEXT:      transform.annotate %loops "./i" : !transform.any_op
 # CHECK-NEXT:      %tiled_linalg_op_0, %loops_1 = transform.structured.tile_using_for %tiled_linalg_op tile_sizes [0, 1, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
@@ -66,39 +66,21 @@ print(f"CODE: {res}")
 # CHECK-NEXT:      transform.annotate %loops_3 "./k" : !transform.any_op
 # CHECK-NEXT:      %tiled_linalg_op_4, %loops_5 = transform.structured.tile_using_for %tiled_linalg_op_2 tile_sizes [0, 0, 0, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
 # CHECK-NEXT:      transform.annotate %loops_5 "./l" : !transform.any_op
-# CHECK-NEXT:      %1 = transform.structured.match attributes {__xtc_id_pad_} in %arg0 : (!transform.any_op) -> !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_6, %loops_7 = transform.structured.tile_using_for %1 tile_sizes [1, 0, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_7 "./i" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_8, %loops_9 = transform.structured.tile_using_for %tiled_linalg_op_6 tile_sizes [0, 1, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_9 "./j" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_10, %loops_11 = transform.structured.tile_using_for %tiled_linalg_op_8 tile_sizes [0, 0, 1, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_11 "./k" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_12, %loops_13 = transform.structured.tile_using_for %tiled_linalg_op_10 tile_sizes [0, 0, 0, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_13 "./l" : !transform.any_op
-# CHECK-NEXT:      %2 = transform.structured.match attributes {__xtc_id_conv_0_} in %arg0 : (!transform.any_op) -> !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_14, %loops_15 = transform.structured.tile_using_for %2 tile_sizes [1, 0, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_15 "./b" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_16, %loops_17 = transform.structured.tile_using_for %tiled_linalg_op_14 tile_sizes [0, 1, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_17 "./h" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_18, %loops_19 = transform.structured.tile_using_for %tiled_linalg_op_16 tile_sizes [0, 0, 1, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_19 "./w" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_20, %loops_21 = transform.structured.tile_using_for %tiled_linalg_op_18 tile_sizes [0, 0, 0, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_21 "./f" : !transform.any_op
-# CHECK-NEXT:      %3 = transform.structured.match attributes {__xtc_id_conv_} in %arg0 : (!transform.any_op) -> !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_22, %loops_23 = transform.structured.tile_using_for %3 tile_sizes [1, 0, 0, 0, 0, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_23 "./b" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_24, %loops_25 = transform.structured.tile_using_for %tiled_linalg_op_22 tile_sizes [0, 1, 0, 0, 0, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_25 "./h" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_26, %loops_27 = transform.structured.tile_using_for %tiled_linalg_op_24 tile_sizes [0, 0, 1, 0, 0, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_27 "./w" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_28, %loops_29 = transform.structured.tile_using_for %tiled_linalg_op_26 tile_sizes [0, 0, 0, 1, 0, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_29 "./f" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_30, %loops_31 = transform.structured.tile_using_for %tiled_linalg_op_28 tile_sizes [0, 0, 0, 0, 1, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_31 "./r" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_32, %loops_33 = transform.structured.tile_using_for %tiled_linalg_op_30 tile_sizes [0, 0, 0, 0, 0, 1, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_33 "./s" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_34, %loops_35 = transform.structured.tile_using_for %tiled_linalg_op_32 tile_sizes [0, 0, 0, 0, 0, 0, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_35 "./c" : !transform.any_op
+# CHECK-NEXT:      %1 = transform.structured.match attributes {__xtc_id_conv_} in %arg0 : (!transform.any_op) -> !transform.any_op
+# CHECK-NEXT:      %tiled_linalg_op_6, %loops_7 = transform.structured.tile_using_for %1 tile_sizes [1, 0, 0, 0, 0, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      transform.annotate %loops_7 "./b" : !transform.any_op
+# CHECK-NEXT:      %tiled_linalg_op_8, %loops_9 = transform.structured.tile_using_for %tiled_linalg_op_6 tile_sizes [0, 1, 0, 0, 0, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      transform.annotate %loops_9 "./h" : !transform.any_op
+# CHECK-NEXT:      %tiled_linalg_op_10, %loops_11 = transform.structured.tile_using_for %tiled_linalg_op_8 tile_sizes [0, 0, 1, 0, 0, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      transform.annotate %loops_11 "./w" : !transform.any_op
+# CHECK-NEXT:      %tiled_linalg_op_12, %loops_13 = transform.structured.tile_using_for %tiled_linalg_op_10 tile_sizes [0, 0, 0, 1, 0, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      transform.annotate %loops_13 "./f" : !transform.any_op
+# CHECK-NEXT:      %tiled_linalg_op_14, %loops_15 = transform.structured.tile_using_for %tiled_linalg_op_12 tile_sizes [0, 0, 0, 0, 1, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      transform.annotate %loops_15 "./r" : !transform.any_op
+# CHECK-NEXT:      %tiled_linalg_op_16, %loops_17 = transform.structured.tile_using_for %tiled_linalg_op_14 tile_sizes [0, 0, 0, 0, 0, 1, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      transform.annotate %loops_17 "./s" : !transform.any_op
+# CHECK-NEXT:      %tiled_linalg_op_18, %loops_19 = transform.structured.tile_using_for %tiled_linalg_op_16 tile_sizes [0, 0, 0, 0, 0, 0, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      transform.annotate %loops_19 "./c" : !transform.any_op
 # CHECK-NEXT:      transform.yield 
 # CHECK-NEXT:    }
 # CHECK-NEXT:  }
@@ -112,141 +94,93 @@ print(f"CODE: {res}")
 # CHECK-NEXT:    func.func @pad_conv2d_nhwc_mini(%arg0: memref<1x8x8x3xf32> {llvm.noalias}, %arg1: memref<5x5x3x16xf32> {llvm.noalias}, %arg2: memref<1x4x4x16xf32> {llvm.noalias}) {
 # CHECK-NEXT:      %alloca = memref.alloca() {alignment = 256 : i64} : memref<1x12x12x3xf32>
 # CHECK-NEXT:      %cst = arith.constant 0.000000e+00 : f32
+# CHECK-NEXT:      linalg.fill {__xtc_id_pad_0_} ins(%cst : f32) outs(%alloca : memref<1x12x12x3xf32>)
+# CHECK-NEXT:      %subview = memref.subview %alloca[0, 2, 2, 0] [1, 8, 8, 3] [1, 1, 1, 1] : memref<1x12x12x3xf32> to memref<1x8x8x3xf32, strided<[432, 36, 3, 1], offset: 78>>
 # CHECK-NEXT:      %c0 = arith.constant 0 : index
 # CHECK-NEXT:      %c1 = arith.constant 1 : index
 # CHECK-NEXT:      %c1_0 = arith.constant 1 : index
 # CHECK-NEXT:      scf.for %arg3 = %c0 to %c1 step %c1_0 {
-# CHECK-NEXT:        %subview_11 = memref.subview %alloca[%arg3, 0, 0, 0] [1, 12, 12, 3] [1, 1, 1, 1] : memref<1x12x12x3xf32> to memref<1x12x12x3xf32, strided<[432, 36, 3, 1], offset: ?>>
-# CHECK-NEXT:        %c0_12 = arith.constant 0 : index
-# CHECK-NEXT:        %c12 = arith.constant 12 : index
-# CHECK-NEXT:        %c1_13 = arith.constant 1 : index
-# CHECK-NEXT:        scf.for %arg4 = %c0_12 to %c12 step %c1_13 {
-# CHECK-NEXT:          %subview_14 = memref.subview %subview_11[0, %arg4, 0, 0] [1, 1, 12, 3] [1, 1, 1, 1] : memref<1x12x12x3xf32, strided<[432, 36, 3, 1], offset: ?>> to memref<1x1x12x3xf32, strided<[432, 36, 3, 1], offset: ?>>
-# CHECK-NEXT:          %c0_15 = arith.constant 0 : index
-# CHECK-NEXT:          %c12_16 = arith.constant 12 : index
-# CHECK-NEXT:          %c1_17 = arith.constant 1 : index
-# CHECK-NEXT:          scf.for %arg5 = %c0_15 to %c12_16 step %c1_17 {
-# CHECK-NEXT:            %subview_18 = memref.subview %subview_14[0, 0, %arg5, 0] [1, 1, 1, 3] [1, 1, 1, 1] : memref<1x1x12x3xf32, strided<[432, 36, 3, 1], offset: ?>> to memref<1x1x1x3xf32, strided<[432, 36, 3, 1], offset: ?>>
-# CHECK-NEXT:            %c0_19 = arith.constant 0 : index
-# CHECK-NEXT:            %c3 = arith.constant 3 : index
-# CHECK-NEXT:            %c1_20 = arith.constant 1 : index
-# CHECK-NEXT:            scf.for %arg6 = %c0_19 to %c3 step %c1_20 {
-# CHECK-NEXT:              %subview_21 = memref.subview %subview_18[0, 0, 0, %arg6] [1, 1, 1, 1] [1, 1, 1, 1] : memref<1x1x1x3xf32, strided<[432, 36, 3, 1], offset: ?>> to memref<1x1x1x1xf32, strided<[432, 36, 3, 1], offset: ?>>
-# CHECK-NEXT:              linalg.fill {__xtc_id_pad_0_} ins(%cst : f32) outs(%subview_21 : memref<1x1x1x1xf32, strided<[432, 36, 3, 1], offset: ?>>)
-# CHECK-NEXT:            } {"./l"}
-# CHECK-NEXT:          } {"./k"}
-# CHECK-NEXT:        } {"./j"}
-# CHECK-NEXT:      } {"./i"}
-# CHECK-NEXT:      %subview = memref.subview %alloca[0, 2, 2, 0] [1, 8, 8, 3] [1, 1, 1, 1] : memref<1x12x12x3xf32> to memref<1x8x8x3xf32, strided<[432, 36, 3, 1], offset: 78>>
-# CHECK-NEXT:      %c0_1 = arith.constant 0 : index
-# CHECK-NEXT:      %c1_2 = arith.constant 1 : index
-# CHECK-NEXT:      %c1_3 = arith.constant 1 : index
-# CHECK-NEXT:      scf.for %arg3 = %c0_1 to %c1_2 step %c1_3 {
-# CHECK-NEXT:        %subview_11 = memref.subview %arg0[%arg3, 0, 0, 0] [1, 8, 8, 3] [1, 1, 1, 1] : memref<1x8x8x3xf32> to memref<1x8x8x3xf32, strided<[192, 24, 3, 1], offset: ?>>
-# CHECK-NEXT:        %subview_12 = memref.subview %subview[%arg3, 0, 0, 0] [1, 8, 8, 3] [1, 1, 1, 1] : memref<1x8x8x3xf32, strided<[432, 36, 3, 1], offset: 78>> to memref<1x8x8x3xf32, strided<[432, 36, 3, 1], offset: ?>>
-# CHECK-NEXT:        %c0_13 = arith.constant 0 : index
+# CHECK-NEXT:        %subview_5 = memref.subview %arg0[%arg3, 0, 0, 0] [1, 8, 8, 3] [1, 1, 1, 1] : memref<1x8x8x3xf32> to memref<1x8x8x3xf32, strided<[192, 24, 3, 1], offset: ?>>
+# CHECK-NEXT:        %subview_6 = memref.subview %subview[%arg3, 0, 0, 0] [1, 8, 8, 3] [1, 1, 1, 1] : memref<1x8x8x3xf32, strided<[432, 36, 3, 1], offset: 78>> to memref<1x8x8x3xf32, strided<[432, 36, 3, 1], offset: ?>>
+# CHECK-NEXT:        %c0_7 = arith.constant 0 : index
 # CHECK-NEXT:        %c8 = arith.constant 8 : index
-# CHECK-NEXT:        %c1_14 = arith.constant 1 : index
-# CHECK-NEXT:        scf.for %arg4 = %c0_13 to %c8 step %c1_14 {
-# CHECK-NEXT:          %subview_15 = memref.subview %subview_11[0, %arg4, 0, 0] [1, 1, 8, 3] [1, 1, 1, 1] : memref<1x8x8x3xf32, strided<[192, 24, 3, 1], offset: ?>> to memref<1x1x8x3xf32, strided<[192, 24, 3, 1], offset: ?>>
-# CHECK-NEXT:          %subview_16 = memref.subview %subview_12[0, %arg4, 0, 0] [1, 1, 8, 3] [1, 1, 1, 1] : memref<1x8x8x3xf32, strided<[432, 36, 3, 1], offset: ?>> to memref<1x1x8x3xf32, strided<[432, 36, 3, 1], offset: ?>>
-# CHECK-NEXT:          %c0_17 = arith.constant 0 : index
-# CHECK-NEXT:          %c8_18 = arith.constant 8 : index
-# CHECK-NEXT:          %c1_19 = arith.constant 1 : index
-# CHECK-NEXT:          scf.for %arg5 = %c0_17 to %c8_18 step %c1_19 {
-# CHECK-NEXT:            %subview_20 = memref.subview %subview_15[0, 0, %arg5, 0] [1, 1, 1, 3] [1, 1, 1, 1] : memref<1x1x8x3xf32, strided<[192, 24, 3, 1], offset: ?>> to memref<1x1x1x3xf32, strided<[192, 24, 3, 1], offset: ?>>
-# CHECK-NEXT:            %subview_21 = memref.subview %subview_16[0, 0, %arg5, 0] [1, 1, 1, 3] [1, 1, 1, 1] : memref<1x1x8x3xf32, strided<[432, 36, 3, 1], offset: ?>> to memref<1x1x1x3xf32, strided<[432, 36, 3, 1], offset: ?>>
-# CHECK-NEXT:            %c0_22 = arith.constant 0 : index
+# CHECK-NEXT:        %c1_8 = arith.constant 1 : index
+# CHECK-NEXT:        scf.for %arg4 = %c0_7 to %c8 step %c1_8 {
+# CHECK-NEXT:          %subview_9 = memref.subview %subview_5[0, %arg4, 0, 0] [1, 1, 8, 3] [1, 1, 1, 1] : memref<1x8x8x3xf32, strided<[192, 24, 3, 1], offset: ?>> to memref<1x1x8x3xf32, strided<[192, 24, 3, 1], offset: ?>>
+# CHECK-NEXT:          %subview_10 = memref.subview %subview_6[0, %arg4, 0, 0] [1, 1, 8, 3] [1, 1, 1, 1] : memref<1x8x8x3xf32, strided<[432, 36, 3, 1], offset: ?>> to memref<1x1x8x3xf32, strided<[432, 36, 3, 1], offset: ?>>
+# CHECK-NEXT:          %c0_11 = arith.constant 0 : index
+# CHECK-NEXT:          %c8_12 = arith.constant 8 : index
+# CHECK-NEXT:          %c1_13 = arith.constant 1 : index
+# CHECK-NEXT:          scf.for %arg5 = %c0_11 to %c8_12 step %c1_13 {
+# CHECK-NEXT:            %subview_14 = memref.subview %subview_9[0, 0, %arg5, 0] [1, 1, 1, 3] [1, 1, 1, 1] : memref<1x1x8x3xf32, strided<[192, 24, 3, 1], offset: ?>> to memref<1x1x1x3xf32, strided<[192, 24, 3, 1], offset: ?>>
+# CHECK-NEXT:            %subview_15 = memref.subview %subview_10[0, 0, %arg5, 0] [1, 1, 1, 3] [1, 1, 1, 1] : memref<1x1x8x3xf32, strided<[432, 36, 3, 1], offset: ?>> to memref<1x1x1x3xf32, strided<[432, 36, 3, 1], offset: ?>>
+# CHECK-NEXT:            %c0_16 = arith.constant 0 : index
 # CHECK-NEXT:            %c3 = arith.constant 3 : index
-# CHECK-NEXT:            %c1_23 = arith.constant 1 : index
-# CHECK-NEXT:            scf.for %arg6 = %c0_22 to %c3 step %c1_23 {
-# CHECK-NEXT:              %subview_24 = memref.subview %subview_20[0, 0, 0, %arg6] [1, 1, 1, 1] [1, 1, 1, 1] : memref<1x1x1x3xf32, strided<[192, 24, 3, 1], offset: ?>> to memref<1x1x1x1xf32, strided<[192, 24, 3, 1], offset: ?>>
-# CHECK-NEXT:              %subview_25 = memref.subview %subview_21[0, 0, 0, %arg6] [1, 1, 1, 1] [1, 1, 1, 1] : memref<1x1x1x3xf32, strided<[432, 36, 3, 1], offset: ?>> to memref<1x1x1x1xf32, strided<[432, 36, 3, 1], offset: ?>>
-# CHECK-NEXT:              linalg.copy {__xtc_id_pad_} ins(%subview_24 : memref<1x1x1x1xf32, strided<[192, 24, 3, 1], offset: ?>>) outs(%subview_25 : memref<1x1x1x1xf32, strided<[432, 36, 3, 1], offset: ?>>)
+# CHECK-NEXT:            %c1_17 = arith.constant 1 : index
+# CHECK-NEXT:            scf.for %arg6 = %c0_16 to %c3 step %c1_17 {
+# CHECK-NEXT:              %subview_18 = memref.subview %subview_14[0, 0, 0, %arg6] [1, 1, 1, 1] [1, 1, 1, 1] : memref<1x1x1x3xf32, strided<[192, 24, 3, 1], offset: ?>> to memref<1x1x1x1xf32, strided<[192, 24, 3, 1], offset: ?>>
+# CHECK-NEXT:              %subview_19 = memref.subview %subview_15[0, 0, 0, %arg6] [1, 1, 1, 1] [1, 1, 1, 1] : memref<1x1x1x3xf32, strided<[432, 36, 3, 1], offset: ?>> to memref<1x1x1x1xf32, strided<[432, 36, 3, 1], offset: ?>>
+# CHECK-NEXT:              linalg.copy {__xtc_id_pad_} ins(%subview_18 : memref<1x1x1x1xf32, strided<[192, 24, 3, 1], offset: ?>>) outs(%subview_19 : memref<1x1x1x1xf32, strided<[432, 36, 3, 1], offset: ?>>)
 # CHECK-NEXT:            } {"./l"}
 # CHECK-NEXT:          } {"./k"}
 # CHECK-NEXT:        } {"./j"}
 # CHECK-NEXT:      } {"./i"}
-# CHECK-NEXT:      %cst_4 = arith.constant 0.000000e+00 : f32
-# CHECK-NEXT:      %c0_5 = arith.constant 0 : index
-# CHECK-NEXT:      %c1_6 = arith.constant 1 : index
-# CHECK-NEXT:      %c1_7 = arith.constant 1 : index
-# CHECK-NEXT:      scf.for %arg3 = %c0_5 to %c1_6 step %c1_7 {
-# CHECK-NEXT:        %subview_11 = memref.subview %arg2[%arg3, 0, 0, 0] [1, 4, 4, 16] [1, 1, 1, 1] : memref<1x4x4x16xf32> to memref<1x4x4x16xf32, strided<[256, 64, 16, 1], offset: ?>>
-# CHECK-NEXT:        %c0_12 = arith.constant 0 : index
+# CHECK-NEXT:      %cst_1 = arith.constant 0.000000e+00 : f32
+# CHECK-NEXT:      linalg.fill {__xtc_id_conv_0_} ins(%cst_1 : f32) outs(%arg2 : memref<1x4x4x16xf32>)
+# CHECK-NEXT:      %c0_2 = arith.constant 0 : index
+# CHECK-NEXT:      %c1_3 = arith.constant 1 : index
+# CHECK-NEXT:      %c1_4 = arith.constant 1 : index
+# CHECK-NEXT:      scf.for %arg3 = %c0_2 to %c1_3 step %c1_4 {
+# CHECK-NEXT:        %subview_5 = memref.subview %alloca[%arg3, 0, 0, 0] [1, 11, 11, 3] [1, 1, 1, 1] : memref<1x12x12x3xf32> to memref<1x11x11x3xf32, strided<[432, 36, 3, 1], offset: ?>>
+# CHECK-NEXT:        %subview_6 = memref.subview %arg1[0, 0, 0, 0] [5, 5, 3, 16] [1, 1, 1, 1] : memref<5x5x3x16xf32> to memref<5x5x3x16xf32, strided<[240, 48, 16, 1]>>
+# CHECK-NEXT:        %subview_7 = memref.subview %arg2[%arg3, 0, 0, 0] [1, 4, 4, 16] [1, 1, 1, 1] : memref<1x4x4x16xf32> to memref<1x4x4x16xf32, strided<[256, 64, 16, 1], offset: ?>>
+# CHECK-NEXT:        %c0_8 = arith.constant 0 : index
 # CHECK-NEXT:        %c4 = arith.constant 4 : index
-# CHECK-NEXT:        %c1_13 = arith.constant 1 : index
-# CHECK-NEXT:        scf.for %arg4 = %c0_12 to %c4 step %c1_13 {
-# CHECK-NEXT:          %subview_14 = memref.subview %subview_11[0, %arg4, 0, 0] [1, 1, 4, 16] [1, 1, 1, 1] : memref<1x4x4x16xf32, strided<[256, 64, 16, 1], offset: ?>> to memref<1x1x4x16xf32, strided<[256, 64, 16, 1], offset: ?>>
-# CHECK-NEXT:          %c0_15 = arith.constant 0 : index
-# CHECK-NEXT:          %c4_16 = arith.constant 4 : index
-# CHECK-NEXT:          %c1_17 = arith.constant 1 : index
-# CHECK-NEXT:          scf.for %arg5 = %c0_15 to %c4_16 step %c1_17 {
-# CHECK-NEXT:            %subview_18 = memref.subview %subview_14[0, 0, %arg5, 0] [1, 1, 1, 16] [1, 1, 1, 1] : memref<1x1x4x16xf32, strided<[256, 64, 16, 1], offset: ?>> to memref<1x1x1x16xf32, strided<[256, 64, 16, 1], offset: ?>>
+# CHECK-NEXT:        %c1_9 = arith.constant 1 : index
+# CHECK-NEXT:        scf.for %arg4 = %c0_8 to %c4 step %c1_9 {
+# CHECK-NEXT:          %0 = affine.apply #map(%arg4)
+# CHECK-NEXT:          %subview_10 = memref.subview %subview_5[0, %0, 0, 0] [1, 5, 11, 3] [1, 1, 1, 1] : memref<1x11x11x3xf32, strided<[432, 36, 3, 1], offset: ?>> to memref<1x5x11x3xf32, strided<[432, 36, 3, 1], offset: ?>>
+# CHECK-NEXT:          %subview_11 = memref.subview %subview_6[0, 0, 0, 0] [5, 5, 3, 16] [1, 1, 1, 1] : memref<5x5x3x16xf32, strided<[240, 48, 16, 1]>> to memref<5x5x3x16xf32, strided<[240, 48, 16, 1]>>
+# CHECK-NEXT:          %subview_12 = memref.subview %subview_7[0, %arg4, 0, 0] [1, 1, 4, 16] [1, 1, 1, 1] : memref<1x4x4x16xf32, strided<[256, 64, 16, 1], offset: ?>> to memref<1x1x4x16xf32, strided<[256, 64, 16, 1], offset: ?>>
+# CHECK-NEXT:          %c0_13 = arith.constant 0 : index
+# CHECK-NEXT:          %c4_14 = arith.constant 4 : index
+# CHECK-NEXT:          %c1_15 = arith.constant 1 : index
+# CHECK-NEXT:          scf.for %arg5 = %c0_13 to %c4_14 step %c1_15 {
+# CHECK-NEXT:            %1 = affine.apply #map(%arg5)
+# CHECK-NEXT:            %subview_16 = memref.subview %subview_10[0, 0, %1, 0] [1, 5, 5, 3] [1, 1, 1, 1] : memref<1x5x11x3xf32, strided<[432, 36, 3, 1], offset: ?>> to memref<1x5x5x3xf32, strided<[432, 36, 3, 1], offset: ?>>
+# CHECK-NEXT:            %subview_17 = memref.subview %subview_11[0, 0, 0, 0] [5, 5, 3, 16] [1, 1, 1, 1] : memref<5x5x3x16xf32, strided<[240, 48, 16, 1]>> to memref<5x5x3x16xf32, strided<[240, 48, 16, 1]>>
+# CHECK-NEXT:            %subview_18 = memref.subview %subview_12[0, 0, %arg5, 0] [1, 1, 1, 16] [1, 1, 1, 1] : memref<1x1x4x16xf32, strided<[256, 64, 16, 1], offset: ?>> to memref<1x1x1x16xf32, strided<[256, 64, 16, 1], offset: ?>>
 # CHECK-NEXT:            %c0_19 = arith.constant 0 : index
 # CHECK-NEXT:            %c16 = arith.constant 16 : index
 # CHECK-NEXT:            %c1_20 = arith.constant 1 : index
 # CHECK-NEXT:            scf.for %arg6 = %c0_19 to %c16 step %c1_20 {
-# CHECK-NEXT:              %subview_21 = memref.subview %subview_18[0, 0, 0, %arg6] [1, 1, 1, 1] [1, 1, 1, 1] : memref<1x1x1x16xf32, strided<[256, 64, 16, 1], offset: ?>> to memref<1x1x1x1xf32, strided<[256, 64, 16, 1], offset: ?>>
-# CHECK-NEXT:              linalg.fill {__xtc_id_conv_0_} ins(%cst_4 : f32) outs(%subview_21 : memref<1x1x1x1xf32, strided<[256, 64, 16, 1], offset: ?>>)
-# CHECK-NEXT:            } {"./f"}
-# CHECK-NEXT:          } {"./w"}
-# CHECK-NEXT:        } {"./h"}
-# CHECK-NEXT:      } {"./b"}
-# CHECK-NEXT:      %c0_8 = arith.constant 0 : index
-# CHECK-NEXT:      %c1_9 = arith.constant 1 : index
-# CHECK-NEXT:      %c1_10 = arith.constant 1 : index
-# CHECK-NEXT:      scf.for %arg3 = %c0_8 to %c1_9 step %c1_10 {
-# CHECK-NEXT:        %subview_11 = memref.subview %alloca[%arg3, 0, 0, 0] [1, 11, 11, 3] [1, 1, 1, 1] : memref<1x12x12x3xf32> to memref<1x11x11x3xf32, strided<[432, 36, 3, 1], offset: ?>>
-# CHECK-NEXT:        %subview_12 = memref.subview %arg1[0, 0, 0, 0] [5, 5, 3, 16] [1, 1, 1, 1] : memref<5x5x3x16xf32> to memref<5x5x3x16xf32, strided<[240, 48, 16, 1]>>
-# CHECK-NEXT:        %subview_13 = memref.subview %arg2[%arg3, 0, 0, 0] [1, 4, 4, 16] [1, 1, 1, 1] : memref<1x4x4x16xf32> to memref<1x4x4x16xf32, strided<[256, 64, 16, 1], offset: ?>>
-# CHECK-NEXT:        %c0_14 = arith.constant 0 : index
-# CHECK-NEXT:        %c4 = arith.constant 4 : index
-# CHECK-NEXT:        %c1_15 = arith.constant 1 : index
-# CHECK-NEXT:        scf.for %arg4 = %c0_14 to %c4 step %c1_15 {
-# CHECK-NEXT:          %0 = affine.apply #map(%arg4)
-# CHECK-NEXT:          %subview_16 = memref.subview %subview_11[0, %0, 0, 0] [1, 5, 11, 3] [1, 1, 1, 1] : memref<1x11x11x3xf32, strided<[432, 36, 3, 1], offset: ?>> to memref<1x5x11x3xf32, strided<[432, 36, 3, 1], offset: ?>>
-# CHECK-NEXT:          %subview_17 = memref.subview %subview_12[0, 0, 0, 0] [5, 5, 3, 16] [1, 1, 1, 1] : memref<5x5x3x16xf32, strided<[240, 48, 16, 1]>> to memref<5x5x3x16xf32, strided<[240, 48, 16, 1]>>
-# CHECK-NEXT:          %subview_18 = memref.subview %subview_13[0, %arg4, 0, 0] [1, 1, 4, 16] [1, 1, 1, 1] : memref<1x4x4x16xf32, strided<[256, 64, 16, 1], offset: ?>> to memref<1x1x4x16xf32, strided<[256, 64, 16, 1], offset: ?>>
-# CHECK-NEXT:          %c0_19 = arith.constant 0 : index
-# CHECK-NEXT:          %c4_20 = arith.constant 4 : index
-# CHECK-NEXT:          %c1_21 = arith.constant 1 : index
-# CHECK-NEXT:          scf.for %arg5 = %c0_19 to %c4_20 step %c1_21 {
-# CHECK-NEXT:            %1 = affine.apply #map(%arg5)
-# CHECK-NEXT:            %subview_22 = memref.subview %subview_16[0, 0, %1, 0] [1, 5, 5, 3] [1, 1, 1, 1] : memref<1x5x11x3xf32, strided<[432, 36, 3, 1], offset: ?>> to memref<1x5x5x3xf32, strided<[432, 36, 3, 1], offset: ?>>
-# CHECK-NEXT:            %subview_23 = memref.subview %subview_17[0, 0, 0, 0] [5, 5, 3, 16] [1, 1, 1, 1] : memref<5x5x3x16xf32, strided<[240, 48, 16, 1]>> to memref<5x5x3x16xf32, strided<[240, 48, 16, 1]>>
-# CHECK-NEXT:            %subview_24 = memref.subview %subview_18[0, 0, %arg5, 0] [1, 1, 1, 16] [1, 1, 1, 1] : memref<1x1x4x16xf32, strided<[256, 64, 16, 1], offset: ?>> to memref<1x1x1x16xf32, strided<[256, 64, 16, 1], offset: ?>>
-# CHECK-NEXT:            %c0_25 = arith.constant 0 : index
-# CHECK-NEXT:            %c16 = arith.constant 16 : index
-# CHECK-NEXT:            %c1_26 = arith.constant 1 : index
-# CHECK-NEXT:            scf.for %arg6 = %c0_25 to %c16 step %c1_26 {
-# CHECK-NEXT:              %subview_27 = memref.subview %subview_22[0, 0, 0, 0] [1, 5, 5, 3] [1, 1, 1, 1] : memref<1x5x5x3xf32, strided<[432, 36, 3, 1], offset: ?>> to memref<1x5x5x3xf32, strided<[432, 36, 3, 1], offset: ?>>
-# CHECK-NEXT:              %subview_28 = memref.subview %subview_23[0, 0, 0, %arg6] [5, 5, 3, 1] [1, 1, 1, 1] : memref<5x5x3x16xf32, strided<[240, 48, 16, 1]>> to memref<5x5x3x1xf32, strided<[240, 48, 16, 1], offset: ?>>
-# CHECK-NEXT:              %subview_29 = memref.subview %subview_24[0, 0, 0, %arg6] [1, 1, 1, 1] [1, 1, 1, 1] : memref<1x1x1x16xf32, strided<[256, 64, 16, 1], offset: ?>> to memref<1x1x1x1xf32, strided<[256, 64, 16, 1], offset: ?>>
-# CHECK-NEXT:              %c0_30 = arith.constant 0 : index
+# CHECK-NEXT:              %subview_21 = memref.subview %subview_16[0, 0, 0, 0] [1, 5, 5, 3] [1, 1, 1, 1] : memref<1x5x5x3xf32, strided<[432, 36, 3, 1], offset: ?>> to memref<1x5x5x3xf32, strided<[432, 36, 3, 1], offset: ?>>
+# CHECK-NEXT:              %subview_22 = memref.subview %subview_17[0, 0, 0, %arg6] [5, 5, 3, 1] [1, 1, 1, 1] : memref<5x5x3x16xf32, strided<[240, 48, 16, 1]>> to memref<5x5x3x1xf32, strided<[240, 48, 16, 1], offset: ?>>
+# CHECK-NEXT:              %subview_23 = memref.subview %subview_18[0, 0, 0, %arg6] [1, 1, 1, 1] [1, 1, 1, 1] : memref<1x1x1x16xf32, strided<[256, 64, 16, 1], offset: ?>> to memref<1x1x1x1xf32, strided<[256, 64, 16, 1], offset: ?>>
+# CHECK-NEXT:              %c0_24 = arith.constant 0 : index
 # CHECK-NEXT:              %c5 = arith.constant 5 : index
-# CHECK-NEXT:              %c1_31 = arith.constant 1 : index
-# CHECK-NEXT:              scf.for %arg7 = %c0_30 to %c5 step %c1_31 {
-# CHECK-NEXT:                %subview_32 = memref.subview %subview_27[0, %arg7, 0, 0] [1, 1, 5, 3] [1, 1, 1, 1] : memref<1x5x5x3xf32, strided<[432, 36, 3, 1], offset: ?>> to memref<1x1x5x3xf32, strided<[432, 36, 3, 1], offset: ?>>
-# CHECK-NEXT:                %subview_33 = memref.subview %subview_28[%arg7, 0, 0, 0] [1, 5, 3, 1] [1, 1, 1, 1] : memref<5x5x3x1xf32, strided<[240, 48, 16, 1], offset: ?>> to memref<1x5x3x1xf32, strided<[240, 48, 16, 1], offset: ?>>
-# CHECK-NEXT:                %subview_34 = memref.subview %subview_29[0, 0, 0, 0] [1, 1, 1, 1] [1, 1, 1, 1] : memref<1x1x1x1xf32, strided<[256, 64, 16, 1], offset: ?>> to memref<1x1x1x1xf32, strided<[256, 64, 16, 1], offset: ?>>
-# CHECK-NEXT:                %c0_35 = arith.constant 0 : index
-# CHECK-NEXT:                %c5_36 = arith.constant 5 : index
-# CHECK-NEXT:                %c1_37 = arith.constant 1 : index
-# CHECK-NEXT:                scf.for %arg8 = %c0_35 to %c5_36 step %c1_37 {
-# CHECK-NEXT:                  %subview_38 = memref.subview %subview_32[0, 0, %arg8, 0] [1, 1, 1, 3] [1, 1, 1, 1] : memref<1x1x5x3xf32, strided<[432, 36, 3, 1], offset: ?>> to memref<1x1x1x3xf32, strided<[432, 36, 3, 1], offset: ?>>
-# CHECK-NEXT:                  %subview_39 = memref.subview %subview_33[0, %arg8, 0, 0] [1, 1, 3, 1] [1, 1, 1, 1] : memref<1x5x3x1xf32, strided<[240, 48, 16, 1], offset: ?>> to memref<1x1x3x1xf32, strided<[240, 48, 16, 1], offset: ?>>
-# CHECK-NEXT:                  %subview_40 = memref.subview %subview_34[0, 0, 0, 0] [1, 1, 1, 1] [1, 1, 1, 1] : memref<1x1x1x1xf32, strided<[256, 64, 16, 1], offset: ?>> to memref<1x1x1x1xf32, strided<[256, 64, 16, 1], offset: ?>>
-# CHECK-NEXT:                  %c0_41 = arith.constant 0 : index
+# CHECK-NEXT:              %c1_25 = arith.constant 1 : index
+# CHECK-NEXT:              scf.for %arg7 = %c0_24 to %c5 step %c1_25 {
+# CHECK-NEXT:                %subview_26 = memref.subview %subview_21[0, %arg7, 0, 0] [1, 1, 5, 3] [1, 1, 1, 1] : memref<1x5x5x3xf32, strided<[432, 36, 3, 1], offset: ?>> to memref<1x1x5x3xf32, strided<[432, 36, 3, 1], offset: ?>>
+# CHECK-NEXT:                %subview_27 = memref.subview %subview_22[%arg7, 0, 0, 0] [1, 5, 3, 1] [1, 1, 1, 1] : memref<5x5x3x1xf32, strided<[240, 48, 16, 1], offset: ?>> to memref<1x5x3x1xf32, strided<[240, 48, 16, 1], offset: ?>>
+# CHECK-NEXT:                %subview_28 = memref.subview %subview_23[0, 0, 0, 0] [1, 1, 1, 1] [1, 1, 1, 1] : memref<1x1x1x1xf32, strided<[256, 64, 16, 1], offset: ?>> to memref<1x1x1x1xf32, strided<[256, 64, 16, 1], offset: ?>>
+# CHECK-NEXT:                %c0_29 = arith.constant 0 : index
+# CHECK-NEXT:                %c5_30 = arith.constant 5 : index
+# CHECK-NEXT:                %c1_31 = arith.constant 1 : index
+# CHECK-NEXT:                scf.for %arg8 = %c0_29 to %c5_30 step %c1_31 {
+# CHECK-NEXT:                  %subview_32 = memref.subview %subview_26[0, 0, %arg8, 0] [1, 1, 1, 3] [1, 1, 1, 1] : memref<1x1x5x3xf32, strided<[432, 36, 3, 1], offset: ?>> to memref<1x1x1x3xf32, strided<[432, 36, 3, 1], offset: ?>>
+# CHECK-NEXT:                  %subview_33 = memref.subview %subview_27[0, %arg8, 0, 0] [1, 1, 3, 1] [1, 1, 1, 1] : memref<1x5x3x1xf32, strided<[240, 48, 16, 1], offset: ?>> to memref<1x1x3x1xf32, strided<[240, 48, 16, 1], offset: ?>>
+# CHECK-NEXT:                  %subview_34 = memref.subview %subview_28[0, 0, 0, 0] [1, 1, 1, 1] [1, 1, 1, 1] : memref<1x1x1x1xf32, strided<[256, 64, 16, 1], offset: ?>> to memref<1x1x1x1xf32, strided<[256, 64, 16, 1], offset: ?>>
+# CHECK-NEXT:                  %c0_35 = arith.constant 0 : index
 # CHECK-NEXT:                  %c3 = arith.constant 3 : index
-# CHECK-NEXT:                  %c1_42 = arith.constant 1 : index
-# CHECK-NEXT:                  scf.for %arg9 = %c0_41 to %c3 step %c1_42 {
-# CHECK-NEXT:                    %subview_43 = memref.subview %subview_38[0, 0, 0, %arg9] [1, 1, 1, 1] [1, 1, 1, 1] : memref<1x1x1x3xf32, strided<[432, 36, 3, 1], offset: ?>> to memref<1x1x1x1xf32, strided<[432, 36, 3, 1], offset: ?>>
-# CHECK-NEXT:                    %subview_44 = memref.subview %subview_39[0, 0, %arg9, 0] [1, 1, 1, 1] [1, 1, 1, 1] : memref<1x1x3x1xf32, strided<[240, 48, 16, 1], offset: ?>> to memref<1x1x1x1xf32, strided<[240, 48, 16, 1], offset: ?>>
-# CHECK-NEXT:                    %subview_45 = memref.subview %subview_40[0, 0, 0, 0] [1, 1, 1, 1] [1, 1, 1, 1] : memref<1x1x1x1xf32, strided<[256, 64, 16, 1], offset: ?>> to memref<1x1x1x1xf32, strided<[256, 64, 16, 1], offset: ?>>
-# CHECK-NEXT:                    linalg.generic {indexing_maps = [#map1, #map2, #map3], iterator_types = ["parallel", "parallel", "parallel", "parallel", "reduction", "reduction", "reduction"]} ins(%subview_43, %subview_44 : memref<1x1x1x1xf32, strided<[432, 36, 3, 1], offset: ?>>, memref<1x1x1x1xf32, strided<[240, 48, 16, 1], offset: ?>>) outs(%subview_45 : memref<1x1x1x1xf32, strided<[256, 64, 16, 1], offset: ?>>) attrs =  {__xtc_id_conv_} {
-# CHECK-NEXT:                    ^bb0(%in: f32, %in_46: f32, %out: f32):
-# CHECK-NEXT:                      %2 = arith.mulf %in, %in_46 : f32
+# CHECK-NEXT:                  %c1_36 = arith.constant 1 : index
+# CHECK-NEXT:                  scf.for %arg9 = %c0_35 to %c3 step %c1_36 {
+# CHECK-NEXT:                    %subview_37 = memref.subview %subview_32[0, 0, 0, %arg9] [1, 1, 1, 1] [1, 1, 1, 1] : memref<1x1x1x3xf32, strided<[432, 36, 3, 1], offset: ?>> to memref<1x1x1x1xf32, strided<[432, 36, 3, 1], offset: ?>>
+# CHECK-NEXT:                    %subview_38 = memref.subview %subview_33[0, 0, %arg9, 0] [1, 1, 1, 1] [1, 1, 1, 1] : memref<1x1x3x1xf32, strided<[240, 48, 16, 1], offset: ?>> to memref<1x1x1x1xf32, strided<[240, 48, 16, 1], offset: ?>>
+# CHECK-NEXT:                    %subview_39 = memref.subview %subview_34[0, 0, 0, 0] [1, 1, 1, 1] [1, 1, 1, 1] : memref<1x1x1x1xf32, strided<[256, 64, 16, 1], offset: ?>> to memref<1x1x1x1xf32, strided<[256, 64, 16, 1], offset: ?>>
+# CHECK-NEXT:                    linalg.generic {indexing_maps = [#map1, #map2, #map3], iterator_types = ["parallel", "parallel", "parallel", "parallel", "reduction", "reduction", "reduction"]} ins(%subview_37, %subview_38 : memref<1x1x1x1xf32, strided<[432, 36, 3, 1], offset: ?>>, memref<1x1x1x1xf32, strided<[240, 48, 16, 1], offset: ?>>) outs(%subview_39 : memref<1x1x1x1xf32, strided<[256, 64, 16, 1], offset: ?>>) attrs =  {__xtc_id_conv_} {
+# CHECK-NEXT:                    ^bb0(%in: f32, %in_40: f32, %out: f32):
+# CHECK-NEXT:                      %2 = arith.mulf %in, %in_40 : f32
 # CHECK-NEXT:                      %3 = arith.addf %out, %2 : f32
 # CHECK-NEXT:                      linalg.yield %3 : f32
 # CHECK-NEXT:                    }

--- a/tests/filecheck/backends/padding/test_gen_pad_tuple_conv2d_mlir.py
+++ b/tests/filecheck/backends/padding/test_gen_pad_tuple_conv2d_mlir.py
@@ -57,7 +57,7 @@ print(f"CODE: {res}")
 # CHECK-NEXT:      transform.yield 
 # CHECK-NEXT:    }
 # CHECK-NEXT:    transform.named_sequence @__transform_main(%arg0: !transform.any_op {transform.readonly}) {
-# CHECK-NEXT:      %0 = transform.structured.match attributes {__xtc_id_pad_0_} in %arg0 : (!transform.any_op) -> !transform.any_op
+# CHECK-NEXT:      %0 = transform.structured.match attributes {__xtc_id_pad_} in %arg0 : (!transform.any_op) -> !transform.any_op
 # CHECK-NEXT:      %tiled_linalg_op, %loops = transform.structured.tile_using_for %0 tile_sizes [1, 0, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
 # CHECK-NEXT:      transform.annotate %loops "./i" : !transform.any_op
 # CHECK-NEXT:      %tiled_linalg_op_0, %loops_1 = transform.structured.tile_using_for %tiled_linalg_op tile_sizes [0, 1, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
@@ -66,39 +66,21 @@ print(f"CODE: {res}")
 # CHECK-NEXT:      transform.annotate %loops_3 "./k" : !transform.any_op
 # CHECK-NEXT:      %tiled_linalg_op_4, %loops_5 = transform.structured.tile_using_for %tiled_linalg_op_2 tile_sizes [0, 0, 0, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
 # CHECK-NEXT:      transform.annotate %loops_5 "./l" : !transform.any_op
-# CHECK-NEXT:      %1 = transform.structured.match attributes {__xtc_id_pad_} in %arg0 : (!transform.any_op) -> !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_6, %loops_7 = transform.structured.tile_using_for %1 tile_sizes [1, 0, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_7 "./i" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_8, %loops_9 = transform.structured.tile_using_for %tiled_linalg_op_6 tile_sizes [0, 1, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_9 "./j" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_10, %loops_11 = transform.structured.tile_using_for %tiled_linalg_op_8 tile_sizes [0, 0, 1, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_11 "./k" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_12, %loops_13 = transform.structured.tile_using_for %tiled_linalg_op_10 tile_sizes [0, 0, 0, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_13 "./l" : !transform.any_op
-# CHECK-NEXT:      %2 = transform.structured.match attributes {__xtc_id_conv_0_} in %arg0 : (!transform.any_op) -> !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_14, %loops_15 = transform.structured.tile_using_for %2 tile_sizes [1, 0, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_15 "./b" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_16, %loops_17 = transform.structured.tile_using_for %tiled_linalg_op_14 tile_sizes [0, 1, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_17 "./h" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_18, %loops_19 = transform.structured.tile_using_for %tiled_linalg_op_16 tile_sizes [0, 0, 1, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_19 "./w" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_20, %loops_21 = transform.structured.tile_using_for %tiled_linalg_op_18 tile_sizes [0, 0, 0, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_21 "./f" : !transform.any_op
-# CHECK-NEXT:      %3 = transform.structured.match attributes {__xtc_id_conv_} in %arg0 : (!transform.any_op) -> !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_22, %loops_23 = transform.structured.tile_using_for %3 tile_sizes [1, 0, 0, 0, 0, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_23 "./b" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_24, %loops_25 = transform.structured.tile_using_for %tiled_linalg_op_22 tile_sizes [0, 1, 0, 0, 0, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_25 "./h" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_26, %loops_27 = transform.structured.tile_using_for %tiled_linalg_op_24 tile_sizes [0, 0, 1, 0, 0, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_27 "./w" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_28, %loops_29 = transform.structured.tile_using_for %tiled_linalg_op_26 tile_sizes [0, 0, 0, 1, 0, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_29 "./f" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_30, %loops_31 = transform.structured.tile_using_for %tiled_linalg_op_28 tile_sizes [0, 0, 0, 0, 1, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_31 "./r" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_32, %loops_33 = transform.structured.tile_using_for %tiled_linalg_op_30 tile_sizes [0, 0, 0, 0, 0, 1, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_33 "./s" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_34, %loops_35 = transform.structured.tile_using_for %tiled_linalg_op_32 tile_sizes [0, 0, 0, 0, 0, 0, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_35 "./c" : !transform.any_op
+# CHECK-NEXT:      %1 = transform.structured.match attributes {__xtc_id_conv_} in %arg0 : (!transform.any_op) -> !transform.any_op
+# CHECK-NEXT:      %tiled_linalg_op_6, %loops_7 = transform.structured.tile_using_for %1 tile_sizes [1, 0, 0, 0, 0, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      transform.annotate %loops_7 "./b" : !transform.any_op
+# CHECK-NEXT:      %tiled_linalg_op_8, %loops_9 = transform.structured.tile_using_for %tiled_linalg_op_6 tile_sizes [0, 1, 0, 0, 0, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      transform.annotate %loops_9 "./h" : !transform.any_op
+# CHECK-NEXT:      %tiled_linalg_op_10, %loops_11 = transform.structured.tile_using_for %tiled_linalg_op_8 tile_sizes [0, 0, 1, 0, 0, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      transform.annotate %loops_11 "./w" : !transform.any_op
+# CHECK-NEXT:      %tiled_linalg_op_12, %loops_13 = transform.structured.tile_using_for %tiled_linalg_op_10 tile_sizes [0, 0, 0, 1, 0, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      transform.annotate %loops_13 "./f" : !transform.any_op
+# CHECK-NEXT:      %tiled_linalg_op_14, %loops_15 = transform.structured.tile_using_for %tiled_linalg_op_12 tile_sizes [0, 0, 0, 0, 1, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      transform.annotate %loops_15 "./r" : !transform.any_op
+# CHECK-NEXT:      %tiled_linalg_op_16, %loops_17 = transform.structured.tile_using_for %tiled_linalg_op_14 tile_sizes [0, 0, 0, 0, 0, 1, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      transform.annotate %loops_17 "./s" : !transform.any_op
+# CHECK-NEXT:      %tiled_linalg_op_18, %loops_19 = transform.structured.tile_using_for %tiled_linalg_op_16 tile_sizes [0, 0, 0, 0, 0, 0, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      transform.annotate %loops_19 "./c" : !transform.any_op
 # CHECK-NEXT:      transform.yield 
 # CHECK-NEXT:    }
 # CHECK-NEXT:  }
@@ -112,141 +94,93 @@ print(f"CODE: {res}")
 # CHECK-NEXT:    func.func @pad_conv2d_nhwc_mini(%arg0: memref<1x8x8x3xf32> {llvm.noalias}, %arg1: memref<5x5x3x16xf32> {llvm.noalias}, %arg2: memref<1x4x4x16xf32> {llvm.noalias}) {
 # CHECK-NEXT:      %alloca = memref.alloca() {alignment = 256 : i64} : memref<1x12x12x3xf32>
 # CHECK-NEXT:      %cst = arith.constant 0.000000e+00 : f32
+# CHECK-NEXT:      linalg.fill {__xtc_id_pad_0_} ins(%cst : f32) outs(%alloca : memref<1x12x12x3xf32>)
+# CHECK-NEXT:      %subview = memref.subview %alloca[0, 2, 2, 0] [1, 8, 8, 3] [1, 1, 1, 1] : memref<1x12x12x3xf32> to memref<1x8x8x3xf32, strided<[432, 36, 3, 1], offset: 78>>
 # CHECK-NEXT:      %c0 = arith.constant 0 : index
 # CHECK-NEXT:      %c1 = arith.constant 1 : index
 # CHECK-NEXT:      %c1_0 = arith.constant 1 : index
 # CHECK-NEXT:      scf.for %arg3 = %c0 to %c1 step %c1_0 {
-# CHECK-NEXT:        %subview_11 = memref.subview %alloca[%arg3, 0, 0, 0] [1, 12, 12, 3] [1, 1, 1, 1] : memref<1x12x12x3xf32> to memref<1x12x12x3xf32, strided<[432, 36, 3, 1], offset: ?>>
-# CHECK-NEXT:        %c0_12 = arith.constant 0 : index
-# CHECK-NEXT:        %c12 = arith.constant 12 : index
-# CHECK-NEXT:        %c1_13 = arith.constant 1 : index
-# CHECK-NEXT:        scf.for %arg4 = %c0_12 to %c12 step %c1_13 {
-# CHECK-NEXT:          %subview_14 = memref.subview %subview_11[0, %arg4, 0, 0] [1, 1, 12, 3] [1, 1, 1, 1] : memref<1x12x12x3xf32, strided<[432, 36, 3, 1], offset: ?>> to memref<1x1x12x3xf32, strided<[432, 36, 3, 1], offset: ?>>
-# CHECK-NEXT:          %c0_15 = arith.constant 0 : index
-# CHECK-NEXT:          %c12_16 = arith.constant 12 : index
-# CHECK-NEXT:          %c1_17 = arith.constant 1 : index
-# CHECK-NEXT:          scf.for %arg5 = %c0_15 to %c12_16 step %c1_17 {
-# CHECK-NEXT:            %subview_18 = memref.subview %subview_14[0, 0, %arg5, 0] [1, 1, 1, 3] [1, 1, 1, 1] : memref<1x1x12x3xf32, strided<[432, 36, 3, 1], offset: ?>> to memref<1x1x1x3xf32, strided<[432, 36, 3, 1], offset: ?>>
-# CHECK-NEXT:            %c0_19 = arith.constant 0 : index
-# CHECK-NEXT:            %c3 = arith.constant 3 : index
-# CHECK-NEXT:            %c1_20 = arith.constant 1 : index
-# CHECK-NEXT:            scf.for %arg6 = %c0_19 to %c3 step %c1_20 {
-# CHECK-NEXT:              %subview_21 = memref.subview %subview_18[0, 0, 0, %arg6] [1, 1, 1, 1] [1, 1, 1, 1] : memref<1x1x1x3xf32, strided<[432, 36, 3, 1], offset: ?>> to memref<1x1x1x1xf32, strided<[432, 36, 3, 1], offset: ?>>
-# CHECK-NEXT:              linalg.fill {__xtc_id_pad_0_} ins(%cst : f32) outs(%subview_21 : memref<1x1x1x1xf32, strided<[432, 36, 3, 1], offset: ?>>)
-# CHECK-NEXT:            } {"./l"}
-# CHECK-NEXT:          } {"./k"}
-# CHECK-NEXT:        } {"./j"}
-# CHECK-NEXT:      } {"./i"}
-# CHECK-NEXT:      %subview = memref.subview %alloca[0, 2, 2, 0] [1, 8, 8, 3] [1, 1, 1, 1] : memref<1x12x12x3xf32> to memref<1x8x8x3xf32, strided<[432, 36, 3, 1], offset: 78>>
-# CHECK-NEXT:      %c0_1 = arith.constant 0 : index
-# CHECK-NEXT:      %c1_2 = arith.constant 1 : index
-# CHECK-NEXT:      %c1_3 = arith.constant 1 : index
-# CHECK-NEXT:      scf.for %arg3 = %c0_1 to %c1_2 step %c1_3 {
-# CHECK-NEXT:        %subview_11 = memref.subview %arg0[%arg3, 0, 0, 0] [1, 8, 8, 3] [1, 1, 1, 1] : memref<1x8x8x3xf32> to memref<1x8x8x3xf32, strided<[192, 24, 3, 1], offset: ?>>
-# CHECK-NEXT:        %subview_12 = memref.subview %subview[%arg3, 0, 0, 0] [1, 8, 8, 3] [1, 1, 1, 1] : memref<1x8x8x3xf32, strided<[432, 36, 3, 1], offset: 78>> to memref<1x8x8x3xf32, strided<[432, 36, 3, 1], offset: ?>>
-# CHECK-NEXT:        %c0_13 = arith.constant 0 : index
+# CHECK-NEXT:        %subview_5 = memref.subview %arg0[%arg3, 0, 0, 0] [1, 8, 8, 3] [1, 1, 1, 1] : memref<1x8x8x3xf32> to memref<1x8x8x3xf32, strided<[192, 24, 3, 1], offset: ?>>
+# CHECK-NEXT:        %subview_6 = memref.subview %subview[%arg3, 0, 0, 0] [1, 8, 8, 3] [1, 1, 1, 1] : memref<1x8x8x3xf32, strided<[432, 36, 3, 1], offset: 78>> to memref<1x8x8x3xf32, strided<[432, 36, 3, 1], offset: ?>>
+# CHECK-NEXT:        %c0_7 = arith.constant 0 : index
 # CHECK-NEXT:        %c8 = arith.constant 8 : index
-# CHECK-NEXT:        %c1_14 = arith.constant 1 : index
-# CHECK-NEXT:        scf.for %arg4 = %c0_13 to %c8 step %c1_14 {
-# CHECK-NEXT:          %subview_15 = memref.subview %subview_11[0, %arg4, 0, 0] [1, 1, 8, 3] [1, 1, 1, 1] : memref<1x8x8x3xf32, strided<[192, 24, 3, 1], offset: ?>> to memref<1x1x8x3xf32, strided<[192, 24, 3, 1], offset: ?>>
-# CHECK-NEXT:          %subview_16 = memref.subview %subview_12[0, %arg4, 0, 0] [1, 1, 8, 3] [1, 1, 1, 1] : memref<1x8x8x3xf32, strided<[432, 36, 3, 1], offset: ?>> to memref<1x1x8x3xf32, strided<[432, 36, 3, 1], offset: ?>>
-# CHECK-NEXT:          %c0_17 = arith.constant 0 : index
-# CHECK-NEXT:          %c8_18 = arith.constant 8 : index
-# CHECK-NEXT:          %c1_19 = arith.constant 1 : index
-# CHECK-NEXT:          scf.for %arg5 = %c0_17 to %c8_18 step %c1_19 {
-# CHECK-NEXT:            %subview_20 = memref.subview %subview_15[0, 0, %arg5, 0] [1, 1, 1, 3] [1, 1, 1, 1] : memref<1x1x8x3xf32, strided<[192, 24, 3, 1], offset: ?>> to memref<1x1x1x3xf32, strided<[192, 24, 3, 1], offset: ?>>
-# CHECK-NEXT:            %subview_21 = memref.subview %subview_16[0, 0, %arg5, 0] [1, 1, 1, 3] [1, 1, 1, 1] : memref<1x1x8x3xf32, strided<[432, 36, 3, 1], offset: ?>> to memref<1x1x1x3xf32, strided<[432, 36, 3, 1], offset: ?>>
-# CHECK-NEXT:            %c0_22 = arith.constant 0 : index
+# CHECK-NEXT:        %c1_8 = arith.constant 1 : index
+# CHECK-NEXT:        scf.for %arg4 = %c0_7 to %c8 step %c1_8 {
+# CHECK-NEXT:          %subview_9 = memref.subview %subview_5[0, %arg4, 0, 0] [1, 1, 8, 3] [1, 1, 1, 1] : memref<1x8x8x3xf32, strided<[192, 24, 3, 1], offset: ?>> to memref<1x1x8x3xf32, strided<[192, 24, 3, 1], offset: ?>>
+# CHECK-NEXT:          %subview_10 = memref.subview %subview_6[0, %arg4, 0, 0] [1, 1, 8, 3] [1, 1, 1, 1] : memref<1x8x8x3xf32, strided<[432, 36, 3, 1], offset: ?>> to memref<1x1x8x3xf32, strided<[432, 36, 3, 1], offset: ?>>
+# CHECK-NEXT:          %c0_11 = arith.constant 0 : index
+# CHECK-NEXT:          %c8_12 = arith.constant 8 : index
+# CHECK-NEXT:          %c1_13 = arith.constant 1 : index
+# CHECK-NEXT:          scf.for %arg5 = %c0_11 to %c8_12 step %c1_13 {
+# CHECK-NEXT:            %subview_14 = memref.subview %subview_9[0, 0, %arg5, 0] [1, 1, 1, 3] [1, 1, 1, 1] : memref<1x1x8x3xf32, strided<[192, 24, 3, 1], offset: ?>> to memref<1x1x1x3xf32, strided<[192, 24, 3, 1], offset: ?>>
+# CHECK-NEXT:            %subview_15 = memref.subview %subview_10[0, 0, %arg5, 0] [1, 1, 1, 3] [1, 1, 1, 1] : memref<1x1x8x3xf32, strided<[432, 36, 3, 1], offset: ?>> to memref<1x1x1x3xf32, strided<[432, 36, 3, 1], offset: ?>>
+# CHECK-NEXT:            %c0_16 = arith.constant 0 : index
 # CHECK-NEXT:            %c3 = arith.constant 3 : index
-# CHECK-NEXT:            %c1_23 = arith.constant 1 : index
-# CHECK-NEXT:            scf.for %arg6 = %c0_22 to %c3 step %c1_23 {
-# CHECK-NEXT:              %subview_24 = memref.subview %subview_20[0, 0, 0, %arg6] [1, 1, 1, 1] [1, 1, 1, 1] : memref<1x1x1x3xf32, strided<[192, 24, 3, 1], offset: ?>> to memref<1x1x1x1xf32, strided<[192, 24, 3, 1], offset: ?>>
-# CHECK-NEXT:              %subview_25 = memref.subview %subview_21[0, 0, 0, %arg6] [1, 1, 1, 1] [1, 1, 1, 1] : memref<1x1x1x3xf32, strided<[432, 36, 3, 1], offset: ?>> to memref<1x1x1x1xf32, strided<[432, 36, 3, 1], offset: ?>>
-# CHECK-NEXT:              linalg.copy {__xtc_id_pad_} ins(%subview_24 : memref<1x1x1x1xf32, strided<[192, 24, 3, 1], offset: ?>>) outs(%subview_25 : memref<1x1x1x1xf32, strided<[432, 36, 3, 1], offset: ?>>)
+# CHECK-NEXT:            %c1_17 = arith.constant 1 : index
+# CHECK-NEXT:            scf.for %arg6 = %c0_16 to %c3 step %c1_17 {
+# CHECK-NEXT:              %subview_18 = memref.subview %subview_14[0, 0, 0, %arg6] [1, 1, 1, 1] [1, 1, 1, 1] : memref<1x1x1x3xf32, strided<[192, 24, 3, 1], offset: ?>> to memref<1x1x1x1xf32, strided<[192, 24, 3, 1], offset: ?>>
+# CHECK-NEXT:              %subview_19 = memref.subview %subview_15[0, 0, 0, %arg6] [1, 1, 1, 1] [1, 1, 1, 1] : memref<1x1x1x3xf32, strided<[432, 36, 3, 1], offset: ?>> to memref<1x1x1x1xf32, strided<[432, 36, 3, 1], offset: ?>>
+# CHECK-NEXT:              linalg.copy {__xtc_id_pad_} ins(%subview_18 : memref<1x1x1x1xf32, strided<[192, 24, 3, 1], offset: ?>>) outs(%subview_19 : memref<1x1x1x1xf32, strided<[432, 36, 3, 1], offset: ?>>)
 # CHECK-NEXT:            } {"./l"}
 # CHECK-NEXT:          } {"./k"}
 # CHECK-NEXT:        } {"./j"}
 # CHECK-NEXT:      } {"./i"}
-# CHECK-NEXT:      %cst_4 = arith.constant 0.000000e+00 : f32
-# CHECK-NEXT:      %c0_5 = arith.constant 0 : index
-# CHECK-NEXT:      %c1_6 = arith.constant 1 : index
-# CHECK-NEXT:      %c1_7 = arith.constant 1 : index
-# CHECK-NEXT:      scf.for %arg3 = %c0_5 to %c1_6 step %c1_7 {
-# CHECK-NEXT:        %subview_11 = memref.subview %arg2[%arg3, 0, 0, 0] [1, 4, 4, 16] [1, 1, 1, 1] : memref<1x4x4x16xf32> to memref<1x4x4x16xf32, strided<[256, 64, 16, 1], offset: ?>>
-# CHECK-NEXT:        %c0_12 = arith.constant 0 : index
+# CHECK-NEXT:      %cst_1 = arith.constant 0.000000e+00 : f32
+# CHECK-NEXT:      linalg.fill {__xtc_id_conv_0_} ins(%cst_1 : f32) outs(%arg2 : memref<1x4x4x16xf32>)
+# CHECK-NEXT:      %c0_2 = arith.constant 0 : index
+# CHECK-NEXT:      %c1_3 = arith.constant 1 : index
+# CHECK-NEXT:      %c1_4 = arith.constant 1 : index
+# CHECK-NEXT:      scf.for %arg3 = %c0_2 to %c1_3 step %c1_4 {
+# CHECK-NEXT:        %subview_5 = memref.subview %alloca[%arg3, 0, 0, 0] [1, 11, 11, 3] [1, 1, 1, 1] : memref<1x12x12x3xf32> to memref<1x11x11x3xf32, strided<[432, 36, 3, 1], offset: ?>>
+# CHECK-NEXT:        %subview_6 = memref.subview %arg1[0, 0, 0, 0] [5, 5, 3, 16] [1, 1, 1, 1] : memref<5x5x3x16xf32> to memref<5x5x3x16xf32, strided<[240, 48, 16, 1]>>
+# CHECK-NEXT:        %subview_7 = memref.subview %arg2[%arg3, 0, 0, 0] [1, 4, 4, 16] [1, 1, 1, 1] : memref<1x4x4x16xf32> to memref<1x4x4x16xf32, strided<[256, 64, 16, 1], offset: ?>>
+# CHECK-NEXT:        %c0_8 = arith.constant 0 : index
 # CHECK-NEXT:        %c4 = arith.constant 4 : index
-# CHECK-NEXT:        %c1_13 = arith.constant 1 : index
-# CHECK-NEXT:        scf.for %arg4 = %c0_12 to %c4 step %c1_13 {
-# CHECK-NEXT:          %subview_14 = memref.subview %subview_11[0, %arg4, 0, 0] [1, 1, 4, 16] [1, 1, 1, 1] : memref<1x4x4x16xf32, strided<[256, 64, 16, 1], offset: ?>> to memref<1x1x4x16xf32, strided<[256, 64, 16, 1], offset: ?>>
-# CHECK-NEXT:          %c0_15 = arith.constant 0 : index
-# CHECK-NEXT:          %c4_16 = arith.constant 4 : index
-# CHECK-NEXT:          %c1_17 = arith.constant 1 : index
-# CHECK-NEXT:          scf.for %arg5 = %c0_15 to %c4_16 step %c1_17 {
-# CHECK-NEXT:            %subview_18 = memref.subview %subview_14[0, 0, %arg5, 0] [1, 1, 1, 16] [1, 1, 1, 1] : memref<1x1x4x16xf32, strided<[256, 64, 16, 1], offset: ?>> to memref<1x1x1x16xf32, strided<[256, 64, 16, 1], offset: ?>>
+# CHECK-NEXT:        %c1_9 = arith.constant 1 : index
+# CHECK-NEXT:        scf.for %arg4 = %c0_8 to %c4 step %c1_9 {
+# CHECK-NEXT:          %0 = affine.apply #map(%arg4)
+# CHECK-NEXT:          %subview_10 = memref.subview %subview_5[0, %0, 0, 0] [1, 5, 11, 3] [1, 1, 1, 1] : memref<1x11x11x3xf32, strided<[432, 36, 3, 1], offset: ?>> to memref<1x5x11x3xf32, strided<[432, 36, 3, 1], offset: ?>>
+# CHECK-NEXT:          %subview_11 = memref.subview %subview_6[0, 0, 0, 0] [5, 5, 3, 16] [1, 1, 1, 1] : memref<5x5x3x16xf32, strided<[240, 48, 16, 1]>> to memref<5x5x3x16xf32, strided<[240, 48, 16, 1]>>
+# CHECK-NEXT:          %subview_12 = memref.subview %subview_7[0, %arg4, 0, 0] [1, 1, 4, 16] [1, 1, 1, 1] : memref<1x4x4x16xf32, strided<[256, 64, 16, 1], offset: ?>> to memref<1x1x4x16xf32, strided<[256, 64, 16, 1], offset: ?>>
+# CHECK-NEXT:          %c0_13 = arith.constant 0 : index
+# CHECK-NEXT:          %c4_14 = arith.constant 4 : index
+# CHECK-NEXT:          %c1_15 = arith.constant 1 : index
+# CHECK-NEXT:          scf.for %arg5 = %c0_13 to %c4_14 step %c1_15 {
+# CHECK-NEXT:            %1 = affine.apply #map(%arg5)
+# CHECK-NEXT:            %subview_16 = memref.subview %subview_10[0, 0, %1, 0] [1, 5, 5, 3] [1, 1, 1, 1] : memref<1x5x11x3xf32, strided<[432, 36, 3, 1], offset: ?>> to memref<1x5x5x3xf32, strided<[432, 36, 3, 1], offset: ?>>
+# CHECK-NEXT:            %subview_17 = memref.subview %subview_11[0, 0, 0, 0] [5, 5, 3, 16] [1, 1, 1, 1] : memref<5x5x3x16xf32, strided<[240, 48, 16, 1]>> to memref<5x5x3x16xf32, strided<[240, 48, 16, 1]>>
+# CHECK-NEXT:            %subview_18 = memref.subview %subview_12[0, 0, %arg5, 0] [1, 1, 1, 16] [1, 1, 1, 1] : memref<1x1x4x16xf32, strided<[256, 64, 16, 1], offset: ?>> to memref<1x1x1x16xf32, strided<[256, 64, 16, 1], offset: ?>>
 # CHECK-NEXT:            %c0_19 = arith.constant 0 : index
 # CHECK-NEXT:            %c16 = arith.constant 16 : index
 # CHECK-NEXT:            %c1_20 = arith.constant 1 : index
 # CHECK-NEXT:            scf.for %arg6 = %c0_19 to %c16 step %c1_20 {
-# CHECK-NEXT:              %subview_21 = memref.subview %subview_18[0, 0, 0, %arg6] [1, 1, 1, 1] [1, 1, 1, 1] : memref<1x1x1x16xf32, strided<[256, 64, 16, 1], offset: ?>> to memref<1x1x1x1xf32, strided<[256, 64, 16, 1], offset: ?>>
-# CHECK-NEXT:              linalg.fill {__xtc_id_conv_0_} ins(%cst_4 : f32) outs(%subview_21 : memref<1x1x1x1xf32, strided<[256, 64, 16, 1], offset: ?>>)
-# CHECK-NEXT:            } {"./f"}
-# CHECK-NEXT:          } {"./w"}
-# CHECK-NEXT:        } {"./h"}
-# CHECK-NEXT:      } {"./b"}
-# CHECK-NEXT:      %c0_8 = arith.constant 0 : index
-# CHECK-NEXT:      %c1_9 = arith.constant 1 : index
-# CHECK-NEXT:      %c1_10 = arith.constant 1 : index
-# CHECK-NEXT:      scf.for %arg3 = %c0_8 to %c1_9 step %c1_10 {
-# CHECK-NEXT:        %subview_11 = memref.subview %alloca[%arg3, 0, 0, 0] [1, 11, 11, 3] [1, 1, 1, 1] : memref<1x12x12x3xf32> to memref<1x11x11x3xf32, strided<[432, 36, 3, 1], offset: ?>>
-# CHECK-NEXT:        %subview_12 = memref.subview %arg1[0, 0, 0, 0] [5, 5, 3, 16] [1, 1, 1, 1] : memref<5x5x3x16xf32> to memref<5x5x3x16xf32, strided<[240, 48, 16, 1]>>
-# CHECK-NEXT:        %subview_13 = memref.subview %arg2[%arg3, 0, 0, 0] [1, 4, 4, 16] [1, 1, 1, 1] : memref<1x4x4x16xf32> to memref<1x4x4x16xf32, strided<[256, 64, 16, 1], offset: ?>>
-# CHECK-NEXT:        %c0_14 = arith.constant 0 : index
-# CHECK-NEXT:        %c4 = arith.constant 4 : index
-# CHECK-NEXT:        %c1_15 = arith.constant 1 : index
-# CHECK-NEXT:        scf.for %arg4 = %c0_14 to %c4 step %c1_15 {
-# CHECK-NEXT:          %0 = affine.apply #map(%arg4)
-# CHECK-NEXT:          %subview_16 = memref.subview %subview_11[0, %0, 0, 0] [1, 5, 11, 3] [1, 1, 1, 1] : memref<1x11x11x3xf32, strided<[432, 36, 3, 1], offset: ?>> to memref<1x5x11x3xf32, strided<[432, 36, 3, 1], offset: ?>>
-# CHECK-NEXT:          %subview_17 = memref.subview %subview_12[0, 0, 0, 0] [5, 5, 3, 16] [1, 1, 1, 1] : memref<5x5x3x16xf32, strided<[240, 48, 16, 1]>> to memref<5x5x3x16xf32, strided<[240, 48, 16, 1]>>
-# CHECK-NEXT:          %subview_18 = memref.subview %subview_13[0, %arg4, 0, 0] [1, 1, 4, 16] [1, 1, 1, 1] : memref<1x4x4x16xf32, strided<[256, 64, 16, 1], offset: ?>> to memref<1x1x4x16xf32, strided<[256, 64, 16, 1], offset: ?>>
-# CHECK-NEXT:          %c0_19 = arith.constant 0 : index
-# CHECK-NEXT:          %c4_20 = arith.constant 4 : index
-# CHECK-NEXT:          %c1_21 = arith.constant 1 : index
-# CHECK-NEXT:          scf.for %arg5 = %c0_19 to %c4_20 step %c1_21 {
-# CHECK-NEXT:            %1 = affine.apply #map(%arg5)
-# CHECK-NEXT:            %subview_22 = memref.subview %subview_16[0, 0, %1, 0] [1, 5, 5, 3] [1, 1, 1, 1] : memref<1x5x11x3xf32, strided<[432, 36, 3, 1], offset: ?>> to memref<1x5x5x3xf32, strided<[432, 36, 3, 1], offset: ?>>
-# CHECK-NEXT:            %subview_23 = memref.subview %subview_17[0, 0, 0, 0] [5, 5, 3, 16] [1, 1, 1, 1] : memref<5x5x3x16xf32, strided<[240, 48, 16, 1]>> to memref<5x5x3x16xf32, strided<[240, 48, 16, 1]>>
-# CHECK-NEXT:            %subview_24 = memref.subview %subview_18[0, 0, %arg5, 0] [1, 1, 1, 16] [1, 1, 1, 1] : memref<1x1x4x16xf32, strided<[256, 64, 16, 1], offset: ?>> to memref<1x1x1x16xf32, strided<[256, 64, 16, 1], offset: ?>>
-# CHECK-NEXT:            %c0_25 = arith.constant 0 : index
-# CHECK-NEXT:            %c16 = arith.constant 16 : index
-# CHECK-NEXT:            %c1_26 = arith.constant 1 : index
-# CHECK-NEXT:            scf.for %arg6 = %c0_25 to %c16 step %c1_26 {
-# CHECK-NEXT:              %subview_27 = memref.subview %subview_22[0, 0, 0, 0] [1, 5, 5, 3] [1, 1, 1, 1] : memref<1x5x5x3xf32, strided<[432, 36, 3, 1], offset: ?>> to memref<1x5x5x3xf32, strided<[432, 36, 3, 1], offset: ?>>
-# CHECK-NEXT:              %subview_28 = memref.subview %subview_23[0, 0, 0, %arg6] [5, 5, 3, 1] [1, 1, 1, 1] : memref<5x5x3x16xf32, strided<[240, 48, 16, 1]>> to memref<5x5x3x1xf32, strided<[240, 48, 16, 1], offset: ?>>
-# CHECK-NEXT:              %subview_29 = memref.subview %subview_24[0, 0, 0, %arg6] [1, 1, 1, 1] [1, 1, 1, 1] : memref<1x1x1x16xf32, strided<[256, 64, 16, 1], offset: ?>> to memref<1x1x1x1xf32, strided<[256, 64, 16, 1], offset: ?>>
-# CHECK-NEXT:              %c0_30 = arith.constant 0 : index
+# CHECK-NEXT:              %subview_21 = memref.subview %subview_16[0, 0, 0, 0] [1, 5, 5, 3] [1, 1, 1, 1] : memref<1x5x5x3xf32, strided<[432, 36, 3, 1], offset: ?>> to memref<1x5x5x3xf32, strided<[432, 36, 3, 1], offset: ?>>
+# CHECK-NEXT:              %subview_22 = memref.subview %subview_17[0, 0, 0, %arg6] [5, 5, 3, 1] [1, 1, 1, 1] : memref<5x5x3x16xf32, strided<[240, 48, 16, 1]>> to memref<5x5x3x1xf32, strided<[240, 48, 16, 1], offset: ?>>
+# CHECK-NEXT:              %subview_23 = memref.subview %subview_18[0, 0, 0, %arg6] [1, 1, 1, 1] [1, 1, 1, 1] : memref<1x1x1x16xf32, strided<[256, 64, 16, 1], offset: ?>> to memref<1x1x1x1xf32, strided<[256, 64, 16, 1], offset: ?>>
+# CHECK-NEXT:              %c0_24 = arith.constant 0 : index
 # CHECK-NEXT:              %c5 = arith.constant 5 : index
-# CHECK-NEXT:              %c1_31 = arith.constant 1 : index
-# CHECK-NEXT:              scf.for %arg7 = %c0_30 to %c5 step %c1_31 {
-# CHECK-NEXT:                %subview_32 = memref.subview %subview_27[0, %arg7, 0, 0] [1, 1, 5, 3] [1, 1, 1, 1] : memref<1x5x5x3xf32, strided<[432, 36, 3, 1], offset: ?>> to memref<1x1x5x3xf32, strided<[432, 36, 3, 1], offset: ?>>
-# CHECK-NEXT:                %subview_33 = memref.subview %subview_28[%arg7, 0, 0, 0] [1, 5, 3, 1] [1, 1, 1, 1] : memref<5x5x3x1xf32, strided<[240, 48, 16, 1], offset: ?>> to memref<1x5x3x1xf32, strided<[240, 48, 16, 1], offset: ?>>
-# CHECK-NEXT:                %subview_34 = memref.subview %subview_29[0, 0, 0, 0] [1, 1, 1, 1] [1, 1, 1, 1] : memref<1x1x1x1xf32, strided<[256, 64, 16, 1], offset: ?>> to memref<1x1x1x1xf32, strided<[256, 64, 16, 1], offset: ?>>
-# CHECK-NEXT:                %c0_35 = arith.constant 0 : index
-# CHECK-NEXT:                %c5_36 = arith.constant 5 : index
-# CHECK-NEXT:                %c1_37 = arith.constant 1 : index
-# CHECK-NEXT:                scf.for %arg8 = %c0_35 to %c5_36 step %c1_37 {
-# CHECK-NEXT:                  %subview_38 = memref.subview %subview_32[0, 0, %arg8, 0] [1, 1, 1, 3] [1, 1, 1, 1] : memref<1x1x5x3xf32, strided<[432, 36, 3, 1], offset: ?>> to memref<1x1x1x3xf32, strided<[432, 36, 3, 1], offset: ?>>
-# CHECK-NEXT:                  %subview_39 = memref.subview %subview_33[0, %arg8, 0, 0] [1, 1, 3, 1] [1, 1, 1, 1] : memref<1x5x3x1xf32, strided<[240, 48, 16, 1], offset: ?>> to memref<1x1x3x1xf32, strided<[240, 48, 16, 1], offset: ?>>
-# CHECK-NEXT:                  %subview_40 = memref.subview %subview_34[0, 0, 0, 0] [1, 1, 1, 1] [1, 1, 1, 1] : memref<1x1x1x1xf32, strided<[256, 64, 16, 1], offset: ?>> to memref<1x1x1x1xf32, strided<[256, 64, 16, 1], offset: ?>>
-# CHECK-NEXT:                  %c0_41 = arith.constant 0 : index
+# CHECK-NEXT:              %c1_25 = arith.constant 1 : index
+# CHECK-NEXT:              scf.for %arg7 = %c0_24 to %c5 step %c1_25 {
+# CHECK-NEXT:                %subview_26 = memref.subview %subview_21[0, %arg7, 0, 0] [1, 1, 5, 3] [1, 1, 1, 1] : memref<1x5x5x3xf32, strided<[432, 36, 3, 1], offset: ?>> to memref<1x1x5x3xf32, strided<[432, 36, 3, 1], offset: ?>>
+# CHECK-NEXT:                %subview_27 = memref.subview %subview_22[%arg7, 0, 0, 0] [1, 5, 3, 1] [1, 1, 1, 1] : memref<5x5x3x1xf32, strided<[240, 48, 16, 1], offset: ?>> to memref<1x5x3x1xf32, strided<[240, 48, 16, 1], offset: ?>>
+# CHECK-NEXT:                %subview_28 = memref.subview %subview_23[0, 0, 0, 0] [1, 1, 1, 1] [1, 1, 1, 1] : memref<1x1x1x1xf32, strided<[256, 64, 16, 1], offset: ?>> to memref<1x1x1x1xf32, strided<[256, 64, 16, 1], offset: ?>>
+# CHECK-NEXT:                %c0_29 = arith.constant 0 : index
+# CHECK-NEXT:                %c5_30 = arith.constant 5 : index
+# CHECK-NEXT:                %c1_31 = arith.constant 1 : index
+# CHECK-NEXT:                scf.for %arg8 = %c0_29 to %c5_30 step %c1_31 {
+# CHECK-NEXT:                  %subview_32 = memref.subview %subview_26[0, 0, %arg8, 0] [1, 1, 1, 3] [1, 1, 1, 1] : memref<1x1x5x3xf32, strided<[432, 36, 3, 1], offset: ?>> to memref<1x1x1x3xf32, strided<[432, 36, 3, 1], offset: ?>>
+# CHECK-NEXT:                  %subview_33 = memref.subview %subview_27[0, %arg8, 0, 0] [1, 1, 3, 1] [1, 1, 1, 1] : memref<1x5x3x1xf32, strided<[240, 48, 16, 1], offset: ?>> to memref<1x1x3x1xf32, strided<[240, 48, 16, 1], offset: ?>>
+# CHECK-NEXT:                  %subview_34 = memref.subview %subview_28[0, 0, 0, 0] [1, 1, 1, 1] [1, 1, 1, 1] : memref<1x1x1x1xf32, strided<[256, 64, 16, 1], offset: ?>> to memref<1x1x1x1xf32, strided<[256, 64, 16, 1], offset: ?>>
+# CHECK-NEXT:                  %c0_35 = arith.constant 0 : index
 # CHECK-NEXT:                  %c3 = arith.constant 3 : index
-# CHECK-NEXT:                  %c1_42 = arith.constant 1 : index
-# CHECK-NEXT:                  scf.for %arg9 = %c0_41 to %c3 step %c1_42 {
-# CHECK-NEXT:                    %subview_43 = memref.subview %subview_38[0, 0, 0, %arg9] [1, 1, 1, 1] [1, 1, 1, 1] : memref<1x1x1x3xf32, strided<[432, 36, 3, 1], offset: ?>> to memref<1x1x1x1xf32, strided<[432, 36, 3, 1], offset: ?>>
-# CHECK-NEXT:                    %subview_44 = memref.subview %subview_39[0, 0, %arg9, 0] [1, 1, 1, 1] [1, 1, 1, 1] : memref<1x1x3x1xf32, strided<[240, 48, 16, 1], offset: ?>> to memref<1x1x1x1xf32, strided<[240, 48, 16, 1], offset: ?>>
-# CHECK-NEXT:                    %subview_45 = memref.subview %subview_40[0, 0, 0, 0] [1, 1, 1, 1] [1, 1, 1, 1] : memref<1x1x1x1xf32, strided<[256, 64, 16, 1], offset: ?>> to memref<1x1x1x1xf32, strided<[256, 64, 16, 1], offset: ?>>
-# CHECK-NEXT:                    linalg.generic {indexing_maps = [#map1, #map2, #map3], iterator_types = ["parallel", "parallel", "parallel", "parallel", "reduction", "reduction", "reduction"]} ins(%subview_43, %subview_44 : memref<1x1x1x1xf32, strided<[432, 36, 3, 1], offset: ?>>, memref<1x1x1x1xf32, strided<[240, 48, 16, 1], offset: ?>>) outs(%subview_45 : memref<1x1x1x1xf32, strided<[256, 64, 16, 1], offset: ?>>) attrs =  {__xtc_id_conv_} {
-# CHECK-NEXT:                    ^bb0(%in: f32, %in_46: f32, %out: f32):
-# CHECK-NEXT:                      %2 = arith.mulf %in, %in_46 fastmath<fast> : f32
+# CHECK-NEXT:                  %c1_36 = arith.constant 1 : index
+# CHECK-NEXT:                  scf.for %arg9 = %c0_35 to %c3 step %c1_36 {
+# CHECK-NEXT:                    %subview_37 = memref.subview %subview_32[0, 0, 0, %arg9] [1, 1, 1, 1] [1, 1, 1, 1] : memref<1x1x1x3xf32, strided<[432, 36, 3, 1], offset: ?>> to memref<1x1x1x1xf32, strided<[432, 36, 3, 1], offset: ?>>
+# CHECK-NEXT:                    %subview_38 = memref.subview %subview_33[0, 0, %arg9, 0] [1, 1, 1, 1] [1, 1, 1, 1] : memref<1x1x3x1xf32, strided<[240, 48, 16, 1], offset: ?>> to memref<1x1x1x1xf32, strided<[240, 48, 16, 1], offset: ?>>
+# CHECK-NEXT:                    %subview_39 = memref.subview %subview_34[0, 0, 0, 0] [1, 1, 1, 1] [1, 1, 1, 1] : memref<1x1x1x1xf32, strided<[256, 64, 16, 1], offset: ?>> to memref<1x1x1x1xf32, strided<[256, 64, 16, 1], offset: ?>>
+# CHECK-NEXT:                    linalg.generic {indexing_maps = [#map1, #map2, #map3], iterator_types = ["parallel", "parallel", "parallel", "parallel", "reduction", "reduction", "reduction"]} ins(%subview_37, %subview_38 : memref<1x1x1x1xf32, strided<[432, 36, 3, 1], offset: ?>>, memref<1x1x1x1xf32, strided<[240, 48, 16, 1], offset: ?>>) outs(%subview_39 : memref<1x1x1x1xf32, strided<[256, 64, 16, 1], offset: ?>>) attrs =  {__xtc_id_conv_} {
+# CHECK-NEXT:                    ^bb0(%in: f32, %in_40: f32, %out: f32):
+# CHECK-NEXT:                      %2 = arith.mulf %in, %in_40 fastmath<fast> : f32
 # CHECK-NEXT:                      %3 = arith.addf %out, %2 fastmath<fast> : f32
 # CHECK-NEXT:                      linalg.yield %3 : f32
 # CHECK-NEXT:                    }

--- a/tests/filecheck/backends/padding/test_gen_pad_tuple_matmul_unpad_mlir.py
+++ b/tests/filecheck/backends/padding/test_gen_pad_tuple_matmul_unpad_mlir.py
@@ -57,43 +57,28 @@ print(f"CODE: {res}")
 # CHECK-NEXT:      transform.yield 
 # CHECK-NEXT:    }
 # CHECK-NEXT:    transform.named_sequence @__transform_main(%arg0: !transform.any_op {transform.readonly}) {
-# CHECK-NEXT:      %0 = transform.structured.match attributes {__xtc_id_A_pad_0_} in %arg0 : (!transform.any_op) -> !transform.any_op
+# CHECK-NEXT:      %0 = transform.structured.match attributes {__xtc_id_A_pad_} in %arg0 : (!transform.any_op) -> !transform.any_op
 # CHECK-NEXT:      %tiled_linalg_op, %loops = transform.structured.tile_using_for %0 tile_sizes [1, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
 # CHECK-NEXT:      transform.annotate %loops "./i" : !transform.any_op
 # CHECK-NEXT:      %tiled_linalg_op_0, %loops_1 = transform.structured.tile_using_for %tiled_linalg_op tile_sizes [0, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
 # CHECK-NEXT:      transform.annotate %loops_1 "./j" : !transform.any_op
-# CHECK-NEXT:      %1 = transform.structured.match attributes {__xtc_id_A_pad_} in %arg0 : (!transform.any_op) -> !transform.any_op
+# CHECK-NEXT:      %1 = transform.structured.match attributes {__xtc_id_B_pad_} in %arg0 : (!transform.any_op) -> !transform.any_op
 # CHECK-NEXT:      %tiled_linalg_op_2, %loops_3 = transform.structured.tile_using_for %1 tile_sizes [1, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
 # CHECK-NEXT:      transform.annotate %loops_3 "./i" : !transform.any_op
 # CHECK-NEXT:      %tiled_linalg_op_4, %loops_5 = transform.structured.tile_using_for %tiled_linalg_op_2 tile_sizes [0, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
 # CHECK-NEXT:      transform.annotate %loops_5 "./j" : !transform.any_op
-# CHECK-NEXT:      %2 = transform.structured.match attributes {__xtc_id_B_pad_0_} in %arg0 : (!transform.any_op) -> !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_6, %loops_7 = transform.structured.tile_using_for %2 tile_sizes [1, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      %2 = transform.structured.match attributes {__xtc_id_matmul_padded_} in %arg0 : (!transform.any_op) -> !transform.any_op
+# CHECK-NEXT:      %tiled_linalg_op_6, %loops_7 = transform.structured.tile_using_for %2 tile_sizes [1, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
 # CHECK-NEXT:      transform.annotate %loops_7 "./i" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_8, %loops_9 = transform.structured.tile_using_for %tiled_linalg_op_6 tile_sizes [0, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      %tiled_linalg_op_8, %loops_9 = transform.structured.tile_using_for %tiled_linalg_op_6 tile_sizes [0, 1, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
 # CHECK-NEXT:      transform.annotate %loops_9 "./j" : !transform.any_op
-# CHECK-NEXT:      %3 = transform.structured.match attributes {__xtc_id_B_pad_} in %arg0 : (!transform.any_op) -> !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_10, %loops_11 = transform.structured.tile_using_for %3 tile_sizes [1, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_11 "./i" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_12, %loops_13 = transform.structured.tile_using_for %tiled_linalg_op_10 tile_sizes [0, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_13 "./j" : !transform.any_op
-# CHECK-NEXT:      %4 = transform.structured.match attributes {__xtc_id_matmul_padded_0_} in %arg0 : (!transform.any_op) -> !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_14, %loops_15 = transform.structured.tile_using_for %4 tile_sizes [1, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_15 "./i" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_16, %loops_17 = transform.structured.tile_using_for %tiled_linalg_op_14 tile_sizes [0, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_17 "./j" : !transform.any_op
-# CHECK-NEXT:      %5 = transform.structured.match attributes {__xtc_id_matmul_padded_} in %arg0 : (!transform.any_op) -> !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_18, %loops_19 = transform.structured.tile_using_for %5 tile_sizes [1, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_19 "./i" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_20, %loops_21 = transform.structured.tile_using_for %tiled_linalg_op_18 tile_sizes [0, 1, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_21 "./j" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_22, %loops_23 = transform.structured.tile_using_for %tiled_linalg_op_20 tile_sizes [0, 0, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_23 "./k" : !transform.any_op
-# CHECK-NEXT:      %6 = transform.structured.match attributes {__xtc_id_C_} in %arg0 : (!transform.any_op) -> !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_24, %loops_25 = transform.structured.tile_using_for %6 tile_sizes [1, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_25 "./i" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_26, %loops_27 = transform.structured.tile_using_for %tiled_linalg_op_24 tile_sizes [0, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_27 "./j" : !transform.any_op
+# CHECK-NEXT:      %tiled_linalg_op_10, %loops_11 = transform.structured.tile_using_for %tiled_linalg_op_8 tile_sizes [0, 0, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      transform.annotate %loops_11 "./k" : !transform.any_op
+# CHECK-NEXT:      %3 = transform.structured.match attributes {__xtc_id_C_} in %arg0 : (!transform.any_op) -> !transform.any_op
+# CHECK-NEXT:      %tiled_linalg_op_12, %loops_13 = transform.structured.tile_using_for %3 tile_sizes [1, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      transform.annotate %loops_13 "./i" : !transform.any_op
+# CHECK-NEXT:      %tiled_linalg_op_14, %loops_15 = transform.structured.tile_using_for %tiled_linalg_op_12 tile_sizes [0, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      transform.annotate %loops_15 "./j" : !transform.any_op
 # CHECK-NEXT:      transform.yield 
 # CHECK-NEXT:    }
 # CHECK-NEXT:  }
@@ -103,120 +88,84 @@ print(f"CODE: {res}")
 # CHECK-NEXT:    func.func @pad_matmul_unpad(%arg0: memref<14x14xf32> {llvm.noalias}, %arg1: memref<14x14xf32> {llvm.noalias}, %arg2: memref<14x14xf32> {llvm.noalias}) {
 # CHECK-NEXT:      %alloca = memref.alloca() {alignment = 256 : i64} : memref<16x16xf32>
 # CHECK-NEXT:      %cst = arith.constant 0.000000e+00 : f32
-# CHECK-NEXT:      %c0 = arith.constant 0 : index
-# CHECK-NEXT:      %c16 = arith.constant 16 : index
-# CHECK-NEXT:      %c1 = arith.constant 1 : index
-# CHECK-NEXT:      scf.for %arg3 = %c0 to %c16 step %c1 {
-# CHECK-NEXT:        %subview_23 = memref.subview %alloca[%arg3, 0] [1, 16] [1, 1] : memref<16x16xf32> to memref<1x16xf32, strided<[16, 1], offset: ?>>
-# CHECK-NEXT:        %c0_24 = arith.constant 0 : index
-# CHECK-NEXT:        %c16_25 = arith.constant 16 : index
-# CHECK-NEXT:        %c1_26 = arith.constant 1 : index
-# CHECK-NEXT:        scf.for %arg4 = %c0_24 to %c16_25 step %c1_26 {
-# CHECK-NEXT:          %subview_27 = memref.subview %subview_23[0, %arg4] [1, 1] [1, 1] : memref<1x16xf32, strided<[16, 1], offset: ?>> to memref<1x1xf32, strided<[16, 1], offset: ?>>
-# CHECK-NEXT:          linalg.fill {__xtc_id_A_pad_0_} ins(%cst : f32) outs(%subview_27 : memref<1x1xf32, strided<[16, 1], offset: ?>>)
-# CHECK-NEXT:        } {"./j"}
-# CHECK-NEXT:      } {"./i"}
+# CHECK-NEXT:      linalg.fill {__xtc_id_A_pad_0_} ins(%cst : f32) outs(%alloca : memref<16x16xf32>)
 # CHECK-NEXT:      %subview = memref.subview %alloca[0, 0] [14, 14] [1, 1] : memref<16x16xf32> to memref<14x14xf32, strided<[16, 1]>>
-# CHECK-NEXT:      %c0_0 = arith.constant 0 : index
+# CHECK-NEXT:      %c0 = arith.constant 0 : index
 # CHECK-NEXT:      %c14 = arith.constant 14 : index
-# CHECK-NEXT:      %c1_1 = arith.constant 1 : index
-# CHECK-NEXT:      scf.for %arg3 = %c0_0 to %c14 step %c1_1 {
-# CHECK-NEXT:        %subview_23 = memref.subview %arg0[%arg3, 0] [1, 14] [1, 1] : memref<14x14xf32> to memref<1x14xf32, strided<[14, 1], offset: ?>>
-# CHECK-NEXT:        %subview_24 = memref.subview %subview[%arg3, 0] [1, 14] [1, 1] : memref<14x14xf32, strided<[16, 1]>> to memref<1x14xf32, strided<[16, 1], offset: ?>>
-# CHECK-NEXT:        %c0_25 = arith.constant 0 : index
-# CHECK-NEXT:        %c14_26 = arith.constant 14 : index
-# CHECK-NEXT:        %c1_27 = arith.constant 1 : index
-# CHECK-NEXT:        scf.for %arg4 = %c0_25 to %c14_26 step %c1_27 {
-# CHECK-NEXT:          %subview_28 = memref.subview %subview_23[0, %arg4] [1, 1] [1, 1] : memref<1x14xf32, strided<[14, 1], offset: ?>> to memref<1x1xf32, strided<[14, 1], offset: ?>>
-# CHECK-NEXT:          %subview_29 = memref.subview %subview_24[0, %arg4] [1, 1] [1, 1] : memref<1x14xf32, strided<[16, 1], offset: ?>> to memref<1x1xf32, strided<[16, 1], offset: ?>>
-# CHECK-NEXT:          linalg.copy {__xtc_id_A_pad_} ins(%subview_28 : memref<1x1xf32, strided<[14, 1], offset: ?>>) outs(%subview_29 : memref<1x1xf32, strided<[16, 1], offset: ?>>)
+# CHECK-NEXT:      %c1 = arith.constant 1 : index
+# CHECK-NEXT:      scf.for %arg3 = %c0 to %c14 step %c1 {
+# CHECK-NEXT:        %subview_14 = memref.subview %arg0[%arg3, 0] [1, 14] [1, 1] : memref<14x14xf32> to memref<1x14xf32, strided<[14, 1], offset: ?>>
+# CHECK-NEXT:        %subview_15 = memref.subview %subview[%arg3, 0] [1, 14] [1, 1] : memref<14x14xf32, strided<[16, 1]>> to memref<1x14xf32, strided<[16, 1], offset: ?>>
+# CHECK-NEXT:        %c0_16 = arith.constant 0 : index
+# CHECK-NEXT:        %c14_17 = arith.constant 14 : index
+# CHECK-NEXT:        %c1_18 = arith.constant 1 : index
+# CHECK-NEXT:        scf.for %arg4 = %c0_16 to %c14_17 step %c1_18 {
+# CHECK-NEXT:          %subview_19 = memref.subview %subview_14[0, %arg4] [1, 1] [1, 1] : memref<1x14xf32, strided<[14, 1], offset: ?>> to memref<1x1xf32, strided<[14, 1], offset: ?>>
+# CHECK-NEXT:          %subview_20 = memref.subview %subview_15[0, %arg4] [1, 1] [1, 1] : memref<1x14xf32, strided<[16, 1], offset: ?>> to memref<1x1xf32, strided<[16, 1], offset: ?>>
+# CHECK-NEXT:          linalg.copy {__xtc_id_A_pad_} ins(%subview_19 : memref<1x1xf32, strided<[14, 1], offset: ?>>) outs(%subview_20 : memref<1x1xf32, strided<[16, 1], offset: ?>>)
 # CHECK-NEXT:        } {"./j"}
 # CHECK-NEXT:      } {"./i"}
-# CHECK-NEXT:      %alloca_2 = memref.alloca() {alignment = 256 : i64} : memref<16x16xf32>
-# CHECK-NEXT:      %cst_3 = arith.constant 0.000000e+00 : f32
-# CHECK-NEXT:      %c0_4 = arith.constant 0 : index
-# CHECK-NEXT:      %c16_5 = arith.constant 16 : index
-# CHECK-NEXT:      %c1_6 = arith.constant 1 : index
-# CHECK-NEXT:      scf.for %arg3 = %c0_4 to %c16_5 step %c1_6 {
-# CHECK-NEXT:        %subview_23 = memref.subview %alloca_2[%arg3, 0] [1, 16] [1, 1] : memref<16x16xf32> to memref<1x16xf32, strided<[16, 1], offset: ?>>
-# CHECK-NEXT:        %c0_24 = arith.constant 0 : index
-# CHECK-NEXT:        %c16_25 = arith.constant 16 : index
-# CHECK-NEXT:        %c1_26 = arith.constant 1 : index
-# CHECK-NEXT:        scf.for %arg4 = %c0_24 to %c16_25 step %c1_26 {
-# CHECK-NEXT:          %subview_27 = memref.subview %subview_23[0, %arg4] [1, 1] [1, 1] : memref<1x16xf32, strided<[16, 1], offset: ?>> to memref<1x1xf32, strided<[16, 1], offset: ?>>
-# CHECK-NEXT:          linalg.fill {__xtc_id_B_pad_0_} ins(%cst_3 : f32) outs(%subview_27 : memref<1x1xf32, strided<[16, 1], offset: ?>>)
+# CHECK-NEXT:      %alloca_0 = memref.alloca() {alignment = 256 : i64} : memref<16x16xf32>
+# CHECK-NEXT:      %cst_1 = arith.constant 0.000000e+00 : f32
+# CHECK-NEXT:      linalg.fill {__xtc_id_B_pad_0_} ins(%cst_1 : f32) outs(%alloca_0 : memref<16x16xf32>)
+# CHECK-NEXT:      %subview_2 = memref.subview %alloca_0[0, 0] [14, 14] [1, 1] : memref<16x16xf32> to memref<14x14xf32, strided<[16, 1]>>
+# CHECK-NEXT:      %c0_3 = arith.constant 0 : index
+# CHECK-NEXT:      %c14_4 = arith.constant 14 : index
+# CHECK-NEXT:      %c1_5 = arith.constant 1 : index
+# CHECK-NEXT:      scf.for %arg3 = %c0_3 to %c14_4 step %c1_5 {
+# CHECK-NEXT:        %subview_14 = memref.subview %arg1[%arg3, 0] [1, 14] [1, 1] : memref<14x14xf32> to memref<1x14xf32, strided<[14, 1], offset: ?>>
+# CHECK-NEXT:        %subview_15 = memref.subview %subview_2[%arg3, 0] [1, 14] [1, 1] : memref<14x14xf32, strided<[16, 1]>> to memref<1x14xf32, strided<[16, 1], offset: ?>>
+# CHECK-NEXT:        %c0_16 = arith.constant 0 : index
+# CHECK-NEXT:        %c14_17 = arith.constant 14 : index
+# CHECK-NEXT:        %c1_18 = arith.constant 1 : index
+# CHECK-NEXT:        scf.for %arg4 = %c0_16 to %c14_17 step %c1_18 {
+# CHECK-NEXT:          %subview_19 = memref.subview %subview_14[0, %arg4] [1, 1] [1, 1] : memref<1x14xf32, strided<[14, 1], offset: ?>> to memref<1x1xf32, strided<[14, 1], offset: ?>>
+# CHECK-NEXT:          %subview_20 = memref.subview %subview_15[0, %arg4] [1, 1] [1, 1] : memref<1x14xf32, strided<[16, 1], offset: ?>> to memref<1x1xf32, strided<[16, 1], offset: ?>>
+# CHECK-NEXT:          linalg.copy {__xtc_id_B_pad_} ins(%subview_19 : memref<1x1xf32, strided<[14, 1], offset: ?>>) outs(%subview_20 : memref<1x1xf32, strided<[16, 1], offset: ?>>)
 # CHECK-NEXT:        } {"./j"}
 # CHECK-NEXT:      } {"./i"}
-# CHECK-NEXT:      %subview_7 = memref.subview %alloca_2[0, 0] [14, 14] [1, 1] : memref<16x16xf32> to memref<14x14xf32, strided<[16, 1]>>
+# CHECK-NEXT:      %alloca_6 = memref.alloca() {alignment = 256 : i64} : memref<16x16xf32>
+# CHECK-NEXT:      %cst_7 = arith.constant 0.000000e+00 : f32
+# CHECK-NEXT:      linalg.fill {__xtc_id_matmul_padded_0_} ins(%cst_7 : f32) outs(%alloca_6 : memref<16x16xf32>)
 # CHECK-NEXT:      %c0_8 = arith.constant 0 : index
-# CHECK-NEXT:      %c14_9 = arith.constant 14 : index
-# CHECK-NEXT:      %c1_10 = arith.constant 1 : index
-# CHECK-NEXT:      scf.for %arg3 = %c0_8 to %c14_9 step %c1_10 {
-# CHECK-NEXT:        %subview_23 = memref.subview %arg1[%arg3, 0] [1, 14] [1, 1] : memref<14x14xf32> to memref<1x14xf32, strided<[14, 1], offset: ?>>
-# CHECK-NEXT:        %subview_24 = memref.subview %subview_7[%arg3, 0] [1, 14] [1, 1] : memref<14x14xf32, strided<[16, 1]>> to memref<1x14xf32, strided<[16, 1], offset: ?>>
-# CHECK-NEXT:        %c0_25 = arith.constant 0 : index
-# CHECK-NEXT:        %c14_26 = arith.constant 14 : index
-# CHECK-NEXT:        %c1_27 = arith.constant 1 : index
-# CHECK-NEXT:        scf.for %arg4 = %c0_25 to %c14_26 step %c1_27 {
-# CHECK-NEXT:          %subview_28 = memref.subview %subview_23[0, %arg4] [1, 1] [1, 1] : memref<1x14xf32, strided<[14, 1], offset: ?>> to memref<1x1xf32, strided<[14, 1], offset: ?>>
-# CHECK-NEXT:          %subview_29 = memref.subview %subview_24[0, %arg4] [1, 1] [1, 1] : memref<1x14xf32, strided<[16, 1], offset: ?>> to memref<1x1xf32, strided<[16, 1], offset: ?>>
-# CHECK-NEXT:          linalg.copy {__xtc_id_B_pad_} ins(%subview_28 : memref<1x1xf32, strided<[14, 1], offset: ?>>) outs(%subview_29 : memref<1x1xf32, strided<[16, 1], offset: ?>>)
-# CHECK-NEXT:        } {"./j"}
-# CHECK-NEXT:      } {"./i"}
-# CHECK-NEXT:      %alloca_11 = memref.alloca() {alignment = 256 : i64} : memref<16x16xf32>
-# CHECK-NEXT:      %cst_12 = arith.constant 0.000000e+00 : f32
-# CHECK-NEXT:      %c0_13 = arith.constant 0 : index
-# CHECK-NEXT:      %c16_14 = arith.constant 16 : index
-# CHECK-NEXT:      %c1_15 = arith.constant 1 : index
-# CHECK-NEXT:      scf.for %arg3 = %c0_13 to %c16_14 step %c1_15 {
-# CHECK-NEXT:        %subview_23 = memref.subview %alloca_11[%arg3, 0] [1, 16] [1, 1] : memref<16x16xf32> to memref<1x16xf32, strided<[16, 1], offset: ?>>
-# CHECK-NEXT:        %c0_24 = arith.constant 0 : index
-# CHECK-NEXT:        %c16_25 = arith.constant 16 : index
-# CHECK-NEXT:        %c1_26 = arith.constant 1 : index
-# CHECK-NEXT:        scf.for %arg4 = %c0_24 to %c16_25 step %c1_26 {
-# CHECK-NEXT:          %subview_27 = memref.subview %subview_23[0, %arg4] [1, 1] [1, 1] : memref<1x16xf32, strided<[16, 1], offset: ?>> to memref<1x1xf32, strided<[16, 1], offset: ?>>
-# CHECK-NEXT:          linalg.fill {__xtc_id_matmul_padded_0_} ins(%cst_12 : f32) outs(%subview_27 : memref<1x1xf32, strided<[16, 1], offset: ?>>)
-# CHECK-NEXT:        } {"./j"}
-# CHECK-NEXT:      } {"./i"}
-# CHECK-NEXT:      %c0_16 = arith.constant 0 : index
-# CHECK-NEXT:      %c16_17 = arith.constant 16 : index
-# CHECK-NEXT:      %c1_18 = arith.constant 1 : index
-# CHECK-NEXT:      scf.for %arg3 = %c0_16 to %c16_17 step %c1_18 {
-# CHECK-NEXT:        %subview_23 = memref.subview %alloca[%arg3, 0] [1, 16] [1, 1] : memref<16x16xf32> to memref<1x16xf32, strided<[16, 1], offset: ?>>
-# CHECK-NEXT:        %subview_24 = memref.subview %alloca_2[0, 0] [16, 16] [1, 1] : memref<16x16xf32> to memref<16x16xf32, strided<[16, 1]>>
-# CHECK-NEXT:        %subview_25 = memref.subview %alloca_11[%arg3, 0] [1, 16] [1, 1] : memref<16x16xf32> to memref<1x16xf32, strided<[16, 1], offset: ?>>
-# CHECK-NEXT:        %c0_26 = arith.constant 0 : index
-# CHECK-NEXT:        %c16_27 = arith.constant 16 : index
-# CHECK-NEXT:        %c1_28 = arith.constant 1 : index
-# CHECK-NEXT:        scf.for %arg4 = %c0_26 to %c16_27 step %c1_28 {
-# CHECK-NEXT:          %subview_29 = memref.subview %subview_23[0, 0] [1, 16] [1, 1] : memref<1x16xf32, strided<[16, 1], offset: ?>> to memref<1x16xf32, strided<[16, 1], offset: ?>>
-# CHECK-NEXT:          %subview_30 = memref.subview %subview_24[0, %arg4] [16, 1] [1, 1] : memref<16x16xf32, strided<[16, 1]>> to memref<16x1xf32, strided<[16, 1], offset: ?>>
-# CHECK-NEXT:          %subview_31 = memref.subview %subview_25[0, %arg4] [1, 1] [1, 1] : memref<1x16xf32, strided<[16, 1], offset: ?>> to memref<1x1xf32, strided<[16, 1], offset: ?>>
-# CHECK-NEXT:          %c0_32 = arith.constant 0 : index
-# CHECK-NEXT:          %c16_33 = arith.constant 16 : index
-# CHECK-NEXT:          %c1_34 = arith.constant 1 : index
-# CHECK-NEXT:          scf.for %arg5 = %c0_32 to %c16_33 step %c1_34 {
-# CHECK-NEXT:            %subview_35 = memref.subview %subview_29[0, %arg5] [1, 1] [1, 1] : memref<1x16xf32, strided<[16, 1], offset: ?>> to memref<1x1xf32, strided<[16, 1], offset: ?>>
-# CHECK-NEXT:            %subview_36 = memref.subview %subview_30[%arg5, 0] [1, 1] [1, 1] : memref<16x1xf32, strided<[16, 1], offset: ?>> to memref<1x1xf32, strided<[16, 1], offset: ?>>
-# CHECK-NEXT:            %subview_37 = memref.subview %subview_31[0, 0] [1, 1] [1, 1] : memref<1x1xf32, strided<[16, 1], offset: ?>> to memref<1x1xf32, strided<[16, 1], offset: ?>>
-# CHECK-NEXT:            linalg.matmul {__xtc_id_matmul_padded_} ins(%subview_35, %subview_36 : memref<1x1xf32, strided<[16, 1], offset: ?>>, memref<1x1xf32, strided<[16, 1], offset: ?>>) outs(%subview_37 : memref<1x1xf32, strided<[16, 1], offset: ?>>)
+# CHECK-NEXT:      %c16 = arith.constant 16 : index
+# CHECK-NEXT:      %c1_9 = arith.constant 1 : index
+# CHECK-NEXT:      scf.for %arg3 = %c0_8 to %c16 step %c1_9 {
+# CHECK-NEXT:        %subview_14 = memref.subview %alloca[%arg3, 0] [1, 16] [1, 1] : memref<16x16xf32> to memref<1x16xf32, strided<[16, 1], offset: ?>>
+# CHECK-NEXT:        %subview_15 = memref.subview %alloca_0[0, 0] [16, 16] [1, 1] : memref<16x16xf32> to memref<16x16xf32, strided<[16, 1]>>
+# CHECK-NEXT:        %subview_16 = memref.subview %alloca_6[%arg3, 0] [1, 16] [1, 1] : memref<16x16xf32> to memref<1x16xf32, strided<[16, 1], offset: ?>>
+# CHECK-NEXT:        %c0_17 = arith.constant 0 : index
+# CHECK-NEXT:        %c16_18 = arith.constant 16 : index
+# CHECK-NEXT:        %c1_19 = arith.constant 1 : index
+# CHECK-NEXT:        scf.for %arg4 = %c0_17 to %c16_18 step %c1_19 {
+# CHECK-NEXT:          %subview_20 = memref.subview %subview_14[0, 0] [1, 16] [1, 1] : memref<1x16xf32, strided<[16, 1], offset: ?>> to memref<1x16xf32, strided<[16, 1], offset: ?>>
+# CHECK-NEXT:          %subview_21 = memref.subview %subview_15[0, %arg4] [16, 1] [1, 1] : memref<16x16xf32, strided<[16, 1]>> to memref<16x1xf32, strided<[16, 1], offset: ?>>
+# CHECK-NEXT:          %subview_22 = memref.subview %subview_16[0, %arg4] [1, 1] [1, 1] : memref<1x16xf32, strided<[16, 1], offset: ?>> to memref<1x1xf32, strided<[16, 1], offset: ?>>
+# CHECK-NEXT:          %c0_23 = arith.constant 0 : index
+# CHECK-NEXT:          %c16_24 = arith.constant 16 : index
+# CHECK-NEXT:          %c1_25 = arith.constant 1 : index
+# CHECK-NEXT:          scf.for %arg5 = %c0_23 to %c16_24 step %c1_25 {
+# CHECK-NEXT:            %subview_26 = memref.subview %subview_20[0, %arg5] [1, 1] [1, 1] : memref<1x16xf32, strided<[16, 1], offset: ?>> to memref<1x1xf32, strided<[16, 1], offset: ?>>
+# CHECK-NEXT:            %subview_27 = memref.subview %subview_21[%arg5, 0] [1, 1] [1, 1] : memref<16x1xf32, strided<[16, 1], offset: ?>> to memref<1x1xf32, strided<[16, 1], offset: ?>>
+# CHECK-NEXT:            %subview_28 = memref.subview %subview_22[0, 0] [1, 1] [1, 1] : memref<1x1xf32, strided<[16, 1], offset: ?>> to memref<1x1xf32, strided<[16, 1], offset: ?>>
+# CHECK-NEXT:            linalg.matmul {__xtc_id_matmul_padded_} ins(%subview_26, %subview_27 : memref<1x1xf32, strided<[16, 1], offset: ?>>, memref<1x1xf32, strided<[16, 1], offset: ?>>) outs(%subview_28 : memref<1x1xf32, strided<[16, 1], offset: ?>>)
 # CHECK-NEXT:          } {"./k"}
 # CHECK-NEXT:        } {"./j"}
 # CHECK-NEXT:      } {"./i"}
-# CHECK-NEXT:      %subview_19 = memref.subview %alloca_11[0, 0] [14, 14] [1, 1] : memref<16x16xf32> to memref<14x14xf32, strided<[16, 1]>>
-# CHECK-NEXT:      %c0_20 = arith.constant 0 : index
-# CHECK-NEXT:      %c14_21 = arith.constant 14 : index
-# CHECK-NEXT:      %c1_22 = arith.constant 1 : index
-# CHECK-NEXT:      scf.for %arg3 = %c0_20 to %c14_21 step %c1_22 {
-# CHECK-NEXT:        %subview_23 = memref.subview %subview_19[%arg3, 0] [1, 14] [1, 1] : memref<14x14xf32, strided<[16, 1]>> to memref<1x14xf32, strided<[16, 1], offset: ?>>
-# CHECK-NEXT:        %subview_24 = memref.subview %arg2[%arg3, 0] [1, 14] [1, 1] : memref<14x14xf32> to memref<1x14xf32, strided<[14, 1], offset: ?>>
-# CHECK-NEXT:        %c0_25 = arith.constant 0 : index
-# CHECK-NEXT:        %c14_26 = arith.constant 14 : index
-# CHECK-NEXT:        %c1_27 = arith.constant 1 : index
-# CHECK-NEXT:        scf.for %arg4 = %c0_25 to %c14_26 step %c1_27 {
-# CHECK-NEXT:          %subview_28 = memref.subview %subview_23[0, %arg4] [1, 1] [1, 1] : memref<1x14xf32, strided<[16, 1], offset: ?>> to memref<1x1xf32, strided<[16, 1], offset: ?>>
-# CHECK-NEXT:          %subview_29 = memref.subview %subview_24[0, %arg4] [1, 1] [1, 1] : memref<1x14xf32, strided<[14, 1], offset: ?>> to memref<1x1xf32, strided<[14, 1], offset: ?>>
-# CHECK-NEXT:          linalg.copy {__xtc_id_C_} ins(%subview_28 : memref<1x1xf32, strided<[16, 1], offset: ?>>) outs(%subview_29 : memref<1x1xf32, strided<[14, 1], offset: ?>>)
+# CHECK-NEXT:      %subview_10 = memref.subview %alloca_6[0, 0] [14, 14] [1, 1] : memref<16x16xf32> to memref<14x14xf32, strided<[16, 1]>>
+# CHECK-NEXT:      %c0_11 = arith.constant 0 : index
+# CHECK-NEXT:      %c14_12 = arith.constant 14 : index
+# CHECK-NEXT:      %c1_13 = arith.constant 1 : index
+# CHECK-NEXT:      scf.for %arg3 = %c0_11 to %c14_12 step %c1_13 {
+# CHECK-NEXT:        %subview_14 = memref.subview %subview_10[%arg3, 0] [1, 14] [1, 1] : memref<14x14xf32, strided<[16, 1]>> to memref<1x14xf32, strided<[16, 1], offset: ?>>
+# CHECK-NEXT:        %subview_15 = memref.subview %arg2[%arg3, 0] [1, 14] [1, 1] : memref<14x14xf32> to memref<1x14xf32, strided<[14, 1], offset: ?>>
+# CHECK-NEXT:        %c0_16 = arith.constant 0 : index
+# CHECK-NEXT:        %c14_17 = arith.constant 14 : index
+# CHECK-NEXT:        %c1_18 = arith.constant 1 : index
+# CHECK-NEXT:        scf.for %arg4 = %c0_16 to %c14_17 step %c1_18 {
+# CHECK-NEXT:          %subview_19 = memref.subview %subview_14[0, %arg4] [1, 1] [1, 1] : memref<1x14xf32, strided<[16, 1], offset: ?>> to memref<1x1xf32, strided<[16, 1], offset: ?>>
+# CHECK-NEXT:          %subview_20 = memref.subview %subview_15[0, %arg4] [1, 1] [1, 1] : memref<1x14xf32, strided<[14, 1], offset: ?>> to memref<1x1xf32, strided<[14, 1], offset: ?>>
+# CHECK-NEXT:          linalg.copy {__xtc_id_C_} ins(%subview_19 : memref<1x1xf32, strided<[16, 1], offset: ?>>) outs(%subview_20 : memref<1x1xf32, strided<[14, 1], offset: ?>>)
 # CHECK-NEXT:        } {"./j"}
 # CHECK-NEXT:      } {"./i"}
 # CHECK-NEXT:      return

--- a/tests/filecheck/backends/padding/test_pad2d_dict_matmul_unpad_mlir.py
+++ b/tests/filecheck/backends/padding/test_pad2d_dict_matmul_unpad_mlir.py
@@ -57,43 +57,28 @@ print(f"CODE: {res}")
 # CHECK-NEXT:      transform.yield 
 # CHECK-NEXT:    }
 # CHECK-NEXT:    transform.named_sequence @__transform_main(%arg0: !transform.any_op {transform.readonly}) {
-# CHECK-NEXT:      %0 = transform.structured.match attributes {__xtc_id_A_pad_0_} in %arg0 : (!transform.any_op) -> !transform.any_op
+# CHECK-NEXT:      %0 = transform.structured.match attributes {__xtc_id_A_pad_} in %arg0 : (!transform.any_op) -> !transform.any_op
 # CHECK-NEXT:      %tiled_linalg_op, %loops = transform.structured.tile_using_for %0 tile_sizes [1, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
 # CHECK-NEXT:      transform.annotate %loops "./b" : !transform.any_op
 # CHECK-NEXT:      %tiled_linalg_op_0, %loops_1 = transform.structured.tile_using_for %tiled_linalg_op tile_sizes [0, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
 # CHECK-NEXT:      transform.annotate %loops_1 "./h" : !transform.any_op
-# CHECK-NEXT:      %1 = transform.structured.match attributes {__xtc_id_A_pad_} in %arg0 : (!transform.any_op) -> !transform.any_op
+# CHECK-NEXT:      %1 = transform.structured.match attributes {__xtc_id_B_pad_} in %arg0 : (!transform.any_op) -> !transform.any_op
 # CHECK-NEXT:      %tiled_linalg_op_2, %loops_3 = transform.structured.tile_using_for %1 tile_sizes [1, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
 # CHECK-NEXT:      transform.annotate %loops_3 "./b" : !transform.any_op
 # CHECK-NEXT:      %tiled_linalg_op_4, %loops_5 = transform.structured.tile_using_for %tiled_linalg_op_2 tile_sizes [0, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
 # CHECK-NEXT:      transform.annotate %loops_5 "./h" : !transform.any_op
-# CHECK-NEXT:      %2 = transform.structured.match attributes {__xtc_id_B_pad_0_} in %arg0 : (!transform.any_op) -> !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_6, %loops_7 = transform.structured.tile_using_for %2 tile_sizes [1, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_7 "./b" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_8, %loops_9 = transform.structured.tile_using_for %tiled_linalg_op_6 tile_sizes [0, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_9 "./h" : !transform.any_op
-# CHECK-NEXT:      %3 = transform.structured.match attributes {__xtc_id_B_pad_} in %arg0 : (!transform.any_op) -> !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_10, %loops_11 = transform.structured.tile_using_for %3 tile_sizes [1, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_11 "./b" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_12, %loops_13 = transform.structured.tile_using_for %tiled_linalg_op_10 tile_sizes [0, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_13 "./h" : !transform.any_op
-# CHECK-NEXT:      %4 = transform.structured.match attributes {__xtc_id_matmul_padded_0_} in %arg0 : (!transform.any_op) -> !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_14, %loops_15 = transform.structured.tile_using_for %4 tile_sizes [1, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_15 "./i" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_16, %loops_17 = transform.structured.tile_using_for %tiled_linalg_op_14 tile_sizes [0, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_17 "./j" : !transform.any_op
-# CHECK-NEXT:      %5 = transform.structured.match attributes {__xtc_id_matmul_padded_} in %arg0 : (!transform.any_op) -> !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_18, %loops_19 = transform.structured.tile_using_for %5 tile_sizes [1, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_19 "./i" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_20, %loops_21 = transform.structured.tile_using_for %tiled_linalg_op_18 tile_sizes [0, 1, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_21 "./j" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_22, %loops_23 = transform.structured.tile_using_for %tiled_linalg_op_20 tile_sizes [0, 0, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_23 "./k" : !transform.any_op
-# CHECK-NEXT:      %6 = transform.structured.match attributes {__xtc_id_C_} in %arg0 : (!transform.any_op) -> !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_24, %loops_25 = transform.structured.tile_using_for %6 tile_sizes [1, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_25 "./i" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_26, %loops_27 = transform.structured.tile_using_for %tiled_linalg_op_24 tile_sizes [0, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_27 "./j" : !transform.any_op
+# CHECK-NEXT:      %2 = transform.structured.match attributes {__xtc_id_matmul_padded_} in %arg0 : (!transform.any_op) -> !transform.any_op
+# CHECK-NEXT:      %tiled_linalg_op_6, %loops_7 = transform.structured.tile_using_for %2 tile_sizes [1, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      transform.annotate %loops_7 "./i" : !transform.any_op
+# CHECK-NEXT:      %tiled_linalg_op_8, %loops_9 = transform.structured.tile_using_for %tiled_linalg_op_6 tile_sizes [0, 1, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      transform.annotate %loops_9 "./j" : !transform.any_op
+# CHECK-NEXT:      %tiled_linalg_op_10, %loops_11 = transform.structured.tile_using_for %tiled_linalg_op_8 tile_sizes [0, 0, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      transform.annotate %loops_11 "./k" : !transform.any_op
+# CHECK-NEXT:      %3 = transform.structured.match attributes {__xtc_id_C_} in %arg0 : (!transform.any_op) -> !transform.any_op
+# CHECK-NEXT:      %tiled_linalg_op_12, %loops_13 = transform.structured.tile_using_for %3 tile_sizes [1, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      transform.annotate %loops_13 "./i" : !transform.any_op
+# CHECK-NEXT:      %tiled_linalg_op_14, %loops_15 = transform.structured.tile_using_for %tiled_linalg_op_12 tile_sizes [0, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      transform.annotate %loops_15 "./j" : !transform.any_op
 # CHECK-NEXT:      transform.yield 
 # CHECK-NEXT:    }
 # CHECK-NEXT:  }
@@ -103,120 +88,84 @@ print(f"CODE: {res}")
 # CHECK-NEXT:    func.func @pad_matmul_unpad(%arg0: memref<14x14xf32> {llvm.noalias}, %arg1: memref<14x14xf32> {llvm.noalias}, %arg2: memref<14x14xf32> {llvm.noalias}) {
 # CHECK-NEXT:      %alloca = memref.alloca() {alignment = 256 : i64} : memref<16x16xf32>
 # CHECK-NEXT:      %cst = arith.constant 0.000000e+00 : f32
-# CHECK-NEXT:      %c0 = arith.constant 0 : index
-# CHECK-NEXT:      %c16 = arith.constant 16 : index
-# CHECK-NEXT:      %c1 = arith.constant 1 : index
-# CHECK-NEXT:      scf.for %arg3 = %c0 to %c16 step %c1 {
-# CHECK-NEXT:        %subview_23 = memref.subview %alloca[%arg3, 0] [1, 16] [1, 1] : memref<16x16xf32> to memref<1x16xf32, strided<[16, 1], offset: ?>>
-# CHECK-NEXT:        %c0_24 = arith.constant 0 : index
-# CHECK-NEXT:        %c16_25 = arith.constant 16 : index
-# CHECK-NEXT:        %c1_26 = arith.constant 1 : index
-# CHECK-NEXT:        scf.for %arg4 = %c0_24 to %c16_25 step %c1_26 {
-# CHECK-NEXT:          %subview_27 = memref.subview %subview_23[0, %arg4] [1, 1] [1, 1] : memref<1x16xf32, strided<[16, 1], offset: ?>> to memref<1x1xf32, strided<[16, 1], offset: ?>>
-# CHECK-NEXT:          linalg.fill {__xtc_id_A_pad_0_} ins(%cst : f32) outs(%subview_27 : memref<1x1xf32, strided<[16, 1], offset: ?>>)
-# CHECK-NEXT:        } {"./h"}
-# CHECK-NEXT:      } {"./b"}
+# CHECK-NEXT:      linalg.fill {__xtc_id_A_pad_0_} ins(%cst : f32) outs(%alloca : memref<16x16xf32>)
 # CHECK-NEXT:      %subview = memref.subview %alloca[0, 0] [14, 14] [1, 1] : memref<16x16xf32> to memref<14x14xf32, strided<[16, 1]>>
-# CHECK-NEXT:      %c0_0 = arith.constant 0 : index
+# CHECK-NEXT:      %c0 = arith.constant 0 : index
 # CHECK-NEXT:      %c14 = arith.constant 14 : index
-# CHECK-NEXT:      %c1_1 = arith.constant 1 : index
-# CHECK-NEXT:      scf.for %arg3 = %c0_0 to %c14 step %c1_1 {
-# CHECK-NEXT:        %subview_23 = memref.subview %arg0[%arg3, 0] [1, 14] [1, 1] : memref<14x14xf32> to memref<1x14xf32, strided<[14, 1], offset: ?>>
-# CHECK-NEXT:        %subview_24 = memref.subview %subview[%arg3, 0] [1, 14] [1, 1] : memref<14x14xf32, strided<[16, 1]>> to memref<1x14xf32, strided<[16, 1], offset: ?>>
-# CHECK-NEXT:        %c0_25 = arith.constant 0 : index
-# CHECK-NEXT:        %c14_26 = arith.constant 14 : index
-# CHECK-NEXT:        %c1_27 = arith.constant 1 : index
-# CHECK-NEXT:        scf.for %arg4 = %c0_25 to %c14_26 step %c1_27 {
-# CHECK-NEXT:          %subview_28 = memref.subview %subview_23[0, %arg4] [1, 1] [1, 1] : memref<1x14xf32, strided<[14, 1], offset: ?>> to memref<1x1xf32, strided<[14, 1], offset: ?>>
-# CHECK-NEXT:          %subview_29 = memref.subview %subview_24[0, %arg4] [1, 1] [1, 1] : memref<1x14xf32, strided<[16, 1], offset: ?>> to memref<1x1xf32, strided<[16, 1], offset: ?>>
-# CHECK-NEXT:          linalg.copy {__xtc_id_A_pad_} ins(%subview_28 : memref<1x1xf32, strided<[14, 1], offset: ?>>) outs(%subview_29 : memref<1x1xf32, strided<[16, 1], offset: ?>>)
+# CHECK-NEXT:      %c1 = arith.constant 1 : index
+# CHECK-NEXT:      scf.for %arg3 = %c0 to %c14 step %c1 {
+# CHECK-NEXT:        %subview_14 = memref.subview %arg0[%arg3, 0] [1, 14] [1, 1] : memref<14x14xf32> to memref<1x14xf32, strided<[14, 1], offset: ?>>
+# CHECK-NEXT:        %subview_15 = memref.subview %subview[%arg3, 0] [1, 14] [1, 1] : memref<14x14xf32, strided<[16, 1]>> to memref<1x14xf32, strided<[16, 1], offset: ?>>
+# CHECK-NEXT:        %c0_16 = arith.constant 0 : index
+# CHECK-NEXT:        %c14_17 = arith.constant 14 : index
+# CHECK-NEXT:        %c1_18 = arith.constant 1 : index
+# CHECK-NEXT:        scf.for %arg4 = %c0_16 to %c14_17 step %c1_18 {
+# CHECK-NEXT:          %subview_19 = memref.subview %subview_14[0, %arg4] [1, 1] [1, 1] : memref<1x14xf32, strided<[14, 1], offset: ?>> to memref<1x1xf32, strided<[14, 1], offset: ?>>
+# CHECK-NEXT:          %subview_20 = memref.subview %subview_15[0, %arg4] [1, 1] [1, 1] : memref<1x14xf32, strided<[16, 1], offset: ?>> to memref<1x1xf32, strided<[16, 1], offset: ?>>
+# CHECK-NEXT:          linalg.copy {__xtc_id_A_pad_} ins(%subview_19 : memref<1x1xf32, strided<[14, 1], offset: ?>>) outs(%subview_20 : memref<1x1xf32, strided<[16, 1], offset: ?>>)
 # CHECK-NEXT:        } {"./h"}
 # CHECK-NEXT:      } {"./b"}
-# CHECK-NEXT:      %alloca_2 = memref.alloca() {alignment = 256 : i64} : memref<16x16xf32>
-# CHECK-NEXT:      %cst_3 = arith.constant 0.000000e+00 : f32
-# CHECK-NEXT:      %c0_4 = arith.constant 0 : index
-# CHECK-NEXT:      %c16_5 = arith.constant 16 : index
-# CHECK-NEXT:      %c1_6 = arith.constant 1 : index
-# CHECK-NEXT:      scf.for %arg3 = %c0_4 to %c16_5 step %c1_6 {
-# CHECK-NEXT:        %subview_23 = memref.subview %alloca_2[%arg3, 0] [1, 16] [1, 1] : memref<16x16xf32> to memref<1x16xf32, strided<[16, 1], offset: ?>>
-# CHECK-NEXT:        %c0_24 = arith.constant 0 : index
-# CHECK-NEXT:        %c16_25 = arith.constant 16 : index
-# CHECK-NEXT:        %c1_26 = arith.constant 1 : index
-# CHECK-NEXT:        scf.for %arg4 = %c0_24 to %c16_25 step %c1_26 {
-# CHECK-NEXT:          %subview_27 = memref.subview %subview_23[0, %arg4] [1, 1] [1, 1] : memref<1x16xf32, strided<[16, 1], offset: ?>> to memref<1x1xf32, strided<[16, 1], offset: ?>>
-# CHECK-NEXT:          linalg.fill {__xtc_id_B_pad_0_} ins(%cst_3 : f32) outs(%subview_27 : memref<1x1xf32, strided<[16, 1], offset: ?>>)
+# CHECK-NEXT:      %alloca_0 = memref.alloca() {alignment = 256 : i64} : memref<16x16xf32>
+# CHECK-NEXT:      %cst_1 = arith.constant 0.000000e+00 : f32
+# CHECK-NEXT:      linalg.fill {__xtc_id_B_pad_0_} ins(%cst_1 : f32) outs(%alloca_0 : memref<16x16xf32>)
+# CHECK-NEXT:      %subview_2 = memref.subview %alloca_0[0, 0] [14, 14] [1, 1] : memref<16x16xf32> to memref<14x14xf32, strided<[16, 1]>>
+# CHECK-NEXT:      %c0_3 = arith.constant 0 : index
+# CHECK-NEXT:      %c14_4 = arith.constant 14 : index
+# CHECK-NEXT:      %c1_5 = arith.constant 1 : index
+# CHECK-NEXT:      scf.for %arg3 = %c0_3 to %c14_4 step %c1_5 {
+# CHECK-NEXT:        %subview_14 = memref.subview %arg1[%arg3, 0] [1, 14] [1, 1] : memref<14x14xf32> to memref<1x14xf32, strided<[14, 1], offset: ?>>
+# CHECK-NEXT:        %subview_15 = memref.subview %subview_2[%arg3, 0] [1, 14] [1, 1] : memref<14x14xf32, strided<[16, 1]>> to memref<1x14xf32, strided<[16, 1], offset: ?>>
+# CHECK-NEXT:        %c0_16 = arith.constant 0 : index
+# CHECK-NEXT:        %c14_17 = arith.constant 14 : index
+# CHECK-NEXT:        %c1_18 = arith.constant 1 : index
+# CHECK-NEXT:        scf.for %arg4 = %c0_16 to %c14_17 step %c1_18 {
+# CHECK-NEXT:          %subview_19 = memref.subview %subview_14[0, %arg4] [1, 1] [1, 1] : memref<1x14xf32, strided<[14, 1], offset: ?>> to memref<1x1xf32, strided<[14, 1], offset: ?>>
+# CHECK-NEXT:          %subview_20 = memref.subview %subview_15[0, %arg4] [1, 1] [1, 1] : memref<1x14xf32, strided<[16, 1], offset: ?>> to memref<1x1xf32, strided<[16, 1], offset: ?>>
+# CHECK-NEXT:          linalg.copy {__xtc_id_B_pad_} ins(%subview_19 : memref<1x1xf32, strided<[14, 1], offset: ?>>) outs(%subview_20 : memref<1x1xf32, strided<[16, 1], offset: ?>>)
 # CHECK-NEXT:        } {"./h"}
 # CHECK-NEXT:      } {"./b"}
-# CHECK-NEXT:      %subview_7 = memref.subview %alloca_2[0, 0] [14, 14] [1, 1] : memref<16x16xf32> to memref<14x14xf32, strided<[16, 1]>>
+# CHECK-NEXT:      %alloca_6 = memref.alloca() {alignment = 256 : i64} : memref<16x16xf32>
+# CHECK-NEXT:      %cst_7 = arith.constant 0.000000e+00 : f32
+# CHECK-NEXT:      linalg.fill {__xtc_id_matmul_padded_0_} ins(%cst_7 : f32) outs(%alloca_6 : memref<16x16xf32>)
 # CHECK-NEXT:      %c0_8 = arith.constant 0 : index
-# CHECK-NEXT:      %c14_9 = arith.constant 14 : index
-# CHECK-NEXT:      %c1_10 = arith.constant 1 : index
-# CHECK-NEXT:      scf.for %arg3 = %c0_8 to %c14_9 step %c1_10 {
-# CHECK-NEXT:        %subview_23 = memref.subview %arg1[%arg3, 0] [1, 14] [1, 1] : memref<14x14xf32> to memref<1x14xf32, strided<[14, 1], offset: ?>>
-# CHECK-NEXT:        %subview_24 = memref.subview %subview_7[%arg3, 0] [1, 14] [1, 1] : memref<14x14xf32, strided<[16, 1]>> to memref<1x14xf32, strided<[16, 1], offset: ?>>
-# CHECK-NEXT:        %c0_25 = arith.constant 0 : index
-# CHECK-NEXT:        %c14_26 = arith.constant 14 : index
-# CHECK-NEXT:        %c1_27 = arith.constant 1 : index
-# CHECK-NEXT:        scf.for %arg4 = %c0_25 to %c14_26 step %c1_27 {
-# CHECK-NEXT:          %subview_28 = memref.subview %subview_23[0, %arg4] [1, 1] [1, 1] : memref<1x14xf32, strided<[14, 1], offset: ?>> to memref<1x1xf32, strided<[14, 1], offset: ?>>
-# CHECK-NEXT:          %subview_29 = memref.subview %subview_24[0, %arg4] [1, 1] [1, 1] : memref<1x14xf32, strided<[16, 1], offset: ?>> to memref<1x1xf32, strided<[16, 1], offset: ?>>
-# CHECK-NEXT:          linalg.copy {__xtc_id_B_pad_} ins(%subview_28 : memref<1x1xf32, strided<[14, 1], offset: ?>>) outs(%subview_29 : memref<1x1xf32, strided<[16, 1], offset: ?>>)
-# CHECK-NEXT:        } {"./h"}
-# CHECK-NEXT:      } {"./b"}
-# CHECK-NEXT:      %alloca_11 = memref.alloca() {alignment = 256 : i64} : memref<16x16xf32>
-# CHECK-NEXT:      %cst_12 = arith.constant 0.000000e+00 : f32
-# CHECK-NEXT:      %c0_13 = arith.constant 0 : index
-# CHECK-NEXT:      %c16_14 = arith.constant 16 : index
-# CHECK-NEXT:      %c1_15 = arith.constant 1 : index
-# CHECK-NEXT:      scf.for %arg3 = %c0_13 to %c16_14 step %c1_15 {
-# CHECK-NEXT:        %subview_23 = memref.subview %alloca_11[%arg3, 0] [1, 16] [1, 1] : memref<16x16xf32> to memref<1x16xf32, strided<[16, 1], offset: ?>>
-# CHECK-NEXT:        %c0_24 = arith.constant 0 : index
-# CHECK-NEXT:        %c16_25 = arith.constant 16 : index
-# CHECK-NEXT:        %c1_26 = arith.constant 1 : index
-# CHECK-NEXT:        scf.for %arg4 = %c0_24 to %c16_25 step %c1_26 {
-# CHECK-NEXT:          %subview_27 = memref.subview %subview_23[0, %arg4] [1, 1] [1, 1] : memref<1x16xf32, strided<[16, 1], offset: ?>> to memref<1x1xf32, strided<[16, 1], offset: ?>>
-# CHECK-NEXT:          linalg.fill {__xtc_id_matmul_padded_0_} ins(%cst_12 : f32) outs(%subview_27 : memref<1x1xf32, strided<[16, 1], offset: ?>>)
-# CHECK-NEXT:        } {"./j"}
-# CHECK-NEXT:      } {"./i"}
-# CHECK-NEXT:      %c0_16 = arith.constant 0 : index
-# CHECK-NEXT:      %c16_17 = arith.constant 16 : index
-# CHECK-NEXT:      %c1_18 = arith.constant 1 : index
-# CHECK-NEXT:      scf.for %arg3 = %c0_16 to %c16_17 step %c1_18 {
-# CHECK-NEXT:        %subview_23 = memref.subview %alloca[%arg3, 0] [1, 16] [1, 1] : memref<16x16xf32> to memref<1x16xf32, strided<[16, 1], offset: ?>>
-# CHECK-NEXT:        %subview_24 = memref.subview %alloca_2[0, 0] [16, 16] [1, 1] : memref<16x16xf32> to memref<16x16xf32, strided<[16, 1]>>
-# CHECK-NEXT:        %subview_25 = memref.subview %alloca_11[%arg3, 0] [1, 16] [1, 1] : memref<16x16xf32> to memref<1x16xf32, strided<[16, 1], offset: ?>>
-# CHECK-NEXT:        %c0_26 = arith.constant 0 : index
-# CHECK-NEXT:        %c16_27 = arith.constant 16 : index
-# CHECK-NEXT:        %c1_28 = arith.constant 1 : index
-# CHECK-NEXT:        scf.for %arg4 = %c0_26 to %c16_27 step %c1_28 {
-# CHECK-NEXT:          %subview_29 = memref.subview %subview_23[0, 0] [1, 16] [1, 1] : memref<1x16xf32, strided<[16, 1], offset: ?>> to memref<1x16xf32, strided<[16, 1], offset: ?>>
-# CHECK-NEXT:          %subview_30 = memref.subview %subview_24[0, %arg4] [16, 1] [1, 1] : memref<16x16xf32, strided<[16, 1]>> to memref<16x1xf32, strided<[16, 1], offset: ?>>
-# CHECK-NEXT:          %subview_31 = memref.subview %subview_25[0, %arg4] [1, 1] [1, 1] : memref<1x16xf32, strided<[16, 1], offset: ?>> to memref<1x1xf32, strided<[16, 1], offset: ?>>
-# CHECK-NEXT:          %c0_32 = arith.constant 0 : index
-# CHECK-NEXT:          %c16_33 = arith.constant 16 : index
-# CHECK-NEXT:          %c1_34 = arith.constant 1 : index
-# CHECK-NEXT:          scf.for %arg5 = %c0_32 to %c16_33 step %c1_34 {
-# CHECK-NEXT:            %subview_35 = memref.subview %subview_29[0, %arg5] [1, 1] [1, 1] : memref<1x16xf32, strided<[16, 1], offset: ?>> to memref<1x1xf32, strided<[16, 1], offset: ?>>
-# CHECK-NEXT:            %subview_36 = memref.subview %subview_30[%arg5, 0] [1, 1] [1, 1] : memref<16x1xf32, strided<[16, 1], offset: ?>> to memref<1x1xf32, strided<[16, 1], offset: ?>>
-# CHECK-NEXT:            %subview_37 = memref.subview %subview_31[0, 0] [1, 1] [1, 1] : memref<1x1xf32, strided<[16, 1], offset: ?>> to memref<1x1xf32, strided<[16, 1], offset: ?>>
-# CHECK-NEXT:            linalg.matmul {__xtc_id_matmul_padded_} ins(%subview_35, %subview_36 : memref<1x1xf32, strided<[16, 1], offset: ?>>, memref<1x1xf32, strided<[16, 1], offset: ?>>) outs(%subview_37 : memref<1x1xf32, strided<[16, 1], offset: ?>>)
+# CHECK-NEXT:      %c16 = arith.constant 16 : index
+# CHECK-NEXT:      %c1_9 = arith.constant 1 : index
+# CHECK-NEXT:      scf.for %arg3 = %c0_8 to %c16 step %c1_9 {
+# CHECK-NEXT:        %subview_14 = memref.subview %alloca[%arg3, 0] [1, 16] [1, 1] : memref<16x16xf32> to memref<1x16xf32, strided<[16, 1], offset: ?>>
+# CHECK-NEXT:        %subview_15 = memref.subview %alloca_0[0, 0] [16, 16] [1, 1] : memref<16x16xf32> to memref<16x16xf32, strided<[16, 1]>>
+# CHECK-NEXT:        %subview_16 = memref.subview %alloca_6[%arg3, 0] [1, 16] [1, 1] : memref<16x16xf32> to memref<1x16xf32, strided<[16, 1], offset: ?>>
+# CHECK-NEXT:        %c0_17 = arith.constant 0 : index
+# CHECK-NEXT:        %c16_18 = arith.constant 16 : index
+# CHECK-NEXT:        %c1_19 = arith.constant 1 : index
+# CHECK-NEXT:        scf.for %arg4 = %c0_17 to %c16_18 step %c1_19 {
+# CHECK-NEXT:          %subview_20 = memref.subview %subview_14[0, 0] [1, 16] [1, 1] : memref<1x16xf32, strided<[16, 1], offset: ?>> to memref<1x16xf32, strided<[16, 1], offset: ?>>
+# CHECK-NEXT:          %subview_21 = memref.subview %subview_15[0, %arg4] [16, 1] [1, 1] : memref<16x16xf32, strided<[16, 1]>> to memref<16x1xf32, strided<[16, 1], offset: ?>>
+# CHECK-NEXT:          %subview_22 = memref.subview %subview_16[0, %arg4] [1, 1] [1, 1] : memref<1x16xf32, strided<[16, 1], offset: ?>> to memref<1x1xf32, strided<[16, 1], offset: ?>>
+# CHECK-NEXT:          %c0_23 = arith.constant 0 : index
+# CHECK-NEXT:          %c16_24 = arith.constant 16 : index
+# CHECK-NEXT:          %c1_25 = arith.constant 1 : index
+# CHECK-NEXT:          scf.for %arg5 = %c0_23 to %c16_24 step %c1_25 {
+# CHECK-NEXT:            %subview_26 = memref.subview %subview_20[0, %arg5] [1, 1] [1, 1] : memref<1x16xf32, strided<[16, 1], offset: ?>> to memref<1x1xf32, strided<[16, 1], offset: ?>>
+# CHECK-NEXT:            %subview_27 = memref.subview %subview_21[%arg5, 0] [1, 1] [1, 1] : memref<16x1xf32, strided<[16, 1], offset: ?>> to memref<1x1xf32, strided<[16, 1], offset: ?>>
+# CHECK-NEXT:            %subview_28 = memref.subview %subview_22[0, 0] [1, 1] [1, 1] : memref<1x1xf32, strided<[16, 1], offset: ?>> to memref<1x1xf32, strided<[16, 1], offset: ?>>
+# CHECK-NEXT:            linalg.matmul {__xtc_id_matmul_padded_} ins(%subview_26, %subview_27 : memref<1x1xf32, strided<[16, 1], offset: ?>>, memref<1x1xf32, strided<[16, 1], offset: ?>>) outs(%subview_28 : memref<1x1xf32, strided<[16, 1], offset: ?>>)
 # CHECK-NEXT:          } {"./k"}
 # CHECK-NEXT:        } {"./j"}
 # CHECK-NEXT:      } {"./i"}
-# CHECK-NEXT:      %subview_19 = memref.subview %alloca_11[0, 0] [14, 14] [1, 1] : memref<16x16xf32> to memref<14x14xf32, strided<[16, 1]>>
-# CHECK-NEXT:      %c0_20 = arith.constant 0 : index
-# CHECK-NEXT:      %c14_21 = arith.constant 14 : index
-# CHECK-NEXT:      %c1_22 = arith.constant 1 : index
-# CHECK-NEXT:      scf.for %arg3 = %c0_20 to %c14_21 step %c1_22 {
-# CHECK-NEXT:        %subview_23 = memref.subview %subview_19[%arg3, 0] [1, 14] [1, 1] : memref<14x14xf32, strided<[16, 1]>> to memref<1x14xf32, strided<[16, 1], offset: ?>>
-# CHECK-NEXT:        %subview_24 = memref.subview %arg2[%arg3, 0] [1, 14] [1, 1] : memref<14x14xf32> to memref<1x14xf32, strided<[14, 1], offset: ?>>
-# CHECK-NEXT:        %c0_25 = arith.constant 0 : index
-# CHECK-NEXT:        %c14_26 = arith.constant 14 : index
-# CHECK-NEXT:        %c1_27 = arith.constant 1 : index
-# CHECK-NEXT:        scf.for %arg4 = %c0_25 to %c14_26 step %c1_27 {
-# CHECK-NEXT:          %subview_28 = memref.subview %subview_23[0, %arg4] [1, 1] [1, 1] : memref<1x14xf32, strided<[16, 1], offset: ?>> to memref<1x1xf32, strided<[16, 1], offset: ?>>
-# CHECK-NEXT:          %subview_29 = memref.subview %subview_24[0, %arg4] [1, 1] [1, 1] : memref<1x14xf32, strided<[14, 1], offset: ?>> to memref<1x1xf32, strided<[14, 1], offset: ?>>
-# CHECK-NEXT:          linalg.copy {__xtc_id_C_} ins(%subview_28 : memref<1x1xf32, strided<[16, 1], offset: ?>>) outs(%subview_29 : memref<1x1xf32, strided<[14, 1], offset: ?>>)
+# CHECK-NEXT:      %subview_10 = memref.subview %alloca_6[0, 0] [14, 14] [1, 1] : memref<16x16xf32> to memref<14x14xf32, strided<[16, 1]>>
+# CHECK-NEXT:      %c0_11 = arith.constant 0 : index
+# CHECK-NEXT:      %c14_12 = arith.constant 14 : index
+# CHECK-NEXT:      %c1_13 = arith.constant 1 : index
+# CHECK-NEXT:      scf.for %arg3 = %c0_11 to %c14_12 step %c1_13 {
+# CHECK-NEXT:        %subview_14 = memref.subview %subview_10[%arg3, 0] [1, 14] [1, 1] : memref<14x14xf32, strided<[16, 1]>> to memref<1x14xf32, strided<[16, 1], offset: ?>>
+# CHECK-NEXT:        %subview_15 = memref.subview %arg2[%arg3, 0] [1, 14] [1, 1] : memref<14x14xf32> to memref<1x14xf32, strided<[14, 1], offset: ?>>
+# CHECK-NEXT:        %c0_16 = arith.constant 0 : index
+# CHECK-NEXT:        %c14_17 = arith.constant 14 : index
+# CHECK-NEXT:        %c1_18 = arith.constant 1 : index
+# CHECK-NEXT:        scf.for %arg4 = %c0_16 to %c14_17 step %c1_18 {
+# CHECK-NEXT:          %subview_19 = memref.subview %subview_14[0, %arg4] [1, 1] [1, 1] : memref<1x14xf32, strided<[16, 1], offset: ?>> to memref<1x1xf32, strided<[16, 1], offset: ?>>
+# CHECK-NEXT:          %subview_20 = memref.subview %subview_15[0, %arg4] [1, 1] [1, 1] : memref<1x14xf32, strided<[14, 1], offset: ?>> to memref<1x1xf32, strided<[14, 1], offset: ?>>
+# CHECK-NEXT:          linalg.copy {__xtc_id_C_} ins(%subview_19 : memref<1x1xf32, strided<[16, 1], offset: ?>>) outs(%subview_20 : memref<1x1xf32, strided<[14, 1], offset: ?>>)
 # CHECK-NEXT:        } {"./j"}
 # CHECK-NEXT:      } {"./i"}
 # CHECK-NEXT:      return

--- a/tests/filecheck/backends/padding/test_pad_constant_conv2d_mlir.py
+++ b/tests/filecheck/backends/padding/test_pad_constant_conv2d_mlir.py
@@ -57,7 +57,7 @@ print(f"CODE: {res}")
 # CHECK-NEXT:      transform.yield 
 # CHECK-NEXT:    }
 # CHECK-NEXT:    transform.named_sequence @__transform_main(%arg0: !transform.any_op {transform.readonly}) {
-# CHECK-NEXT:      %0 = transform.structured.match attributes {__xtc_id_pad_0_} in %arg0 : (!transform.any_op) -> !transform.any_op
+# CHECK-NEXT:      %0 = transform.structured.match attributes {__xtc_id_pad_} in %arg0 : (!transform.any_op) -> !transform.any_op
 # CHECK-NEXT:      %tiled_linalg_op, %loops = transform.structured.tile_using_for %0 tile_sizes [1, 0, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
 # CHECK-NEXT:      transform.annotate %loops "./b" : !transform.any_op
 # CHECK-NEXT:      %tiled_linalg_op_0, %loops_1 = transform.structured.tile_using_for %tiled_linalg_op tile_sizes [0, 1, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
@@ -66,39 +66,21 @@ print(f"CODE: {res}")
 # CHECK-NEXT:      transform.annotate %loops_3 "./w" : !transform.any_op
 # CHECK-NEXT:      %tiled_linalg_op_4, %loops_5 = transform.structured.tile_using_for %tiled_linalg_op_2 tile_sizes [0, 0, 0, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
 # CHECK-NEXT:      transform.annotate %loops_5 "./c" : !transform.any_op
-# CHECK-NEXT:      %1 = transform.structured.match attributes {__xtc_id_pad_} in %arg0 : (!transform.any_op) -> !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_6, %loops_7 = transform.structured.tile_using_for %1 tile_sizes [1, 0, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      %1 = transform.structured.match attributes {__xtc_id_conv_} in %arg0 : (!transform.any_op) -> !transform.any_op
+# CHECK-NEXT:      %tiled_linalg_op_6, %loops_7 = transform.structured.tile_using_for %1 tile_sizes [1, 0, 0, 0, 0, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
 # CHECK-NEXT:      transform.annotate %loops_7 "./b" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_8, %loops_9 = transform.structured.tile_using_for %tiled_linalg_op_6 tile_sizes [0, 1, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      %tiled_linalg_op_8, %loops_9 = transform.structured.tile_using_for %tiled_linalg_op_6 tile_sizes [0, 1, 0, 0, 0, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
 # CHECK-NEXT:      transform.annotate %loops_9 "./h" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_10, %loops_11 = transform.structured.tile_using_for %tiled_linalg_op_8 tile_sizes [0, 0, 1, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      %tiled_linalg_op_10, %loops_11 = transform.structured.tile_using_for %tiled_linalg_op_8 tile_sizes [0, 0, 1, 0, 0, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
 # CHECK-NEXT:      transform.annotate %loops_11 "./w" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_12, %loops_13 = transform.structured.tile_using_for %tiled_linalg_op_10 tile_sizes [0, 0, 0, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_13 "./c" : !transform.any_op
-# CHECK-NEXT:      %2 = transform.structured.match attributes {__xtc_id_conv_0_} in %arg0 : (!transform.any_op) -> !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_14, %loops_15 = transform.structured.tile_using_for %2 tile_sizes [1, 0, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_15 "./b" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_16, %loops_17 = transform.structured.tile_using_for %tiled_linalg_op_14 tile_sizes [0, 1, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_17 "./h" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_18, %loops_19 = transform.structured.tile_using_for %tiled_linalg_op_16 tile_sizes [0, 0, 1, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_19 "./w" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_20, %loops_21 = transform.structured.tile_using_for %tiled_linalg_op_18 tile_sizes [0, 0, 0, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_21 "./f" : !transform.any_op
-# CHECK-NEXT:      %3 = transform.structured.match attributes {__xtc_id_conv_} in %arg0 : (!transform.any_op) -> !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_22, %loops_23 = transform.structured.tile_using_for %3 tile_sizes [1, 0, 0, 0, 0, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_23 "./b" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_24, %loops_25 = transform.structured.tile_using_for %tiled_linalg_op_22 tile_sizes [0, 1, 0, 0, 0, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_25 "./h" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_26, %loops_27 = transform.structured.tile_using_for %tiled_linalg_op_24 tile_sizes [0, 0, 1, 0, 0, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_27 "./w" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_28, %loops_29 = transform.structured.tile_using_for %tiled_linalg_op_26 tile_sizes [0, 0, 0, 1, 0, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_29 "./f" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_30, %loops_31 = transform.structured.tile_using_for %tiled_linalg_op_28 tile_sizes [0, 0, 0, 0, 1, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_31 "./r" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_32, %loops_33 = transform.structured.tile_using_for %tiled_linalg_op_30 tile_sizes [0, 0, 0, 0, 0, 1, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_33 "./s" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_34, %loops_35 = transform.structured.tile_using_for %tiled_linalg_op_32 tile_sizes [0, 0, 0, 0, 0, 0, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_35 "./c" : !transform.any_op
+# CHECK-NEXT:      %tiled_linalg_op_12, %loops_13 = transform.structured.tile_using_for %tiled_linalg_op_10 tile_sizes [0, 0, 0, 1, 0, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      transform.annotate %loops_13 "./f" : !transform.any_op
+# CHECK-NEXT:      %tiled_linalg_op_14, %loops_15 = transform.structured.tile_using_for %tiled_linalg_op_12 tile_sizes [0, 0, 0, 0, 1, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      transform.annotate %loops_15 "./r" : !transform.any_op
+# CHECK-NEXT:      %tiled_linalg_op_16, %loops_17 = transform.structured.tile_using_for %tiled_linalg_op_14 tile_sizes [0, 0, 0, 0, 0, 1, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      transform.annotate %loops_17 "./s" : !transform.any_op
+# CHECK-NEXT:      %tiled_linalg_op_18, %loops_19 = transform.structured.tile_using_for %tiled_linalg_op_16 tile_sizes [0, 0, 0, 0, 0, 0, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      transform.annotate %loops_19 "./c" : !transform.any_op
 # CHECK-NEXT:      transform.yield 
 # CHECK-NEXT:    }
 # CHECK-NEXT:  }
@@ -112,141 +94,93 @@ print(f"CODE: {res}")
 # CHECK-NEXT:    func.func @pad_conv2d_nhwc_mini(%arg0: memref<1x8x8x3xf32> {llvm.noalias}, %arg1: memref<5x5x3x16xf32> {llvm.noalias}, %arg2: memref<1x4x4x16xf32> {llvm.noalias}) {
 # CHECK-NEXT:      %alloca = memref.alloca() {alignment = 256 : i64} : memref<1x12x12x3xf32>
 # CHECK-NEXT:      %cst = arith.constant 3.000000e+00 : f32
+# CHECK-NEXT:      linalg.fill {__xtc_id_pad_0_} ins(%cst : f32) outs(%alloca : memref<1x12x12x3xf32>)
+# CHECK-NEXT:      %subview = memref.subview %alloca[0, 2, 2, 0] [1, 8, 8, 3] [1, 1, 1, 1] : memref<1x12x12x3xf32> to memref<1x8x8x3xf32, strided<[432, 36, 3, 1], offset: 78>>
 # CHECK-NEXT:      %c0 = arith.constant 0 : index
 # CHECK-NEXT:      %c1 = arith.constant 1 : index
 # CHECK-NEXT:      %c1_0 = arith.constant 1 : index
 # CHECK-NEXT:      scf.for %arg3 = %c0 to %c1 step %c1_0 {
-# CHECK-NEXT:        %subview_11 = memref.subview %alloca[%arg3, 0, 0, 0] [1, 12, 12, 3] [1, 1, 1, 1] : memref<1x12x12x3xf32> to memref<1x12x12x3xf32, strided<[432, 36, 3, 1], offset: ?>>
-# CHECK-NEXT:        %c0_12 = arith.constant 0 : index
-# CHECK-NEXT:        %c12 = arith.constant 12 : index
-# CHECK-NEXT:        %c1_13 = arith.constant 1 : index
-# CHECK-NEXT:        scf.for %arg4 = %c0_12 to %c12 step %c1_13 {
-# CHECK-NEXT:          %subview_14 = memref.subview %subview_11[0, %arg4, 0, 0] [1, 1, 12, 3] [1, 1, 1, 1] : memref<1x12x12x3xf32, strided<[432, 36, 3, 1], offset: ?>> to memref<1x1x12x3xf32, strided<[432, 36, 3, 1], offset: ?>>
-# CHECK-NEXT:          %c0_15 = arith.constant 0 : index
-# CHECK-NEXT:          %c12_16 = arith.constant 12 : index
-# CHECK-NEXT:          %c1_17 = arith.constant 1 : index
-# CHECK-NEXT:          scf.for %arg5 = %c0_15 to %c12_16 step %c1_17 {
-# CHECK-NEXT:            %subview_18 = memref.subview %subview_14[0, 0, %arg5, 0] [1, 1, 1, 3] [1, 1, 1, 1] : memref<1x1x12x3xf32, strided<[432, 36, 3, 1], offset: ?>> to memref<1x1x1x3xf32, strided<[432, 36, 3, 1], offset: ?>>
-# CHECK-NEXT:            %c0_19 = arith.constant 0 : index
-# CHECK-NEXT:            %c3 = arith.constant 3 : index
-# CHECK-NEXT:            %c1_20 = arith.constant 1 : index
-# CHECK-NEXT:            scf.for %arg6 = %c0_19 to %c3 step %c1_20 {
-# CHECK-NEXT:              %subview_21 = memref.subview %subview_18[0, 0, 0, %arg6] [1, 1, 1, 1] [1, 1, 1, 1] : memref<1x1x1x3xf32, strided<[432, 36, 3, 1], offset: ?>> to memref<1x1x1x1xf32, strided<[432, 36, 3, 1], offset: ?>>
-# CHECK-NEXT:              linalg.fill {__xtc_id_pad_0_} ins(%cst : f32) outs(%subview_21 : memref<1x1x1x1xf32, strided<[432, 36, 3, 1], offset: ?>>)
-# CHECK-NEXT:            } {"./c"}
-# CHECK-NEXT:          } {"./w"}
-# CHECK-NEXT:        } {"./h"}
-# CHECK-NEXT:      } {"./b"}
-# CHECK-NEXT:      %subview = memref.subview %alloca[0, 2, 2, 0] [1, 8, 8, 3] [1, 1, 1, 1] : memref<1x12x12x3xf32> to memref<1x8x8x3xf32, strided<[432, 36, 3, 1], offset: 78>>
-# CHECK-NEXT:      %c0_1 = arith.constant 0 : index
-# CHECK-NEXT:      %c1_2 = arith.constant 1 : index
-# CHECK-NEXT:      %c1_3 = arith.constant 1 : index
-# CHECK-NEXT:      scf.for %arg3 = %c0_1 to %c1_2 step %c1_3 {
-# CHECK-NEXT:        %subview_11 = memref.subview %arg0[%arg3, 0, 0, 0] [1, 8, 8, 3] [1, 1, 1, 1] : memref<1x8x8x3xf32> to memref<1x8x8x3xf32, strided<[192, 24, 3, 1], offset: ?>>
-# CHECK-NEXT:        %subview_12 = memref.subview %subview[%arg3, 0, 0, 0] [1, 8, 8, 3] [1, 1, 1, 1] : memref<1x8x8x3xf32, strided<[432, 36, 3, 1], offset: 78>> to memref<1x8x8x3xf32, strided<[432, 36, 3, 1], offset: ?>>
-# CHECK-NEXT:        %c0_13 = arith.constant 0 : index
+# CHECK-NEXT:        %subview_5 = memref.subview %arg0[%arg3, 0, 0, 0] [1, 8, 8, 3] [1, 1, 1, 1] : memref<1x8x8x3xf32> to memref<1x8x8x3xf32, strided<[192, 24, 3, 1], offset: ?>>
+# CHECK-NEXT:        %subview_6 = memref.subview %subview[%arg3, 0, 0, 0] [1, 8, 8, 3] [1, 1, 1, 1] : memref<1x8x8x3xf32, strided<[432, 36, 3, 1], offset: 78>> to memref<1x8x8x3xf32, strided<[432, 36, 3, 1], offset: ?>>
+# CHECK-NEXT:        %c0_7 = arith.constant 0 : index
 # CHECK-NEXT:        %c8 = arith.constant 8 : index
-# CHECK-NEXT:        %c1_14 = arith.constant 1 : index
-# CHECK-NEXT:        scf.for %arg4 = %c0_13 to %c8 step %c1_14 {
-# CHECK-NEXT:          %subview_15 = memref.subview %subview_11[0, %arg4, 0, 0] [1, 1, 8, 3] [1, 1, 1, 1] : memref<1x8x8x3xf32, strided<[192, 24, 3, 1], offset: ?>> to memref<1x1x8x3xf32, strided<[192, 24, 3, 1], offset: ?>>
-# CHECK-NEXT:          %subview_16 = memref.subview %subview_12[0, %arg4, 0, 0] [1, 1, 8, 3] [1, 1, 1, 1] : memref<1x8x8x3xf32, strided<[432, 36, 3, 1], offset: ?>> to memref<1x1x8x3xf32, strided<[432, 36, 3, 1], offset: ?>>
-# CHECK-NEXT:          %c0_17 = arith.constant 0 : index
-# CHECK-NEXT:          %c8_18 = arith.constant 8 : index
-# CHECK-NEXT:          %c1_19 = arith.constant 1 : index
-# CHECK-NEXT:          scf.for %arg5 = %c0_17 to %c8_18 step %c1_19 {
-# CHECK-NEXT:            %subview_20 = memref.subview %subview_15[0, 0, %arg5, 0] [1, 1, 1, 3] [1, 1, 1, 1] : memref<1x1x8x3xf32, strided<[192, 24, 3, 1], offset: ?>> to memref<1x1x1x3xf32, strided<[192, 24, 3, 1], offset: ?>>
-# CHECK-NEXT:            %subview_21 = memref.subview %subview_16[0, 0, %arg5, 0] [1, 1, 1, 3] [1, 1, 1, 1] : memref<1x1x8x3xf32, strided<[432, 36, 3, 1], offset: ?>> to memref<1x1x1x3xf32, strided<[432, 36, 3, 1], offset: ?>>
-# CHECK-NEXT:            %c0_22 = arith.constant 0 : index
+# CHECK-NEXT:        %c1_8 = arith.constant 1 : index
+# CHECK-NEXT:        scf.for %arg4 = %c0_7 to %c8 step %c1_8 {
+# CHECK-NEXT:          %subview_9 = memref.subview %subview_5[0, %arg4, 0, 0] [1, 1, 8, 3] [1, 1, 1, 1] : memref<1x8x8x3xf32, strided<[192, 24, 3, 1], offset: ?>> to memref<1x1x8x3xf32, strided<[192, 24, 3, 1], offset: ?>>
+# CHECK-NEXT:          %subview_10 = memref.subview %subview_6[0, %arg4, 0, 0] [1, 1, 8, 3] [1, 1, 1, 1] : memref<1x8x8x3xf32, strided<[432, 36, 3, 1], offset: ?>> to memref<1x1x8x3xf32, strided<[432, 36, 3, 1], offset: ?>>
+# CHECK-NEXT:          %c0_11 = arith.constant 0 : index
+# CHECK-NEXT:          %c8_12 = arith.constant 8 : index
+# CHECK-NEXT:          %c1_13 = arith.constant 1 : index
+# CHECK-NEXT:          scf.for %arg5 = %c0_11 to %c8_12 step %c1_13 {
+# CHECK-NEXT:            %subview_14 = memref.subview %subview_9[0, 0, %arg5, 0] [1, 1, 1, 3] [1, 1, 1, 1] : memref<1x1x8x3xf32, strided<[192, 24, 3, 1], offset: ?>> to memref<1x1x1x3xf32, strided<[192, 24, 3, 1], offset: ?>>
+# CHECK-NEXT:            %subview_15 = memref.subview %subview_10[0, 0, %arg5, 0] [1, 1, 1, 3] [1, 1, 1, 1] : memref<1x1x8x3xf32, strided<[432, 36, 3, 1], offset: ?>> to memref<1x1x1x3xf32, strided<[432, 36, 3, 1], offset: ?>>
+# CHECK-NEXT:            %c0_16 = arith.constant 0 : index
 # CHECK-NEXT:            %c3 = arith.constant 3 : index
-# CHECK-NEXT:            %c1_23 = arith.constant 1 : index
-# CHECK-NEXT:            scf.for %arg6 = %c0_22 to %c3 step %c1_23 {
-# CHECK-NEXT:              %subview_24 = memref.subview %subview_20[0, 0, 0, %arg6] [1, 1, 1, 1] [1, 1, 1, 1] : memref<1x1x1x3xf32, strided<[192, 24, 3, 1], offset: ?>> to memref<1x1x1x1xf32, strided<[192, 24, 3, 1], offset: ?>>
-# CHECK-NEXT:              %subview_25 = memref.subview %subview_21[0, 0, 0, %arg6] [1, 1, 1, 1] [1, 1, 1, 1] : memref<1x1x1x3xf32, strided<[432, 36, 3, 1], offset: ?>> to memref<1x1x1x1xf32, strided<[432, 36, 3, 1], offset: ?>>
-# CHECK-NEXT:              linalg.copy {__xtc_id_pad_} ins(%subview_24 : memref<1x1x1x1xf32, strided<[192, 24, 3, 1], offset: ?>>) outs(%subview_25 : memref<1x1x1x1xf32, strided<[432, 36, 3, 1], offset: ?>>)
+# CHECK-NEXT:            %c1_17 = arith.constant 1 : index
+# CHECK-NEXT:            scf.for %arg6 = %c0_16 to %c3 step %c1_17 {
+# CHECK-NEXT:              %subview_18 = memref.subview %subview_14[0, 0, 0, %arg6] [1, 1, 1, 1] [1, 1, 1, 1] : memref<1x1x1x3xf32, strided<[192, 24, 3, 1], offset: ?>> to memref<1x1x1x1xf32, strided<[192, 24, 3, 1], offset: ?>>
+# CHECK-NEXT:              %subview_19 = memref.subview %subview_15[0, 0, 0, %arg6] [1, 1, 1, 1] [1, 1, 1, 1] : memref<1x1x1x3xf32, strided<[432, 36, 3, 1], offset: ?>> to memref<1x1x1x1xf32, strided<[432, 36, 3, 1], offset: ?>>
+# CHECK-NEXT:              linalg.copy {__xtc_id_pad_} ins(%subview_18 : memref<1x1x1x1xf32, strided<[192, 24, 3, 1], offset: ?>>) outs(%subview_19 : memref<1x1x1x1xf32, strided<[432, 36, 3, 1], offset: ?>>)
 # CHECK-NEXT:            } {"./c"}
 # CHECK-NEXT:          } {"./w"}
 # CHECK-NEXT:        } {"./h"}
 # CHECK-NEXT:      } {"./b"}
-# CHECK-NEXT:      %cst_4 = arith.constant 0.000000e+00 : f32
-# CHECK-NEXT:      %c0_5 = arith.constant 0 : index
-# CHECK-NEXT:      %c1_6 = arith.constant 1 : index
-# CHECK-NEXT:      %c1_7 = arith.constant 1 : index
-# CHECK-NEXT:      scf.for %arg3 = %c0_5 to %c1_6 step %c1_7 {
-# CHECK-NEXT:        %subview_11 = memref.subview %arg2[%arg3, 0, 0, 0] [1, 4, 4, 16] [1, 1, 1, 1] : memref<1x4x4x16xf32> to memref<1x4x4x16xf32, strided<[256, 64, 16, 1], offset: ?>>
-# CHECK-NEXT:        %c0_12 = arith.constant 0 : index
+# CHECK-NEXT:      %cst_1 = arith.constant 0.000000e+00 : f32
+# CHECK-NEXT:      linalg.fill {__xtc_id_conv_0_} ins(%cst_1 : f32) outs(%arg2 : memref<1x4x4x16xf32>)
+# CHECK-NEXT:      %c0_2 = arith.constant 0 : index
+# CHECK-NEXT:      %c1_3 = arith.constant 1 : index
+# CHECK-NEXT:      %c1_4 = arith.constant 1 : index
+# CHECK-NEXT:      scf.for %arg3 = %c0_2 to %c1_3 step %c1_4 {
+# CHECK-NEXT:        %subview_5 = memref.subview %alloca[%arg3, 0, 0, 0] [1, 11, 11, 3] [1, 1, 1, 1] : memref<1x12x12x3xf32> to memref<1x11x11x3xf32, strided<[432, 36, 3, 1], offset: ?>>
+# CHECK-NEXT:        %subview_6 = memref.subview %arg1[0, 0, 0, 0] [5, 5, 3, 16] [1, 1, 1, 1] : memref<5x5x3x16xf32> to memref<5x5x3x16xf32, strided<[240, 48, 16, 1]>>
+# CHECK-NEXT:        %subview_7 = memref.subview %arg2[%arg3, 0, 0, 0] [1, 4, 4, 16] [1, 1, 1, 1] : memref<1x4x4x16xf32> to memref<1x4x4x16xf32, strided<[256, 64, 16, 1], offset: ?>>
+# CHECK-NEXT:        %c0_8 = arith.constant 0 : index
 # CHECK-NEXT:        %c4 = arith.constant 4 : index
-# CHECK-NEXT:        %c1_13 = arith.constant 1 : index
-# CHECK-NEXT:        scf.for %arg4 = %c0_12 to %c4 step %c1_13 {
-# CHECK-NEXT:          %subview_14 = memref.subview %subview_11[0, %arg4, 0, 0] [1, 1, 4, 16] [1, 1, 1, 1] : memref<1x4x4x16xf32, strided<[256, 64, 16, 1], offset: ?>> to memref<1x1x4x16xf32, strided<[256, 64, 16, 1], offset: ?>>
-# CHECK-NEXT:          %c0_15 = arith.constant 0 : index
-# CHECK-NEXT:          %c4_16 = arith.constant 4 : index
-# CHECK-NEXT:          %c1_17 = arith.constant 1 : index
-# CHECK-NEXT:          scf.for %arg5 = %c0_15 to %c4_16 step %c1_17 {
-# CHECK-NEXT:            %subview_18 = memref.subview %subview_14[0, 0, %arg5, 0] [1, 1, 1, 16] [1, 1, 1, 1] : memref<1x1x4x16xf32, strided<[256, 64, 16, 1], offset: ?>> to memref<1x1x1x16xf32, strided<[256, 64, 16, 1], offset: ?>>
+# CHECK-NEXT:        %c1_9 = arith.constant 1 : index
+# CHECK-NEXT:        scf.for %arg4 = %c0_8 to %c4 step %c1_9 {
+# CHECK-NEXT:          %0 = affine.apply #map(%arg4)
+# CHECK-NEXT:          %subview_10 = memref.subview %subview_5[0, %0, 0, 0] [1, 5, 11, 3] [1, 1, 1, 1] : memref<1x11x11x3xf32, strided<[432, 36, 3, 1], offset: ?>> to memref<1x5x11x3xf32, strided<[432, 36, 3, 1], offset: ?>>
+# CHECK-NEXT:          %subview_11 = memref.subview %subview_6[0, 0, 0, 0] [5, 5, 3, 16] [1, 1, 1, 1] : memref<5x5x3x16xf32, strided<[240, 48, 16, 1]>> to memref<5x5x3x16xf32, strided<[240, 48, 16, 1]>>
+# CHECK-NEXT:          %subview_12 = memref.subview %subview_7[0, %arg4, 0, 0] [1, 1, 4, 16] [1, 1, 1, 1] : memref<1x4x4x16xf32, strided<[256, 64, 16, 1], offset: ?>> to memref<1x1x4x16xf32, strided<[256, 64, 16, 1], offset: ?>>
+# CHECK-NEXT:          %c0_13 = arith.constant 0 : index
+# CHECK-NEXT:          %c4_14 = arith.constant 4 : index
+# CHECK-NEXT:          %c1_15 = arith.constant 1 : index
+# CHECK-NEXT:          scf.for %arg5 = %c0_13 to %c4_14 step %c1_15 {
+# CHECK-NEXT:            %1 = affine.apply #map(%arg5)
+# CHECK-NEXT:            %subview_16 = memref.subview %subview_10[0, 0, %1, 0] [1, 5, 5, 3] [1, 1, 1, 1] : memref<1x5x11x3xf32, strided<[432, 36, 3, 1], offset: ?>> to memref<1x5x5x3xf32, strided<[432, 36, 3, 1], offset: ?>>
+# CHECK-NEXT:            %subview_17 = memref.subview %subview_11[0, 0, 0, 0] [5, 5, 3, 16] [1, 1, 1, 1] : memref<5x5x3x16xf32, strided<[240, 48, 16, 1]>> to memref<5x5x3x16xf32, strided<[240, 48, 16, 1]>>
+# CHECK-NEXT:            %subview_18 = memref.subview %subview_12[0, 0, %arg5, 0] [1, 1, 1, 16] [1, 1, 1, 1] : memref<1x1x4x16xf32, strided<[256, 64, 16, 1], offset: ?>> to memref<1x1x1x16xf32, strided<[256, 64, 16, 1], offset: ?>>
 # CHECK-NEXT:            %c0_19 = arith.constant 0 : index
 # CHECK-NEXT:            %c16 = arith.constant 16 : index
 # CHECK-NEXT:            %c1_20 = arith.constant 1 : index
 # CHECK-NEXT:            scf.for %arg6 = %c0_19 to %c16 step %c1_20 {
-# CHECK-NEXT:              %subview_21 = memref.subview %subview_18[0, 0, 0, %arg6] [1, 1, 1, 1] [1, 1, 1, 1] : memref<1x1x1x16xf32, strided<[256, 64, 16, 1], offset: ?>> to memref<1x1x1x1xf32, strided<[256, 64, 16, 1], offset: ?>>
-# CHECK-NEXT:              linalg.fill {__xtc_id_conv_0_} ins(%cst_4 : f32) outs(%subview_21 : memref<1x1x1x1xf32, strided<[256, 64, 16, 1], offset: ?>>)
-# CHECK-NEXT:            } {"./f"}
-# CHECK-NEXT:          } {"./w"}
-# CHECK-NEXT:        } {"./h"}
-# CHECK-NEXT:      } {"./b"}
-# CHECK-NEXT:      %c0_8 = arith.constant 0 : index
-# CHECK-NEXT:      %c1_9 = arith.constant 1 : index
-# CHECK-NEXT:      %c1_10 = arith.constant 1 : index
-# CHECK-NEXT:      scf.for %arg3 = %c0_8 to %c1_9 step %c1_10 {
-# CHECK-NEXT:        %subview_11 = memref.subview %alloca[%arg3, 0, 0, 0] [1, 11, 11, 3] [1, 1, 1, 1] : memref<1x12x12x3xf32> to memref<1x11x11x3xf32, strided<[432, 36, 3, 1], offset: ?>>
-# CHECK-NEXT:        %subview_12 = memref.subview %arg1[0, 0, 0, 0] [5, 5, 3, 16] [1, 1, 1, 1] : memref<5x5x3x16xf32> to memref<5x5x3x16xf32, strided<[240, 48, 16, 1]>>
-# CHECK-NEXT:        %subview_13 = memref.subview %arg2[%arg3, 0, 0, 0] [1, 4, 4, 16] [1, 1, 1, 1] : memref<1x4x4x16xf32> to memref<1x4x4x16xf32, strided<[256, 64, 16, 1], offset: ?>>
-# CHECK-NEXT:        %c0_14 = arith.constant 0 : index
-# CHECK-NEXT:        %c4 = arith.constant 4 : index
-# CHECK-NEXT:        %c1_15 = arith.constant 1 : index
-# CHECK-NEXT:        scf.for %arg4 = %c0_14 to %c4 step %c1_15 {
-# CHECK-NEXT:          %0 = affine.apply #map(%arg4)
-# CHECK-NEXT:          %subview_16 = memref.subview %subview_11[0, %0, 0, 0] [1, 5, 11, 3] [1, 1, 1, 1] : memref<1x11x11x3xf32, strided<[432, 36, 3, 1], offset: ?>> to memref<1x5x11x3xf32, strided<[432, 36, 3, 1], offset: ?>>
-# CHECK-NEXT:          %subview_17 = memref.subview %subview_12[0, 0, 0, 0] [5, 5, 3, 16] [1, 1, 1, 1] : memref<5x5x3x16xf32, strided<[240, 48, 16, 1]>> to memref<5x5x3x16xf32, strided<[240, 48, 16, 1]>>
-# CHECK-NEXT:          %subview_18 = memref.subview %subview_13[0, %arg4, 0, 0] [1, 1, 4, 16] [1, 1, 1, 1] : memref<1x4x4x16xf32, strided<[256, 64, 16, 1], offset: ?>> to memref<1x1x4x16xf32, strided<[256, 64, 16, 1], offset: ?>>
-# CHECK-NEXT:          %c0_19 = arith.constant 0 : index
-# CHECK-NEXT:          %c4_20 = arith.constant 4 : index
-# CHECK-NEXT:          %c1_21 = arith.constant 1 : index
-# CHECK-NEXT:          scf.for %arg5 = %c0_19 to %c4_20 step %c1_21 {
-# CHECK-NEXT:            %1 = affine.apply #map(%arg5)
-# CHECK-NEXT:            %subview_22 = memref.subview %subview_16[0, 0, %1, 0] [1, 5, 5, 3] [1, 1, 1, 1] : memref<1x5x11x3xf32, strided<[432, 36, 3, 1], offset: ?>> to memref<1x5x5x3xf32, strided<[432, 36, 3, 1], offset: ?>>
-# CHECK-NEXT:            %subview_23 = memref.subview %subview_17[0, 0, 0, 0] [5, 5, 3, 16] [1, 1, 1, 1] : memref<5x5x3x16xf32, strided<[240, 48, 16, 1]>> to memref<5x5x3x16xf32, strided<[240, 48, 16, 1]>>
-# CHECK-NEXT:            %subview_24 = memref.subview %subview_18[0, 0, %arg5, 0] [1, 1, 1, 16] [1, 1, 1, 1] : memref<1x1x4x16xf32, strided<[256, 64, 16, 1], offset: ?>> to memref<1x1x1x16xf32, strided<[256, 64, 16, 1], offset: ?>>
-# CHECK-NEXT:            %c0_25 = arith.constant 0 : index
-# CHECK-NEXT:            %c16 = arith.constant 16 : index
-# CHECK-NEXT:            %c1_26 = arith.constant 1 : index
-# CHECK-NEXT:            scf.for %arg6 = %c0_25 to %c16 step %c1_26 {
-# CHECK-NEXT:              %subview_27 = memref.subview %subview_22[0, 0, 0, 0] [1, 5, 5, 3] [1, 1, 1, 1] : memref<1x5x5x3xf32, strided<[432, 36, 3, 1], offset: ?>> to memref<1x5x5x3xf32, strided<[432, 36, 3, 1], offset: ?>>
-# CHECK-NEXT:              %subview_28 = memref.subview %subview_23[0, 0, 0, %arg6] [5, 5, 3, 1] [1, 1, 1, 1] : memref<5x5x3x16xf32, strided<[240, 48, 16, 1]>> to memref<5x5x3x1xf32, strided<[240, 48, 16, 1], offset: ?>>
-# CHECK-NEXT:              %subview_29 = memref.subview %subview_24[0, 0, 0, %arg6] [1, 1, 1, 1] [1, 1, 1, 1] : memref<1x1x1x16xf32, strided<[256, 64, 16, 1], offset: ?>> to memref<1x1x1x1xf32, strided<[256, 64, 16, 1], offset: ?>>
-# CHECK-NEXT:              %c0_30 = arith.constant 0 : index
+# CHECK-NEXT:              %subview_21 = memref.subview %subview_16[0, 0, 0, 0] [1, 5, 5, 3] [1, 1, 1, 1] : memref<1x5x5x3xf32, strided<[432, 36, 3, 1], offset: ?>> to memref<1x5x5x3xf32, strided<[432, 36, 3, 1], offset: ?>>
+# CHECK-NEXT:              %subview_22 = memref.subview %subview_17[0, 0, 0, %arg6] [5, 5, 3, 1] [1, 1, 1, 1] : memref<5x5x3x16xf32, strided<[240, 48, 16, 1]>> to memref<5x5x3x1xf32, strided<[240, 48, 16, 1], offset: ?>>
+# CHECK-NEXT:              %subview_23 = memref.subview %subview_18[0, 0, 0, %arg6] [1, 1, 1, 1] [1, 1, 1, 1] : memref<1x1x1x16xf32, strided<[256, 64, 16, 1], offset: ?>> to memref<1x1x1x1xf32, strided<[256, 64, 16, 1], offset: ?>>
+# CHECK-NEXT:              %c0_24 = arith.constant 0 : index
 # CHECK-NEXT:              %c5 = arith.constant 5 : index
-# CHECK-NEXT:              %c1_31 = arith.constant 1 : index
-# CHECK-NEXT:              scf.for %arg7 = %c0_30 to %c5 step %c1_31 {
-# CHECK-NEXT:                %subview_32 = memref.subview %subview_27[0, %arg7, 0, 0] [1, 1, 5, 3] [1, 1, 1, 1] : memref<1x5x5x3xf32, strided<[432, 36, 3, 1], offset: ?>> to memref<1x1x5x3xf32, strided<[432, 36, 3, 1], offset: ?>>
-# CHECK-NEXT:                %subview_33 = memref.subview %subview_28[%arg7, 0, 0, 0] [1, 5, 3, 1] [1, 1, 1, 1] : memref<5x5x3x1xf32, strided<[240, 48, 16, 1], offset: ?>> to memref<1x5x3x1xf32, strided<[240, 48, 16, 1], offset: ?>>
-# CHECK-NEXT:                %subview_34 = memref.subview %subview_29[0, 0, 0, 0] [1, 1, 1, 1] [1, 1, 1, 1] : memref<1x1x1x1xf32, strided<[256, 64, 16, 1], offset: ?>> to memref<1x1x1x1xf32, strided<[256, 64, 16, 1], offset: ?>>
-# CHECK-NEXT:                %c0_35 = arith.constant 0 : index
-# CHECK-NEXT:                %c5_36 = arith.constant 5 : index
-# CHECK-NEXT:                %c1_37 = arith.constant 1 : index
-# CHECK-NEXT:                scf.for %arg8 = %c0_35 to %c5_36 step %c1_37 {
-# CHECK-NEXT:                  %subview_38 = memref.subview %subview_32[0, 0, %arg8, 0] [1, 1, 1, 3] [1, 1, 1, 1] : memref<1x1x5x3xf32, strided<[432, 36, 3, 1], offset: ?>> to memref<1x1x1x3xf32, strided<[432, 36, 3, 1], offset: ?>>
-# CHECK-NEXT:                  %subview_39 = memref.subview %subview_33[0, %arg8, 0, 0] [1, 1, 3, 1] [1, 1, 1, 1] : memref<1x5x3x1xf32, strided<[240, 48, 16, 1], offset: ?>> to memref<1x1x3x1xf32, strided<[240, 48, 16, 1], offset: ?>>
-# CHECK-NEXT:                  %subview_40 = memref.subview %subview_34[0, 0, 0, 0] [1, 1, 1, 1] [1, 1, 1, 1] : memref<1x1x1x1xf32, strided<[256, 64, 16, 1], offset: ?>> to memref<1x1x1x1xf32, strided<[256, 64, 16, 1], offset: ?>>
-# CHECK-NEXT:                  %c0_41 = arith.constant 0 : index
+# CHECK-NEXT:              %c1_25 = arith.constant 1 : index
+# CHECK-NEXT:              scf.for %arg7 = %c0_24 to %c5 step %c1_25 {
+# CHECK-NEXT:                %subview_26 = memref.subview %subview_21[0, %arg7, 0, 0] [1, 1, 5, 3] [1, 1, 1, 1] : memref<1x5x5x3xf32, strided<[432, 36, 3, 1], offset: ?>> to memref<1x1x5x3xf32, strided<[432, 36, 3, 1], offset: ?>>
+# CHECK-NEXT:                %subview_27 = memref.subview %subview_22[%arg7, 0, 0, 0] [1, 5, 3, 1] [1, 1, 1, 1] : memref<5x5x3x1xf32, strided<[240, 48, 16, 1], offset: ?>> to memref<1x5x3x1xf32, strided<[240, 48, 16, 1], offset: ?>>
+# CHECK-NEXT:                %subview_28 = memref.subview %subview_23[0, 0, 0, 0] [1, 1, 1, 1] [1, 1, 1, 1] : memref<1x1x1x1xf32, strided<[256, 64, 16, 1], offset: ?>> to memref<1x1x1x1xf32, strided<[256, 64, 16, 1], offset: ?>>
+# CHECK-NEXT:                %c0_29 = arith.constant 0 : index
+# CHECK-NEXT:                %c5_30 = arith.constant 5 : index
+# CHECK-NEXT:                %c1_31 = arith.constant 1 : index
+# CHECK-NEXT:                scf.for %arg8 = %c0_29 to %c5_30 step %c1_31 {
+# CHECK-NEXT:                  %subview_32 = memref.subview %subview_26[0, 0, %arg8, 0] [1, 1, 1, 3] [1, 1, 1, 1] : memref<1x1x5x3xf32, strided<[432, 36, 3, 1], offset: ?>> to memref<1x1x1x3xf32, strided<[432, 36, 3, 1], offset: ?>>
+# CHECK-NEXT:                  %subview_33 = memref.subview %subview_27[0, %arg8, 0, 0] [1, 1, 3, 1] [1, 1, 1, 1] : memref<1x5x3x1xf32, strided<[240, 48, 16, 1], offset: ?>> to memref<1x1x3x1xf32, strided<[240, 48, 16, 1], offset: ?>>
+# CHECK-NEXT:                  %subview_34 = memref.subview %subview_28[0, 0, 0, 0] [1, 1, 1, 1] [1, 1, 1, 1] : memref<1x1x1x1xf32, strided<[256, 64, 16, 1], offset: ?>> to memref<1x1x1x1xf32, strided<[256, 64, 16, 1], offset: ?>>
+# CHECK-NEXT:                  %c0_35 = arith.constant 0 : index
 # CHECK-NEXT:                  %c3 = arith.constant 3 : index
-# CHECK-NEXT:                  %c1_42 = arith.constant 1 : index
-# CHECK-NEXT:                  scf.for %arg9 = %c0_41 to %c3 step %c1_42 {
-# CHECK-NEXT:                    %subview_43 = memref.subview %subview_38[0, 0, 0, %arg9] [1, 1, 1, 1] [1, 1, 1, 1] : memref<1x1x1x3xf32, strided<[432, 36, 3, 1], offset: ?>> to memref<1x1x1x1xf32, strided<[432, 36, 3, 1], offset: ?>>
-# CHECK-NEXT:                    %subview_44 = memref.subview %subview_39[0, 0, %arg9, 0] [1, 1, 1, 1] [1, 1, 1, 1] : memref<1x1x3x1xf32, strided<[240, 48, 16, 1], offset: ?>> to memref<1x1x1x1xf32, strided<[240, 48, 16, 1], offset: ?>>
-# CHECK-NEXT:                    %subview_45 = memref.subview %subview_40[0, 0, 0, 0] [1, 1, 1, 1] [1, 1, 1, 1] : memref<1x1x1x1xf32, strided<[256, 64, 16, 1], offset: ?>> to memref<1x1x1x1xf32, strided<[256, 64, 16, 1], offset: ?>>
-# CHECK-NEXT:                    linalg.generic {indexing_maps = [#map1, #map2, #map3], iterator_types = ["parallel", "parallel", "parallel", "parallel", "reduction", "reduction", "reduction"]} ins(%subview_43, %subview_44 : memref<1x1x1x1xf32, strided<[432, 36, 3, 1], offset: ?>>, memref<1x1x1x1xf32, strided<[240, 48, 16, 1], offset: ?>>) outs(%subview_45 : memref<1x1x1x1xf32, strided<[256, 64, 16, 1], offset: ?>>) attrs =  {__xtc_id_conv_} {
-# CHECK-NEXT:                    ^bb0(%in: f32, %in_46: f32, %out: f32):
-# CHECK-NEXT:                      %2 = arith.mulf %in, %in_46 : f32
+# CHECK-NEXT:                  %c1_36 = arith.constant 1 : index
+# CHECK-NEXT:                  scf.for %arg9 = %c0_35 to %c3 step %c1_36 {
+# CHECK-NEXT:                    %subview_37 = memref.subview %subview_32[0, 0, 0, %arg9] [1, 1, 1, 1] [1, 1, 1, 1] : memref<1x1x1x3xf32, strided<[432, 36, 3, 1], offset: ?>> to memref<1x1x1x1xf32, strided<[432, 36, 3, 1], offset: ?>>
+# CHECK-NEXT:                    %subview_38 = memref.subview %subview_33[0, 0, %arg9, 0] [1, 1, 1, 1] [1, 1, 1, 1] : memref<1x1x3x1xf32, strided<[240, 48, 16, 1], offset: ?>> to memref<1x1x1x1xf32, strided<[240, 48, 16, 1], offset: ?>>
+# CHECK-NEXT:                    %subview_39 = memref.subview %subview_34[0, 0, 0, 0] [1, 1, 1, 1] [1, 1, 1, 1] : memref<1x1x1x1xf32, strided<[256, 64, 16, 1], offset: ?>> to memref<1x1x1x1xf32, strided<[256, 64, 16, 1], offset: ?>>
+# CHECK-NEXT:                    linalg.generic {indexing_maps = [#map1, #map2, #map3], iterator_types = ["parallel", "parallel", "parallel", "parallel", "reduction", "reduction", "reduction"]} ins(%subview_37, %subview_38 : memref<1x1x1x1xf32, strided<[432, 36, 3, 1], offset: ?>>, memref<1x1x1x1xf32, strided<[240, 48, 16, 1], offset: ?>>) outs(%subview_39 : memref<1x1x1x1xf32, strided<[256, 64, 16, 1], offset: ?>>) attrs =  {__xtc_id_conv_} {
+# CHECK-NEXT:                    ^bb0(%in: f32, %in_40: f32, %out: f32):
+# CHECK-NEXT:                      %2 = arith.mulf %in, %in_40 : f32
 # CHECK-NEXT:                      %3 = arith.addf %out, %2 : f32
 # CHECK-NEXT:                      linalg.yield %3 : f32
 # CHECK-NEXT:                    }

--- a/tests/filecheck/backends/padding/test_pad_constant_conv2d_mlir.py
+++ b/tests/filecheck/backends/padding/test_pad_constant_conv2d_mlir.py
@@ -57,7 +57,7 @@ print(f"CODE: {res}")
 # CHECK-NEXT:      transform.yield 
 # CHECK-NEXT:    }
 # CHECK-NEXT:    transform.named_sequence @__transform_main(%arg0: !transform.any_op {transform.readonly}) {
-# CHECK-NEXT:      %0 = transform.structured.match attributes {__xtc_id_pad_0_} in %arg0 : (!transform.any_op) -> !transform.any_op
+# CHECK-NEXT:      %0 = transform.structured.match attributes {__xtc_id_pad_} in %arg0 : (!transform.any_op) -> !transform.any_op
 # CHECK-NEXT:      %tiled_linalg_op, %loops = transform.structured.tile_using_for %0 tile_sizes [1, 0, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
 # CHECK-NEXT:      transform.annotate %loops "./b" : !transform.any_op
 # CHECK-NEXT:      %tiled_linalg_op_0, %loops_1 = transform.structured.tile_using_for %tiled_linalg_op tile_sizes [0, 1, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
@@ -66,39 +66,21 @@ print(f"CODE: {res}")
 # CHECK-NEXT:      transform.annotate %loops_3 "./w" : !transform.any_op
 # CHECK-NEXT:      %tiled_linalg_op_4, %loops_5 = transform.structured.tile_using_for %tiled_linalg_op_2 tile_sizes [0, 0, 0, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
 # CHECK-NEXT:      transform.annotate %loops_5 "./c" : !transform.any_op
-# CHECK-NEXT:      %1 = transform.structured.match attributes {__xtc_id_pad_} in %arg0 : (!transform.any_op) -> !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_6, %loops_7 = transform.structured.tile_using_for %1 tile_sizes [1, 0, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      %1 = transform.structured.match attributes {__xtc_id_conv_} in %arg0 : (!transform.any_op) -> !transform.any_op
+# CHECK-NEXT:      %tiled_linalg_op_6, %loops_7 = transform.structured.tile_using_for %1 tile_sizes [1, 0, 0, 0, 0, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
 # CHECK-NEXT:      transform.annotate %loops_7 "./b" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_8, %loops_9 = transform.structured.tile_using_for %tiled_linalg_op_6 tile_sizes [0, 1, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      %tiled_linalg_op_8, %loops_9 = transform.structured.tile_using_for %tiled_linalg_op_6 tile_sizes [0, 1, 0, 0, 0, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
 # CHECK-NEXT:      transform.annotate %loops_9 "./h" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_10, %loops_11 = transform.structured.tile_using_for %tiled_linalg_op_8 tile_sizes [0, 0, 1, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      %tiled_linalg_op_10, %loops_11 = transform.structured.tile_using_for %tiled_linalg_op_8 tile_sizes [0, 0, 1, 0, 0, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
 # CHECK-NEXT:      transform.annotate %loops_11 "./w" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_12, %loops_13 = transform.structured.tile_using_for %tiled_linalg_op_10 tile_sizes [0, 0, 0, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_13 "./c" : !transform.any_op
-# CHECK-NEXT:      %2 = transform.structured.match attributes {__xtc_id_conv_0_} in %arg0 : (!transform.any_op) -> !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_14, %loops_15 = transform.structured.tile_using_for %2 tile_sizes [1, 0, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_15 "./b" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_16, %loops_17 = transform.structured.tile_using_for %tiled_linalg_op_14 tile_sizes [0, 1, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_17 "./h" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_18, %loops_19 = transform.structured.tile_using_for %tiled_linalg_op_16 tile_sizes [0, 0, 1, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_19 "./w" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_20, %loops_21 = transform.structured.tile_using_for %tiled_linalg_op_18 tile_sizes [0, 0, 0, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_21 "./f" : !transform.any_op
-# CHECK-NEXT:      %3 = transform.structured.match attributes {__xtc_id_conv_} in %arg0 : (!transform.any_op) -> !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_22, %loops_23 = transform.structured.tile_using_for %3 tile_sizes [1, 0, 0, 0, 0, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_23 "./b" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_24, %loops_25 = transform.structured.tile_using_for %tiled_linalg_op_22 tile_sizes [0, 1, 0, 0, 0, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_25 "./h" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_26, %loops_27 = transform.structured.tile_using_for %tiled_linalg_op_24 tile_sizes [0, 0, 1, 0, 0, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_27 "./w" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_28, %loops_29 = transform.structured.tile_using_for %tiled_linalg_op_26 tile_sizes [0, 0, 0, 1, 0, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_29 "./f" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_30, %loops_31 = transform.structured.tile_using_for %tiled_linalg_op_28 tile_sizes [0, 0, 0, 0, 1, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_31 "./r" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_32, %loops_33 = transform.structured.tile_using_for %tiled_linalg_op_30 tile_sizes [0, 0, 0, 0, 0, 1, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_33 "./s" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_34, %loops_35 = transform.structured.tile_using_for %tiled_linalg_op_32 tile_sizes [0, 0, 0, 0, 0, 0, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_35 "./c" : !transform.any_op
+# CHECK-NEXT:      %tiled_linalg_op_12, %loops_13 = transform.structured.tile_using_for %tiled_linalg_op_10 tile_sizes [0, 0, 0, 1, 0, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      transform.annotate %loops_13 "./f" : !transform.any_op
+# CHECK-NEXT:      %tiled_linalg_op_14, %loops_15 = transform.structured.tile_using_for %tiled_linalg_op_12 tile_sizes [0, 0, 0, 0, 1, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      transform.annotate %loops_15 "./r" : !transform.any_op
+# CHECK-NEXT:      %tiled_linalg_op_16, %loops_17 = transform.structured.tile_using_for %tiled_linalg_op_14 tile_sizes [0, 0, 0, 0, 0, 1, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      transform.annotate %loops_17 "./s" : !transform.any_op
+# CHECK-NEXT:      %tiled_linalg_op_18, %loops_19 = transform.structured.tile_using_for %tiled_linalg_op_16 tile_sizes [0, 0, 0, 0, 0, 0, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      transform.annotate %loops_19 "./c" : !transform.any_op
 # CHECK-NEXT:      transform.yield 
 # CHECK-NEXT:    }
 # CHECK-NEXT:  }
@@ -112,141 +94,93 @@ print(f"CODE: {res}")
 # CHECK-NEXT:    func.func @pad_conv2d_nhwc_mini(%arg0: memref<1x8x8x3xf32> {llvm.noalias}, %arg1: memref<5x5x3x16xf32> {llvm.noalias}, %arg2: memref<1x4x4x16xf32> {llvm.noalias}) {
 # CHECK-NEXT:      %alloca = memref.alloca() {alignment = 256 : i64} : memref<1x12x12x3xf32>
 # CHECK-NEXT:      %cst = arith.constant 3.000000e+00 : f32
+# CHECK-NEXT:      linalg.fill {__xtc_id_pad_0_} ins(%cst : f32) outs(%alloca : memref<1x12x12x3xf32>)
+# CHECK-NEXT:      %subview = memref.subview %alloca[0, 2, 2, 0] [1, 8, 8, 3] [1, 1, 1, 1] : memref<1x12x12x3xf32> to memref<1x8x8x3xf32, strided<[432, 36, 3, 1], offset: 78>>
 # CHECK-NEXT:      %c0 = arith.constant 0 : index
 # CHECK-NEXT:      %c1 = arith.constant 1 : index
 # CHECK-NEXT:      %c1_0 = arith.constant 1 : index
 # CHECK-NEXT:      scf.for %arg3 = %c0 to %c1 step %c1_0 {
-# CHECK-NEXT:        %subview_11 = memref.subview %alloca[%arg3, 0, 0, 0] [1, 12, 12, 3] [1, 1, 1, 1] : memref<1x12x12x3xf32> to memref<1x12x12x3xf32, strided<[432, 36, 3, 1], offset: ?>>
-# CHECK-NEXT:        %c0_12 = arith.constant 0 : index
-# CHECK-NEXT:        %c12 = arith.constant 12 : index
-# CHECK-NEXT:        %c1_13 = arith.constant 1 : index
-# CHECK-NEXT:        scf.for %arg4 = %c0_12 to %c12 step %c1_13 {
-# CHECK-NEXT:          %subview_14 = memref.subview %subview_11[0, %arg4, 0, 0] [1, 1, 12, 3] [1, 1, 1, 1] : memref<1x12x12x3xf32, strided<[432, 36, 3, 1], offset: ?>> to memref<1x1x12x3xf32, strided<[432, 36, 3, 1], offset: ?>>
-# CHECK-NEXT:          %c0_15 = arith.constant 0 : index
-# CHECK-NEXT:          %c12_16 = arith.constant 12 : index
-# CHECK-NEXT:          %c1_17 = arith.constant 1 : index
-# CHECK-NEXT:          scf.for %arg5 = %c0_15 to %c12_16 step %c1_17 {
-# CHECK-NEXT:            %subview_18 = memref.subview %subview_14[0, 0, %arg5, 0] [1, 1, 1, 3] [1, 1, 1, 1] : memref<1x1x12x3xf32, strided<[432, 36, 3, 1], offset: ?>> to memref<1x1x1x3xf32, strided<[432, 36, 3, 1], offset: ?>>
-# CHECK-NEXT:            %c0_19 = arith.constant 0 : index
-# CHECK-NEXT:            %c3 = arith.constant 3 : index
-# CHECK-NEXT:            %c1_20 = arith.constant 1 : index
-# CHECK-NEXT:            scf.for %arg6 = %c0_19 to %c3 step %c1_20 {
-# CHECK-NEXT:              %subview_21 = memref.subview %subview_18[0, 0, 0, %arg6] [1, 1, 1, 1] [1, 1, 1, 1] : memref<1x1x1x3xf32, strided<[432, 36, 3, 1], offset: ?>> to memref<1x1x1x1xf32, strided<[432, 36, 3, 1], offset: ?>>
-# CHECK-NEXT:              linalg.fill {__xtc_id_pad_0_} ins(%cst : f32) outs(%subview_21 : memref<1x1x1x1xf32, strided<[432, 36, 3, 1], offset: ?>>)
-# CHECK-NEXT:            } {"./c"}
-# CHECK-NEXT:          } {"./w"}
-# CHECK-NEXT:        } {"./h"}
-# CHECK-NEXT:      } {"./b"}
-# CHECK-NEXT:      %subview = memref.subview %alloca[0, 2, 2, 0] [1, 8, 8, 3] [1, 1, 1, 1] : memref<1x12x12x3xf32> to memref<1x8x8x3xf32, strided<[432, 36, 3, 1], offset: 78>>
-# CHECK-NEXT:      %c0_1 = arith.constant 0 : index
-# CHECK-NEXT:      %c1_2 = arith.constant 1 : index
-# CHECK-NEXT:      %c1_3 = arith.constant 1 : index
-# CHECK-NEXT:      scf.for %arg3 = %c0_1 to %c1_2 step %c1_3 {
-# CHECK-NEXT:        %subview_11 = memref.subview %arg0[%arg3, 0, 0, 0] [1, 8, 8, 3] [1, 1, 1, 1] : memref<1x8x8x3xf32> to memref<1x8x8x3xf32, strided<[192, 24, 3, 1], offset: ?>>
-# CHECK-NEXT:        %subview_12 = memref.subview %subview[%arg3, 0, 0, 0] [1, 8, 8, 3] [1, 1, 1, 1] : memref<1x8x8x3xf32, strided<[432, 36, 3, 1], offset: 78>> to memref<1x8x8x3xf32, strided<[432, 36, 3, 1], offset: ?>>
-# CHECK-NEXT:        %c0_13 = arith.constant 0 : index
+# CHECK-NEXT:        %subview_5 = memref.subview %arg0[%arg3, 0, 0, 0] [1, 8, 8, 3] [1, 1, 1, 1] : memref<1x8x8x3xf32> to memref<1x8x8x3xf32, strided<[192, 24, 3, 1], offset: ?>>
+# CHECK-NEXT:        %subview_6 = memref.subview %subview[%arg3, 0, 0, 0] [1, 8, 8, 3] [1, 1, 1, 1] : memref<1x8x8x3xf32, strided<[432, 36, 3, 1], offset: 78>> to memref<1x8x8x3xf32, strided<[432, 36, 3, 1], offset: ?>>
+# CHECK-NEXT:        %c0_7 = arith.constant 0 : index
 # CHECK-NEXT:        %c8 = arith.constant 8 : index
-# CHECK-NEXT:        %c1_14 = arith.constant 1 : index
-# CHECK-NEXT:        scf.for %arg4 = %c0_13 to %c8 step %c1_14 {
-# CHECK-NEXT:          %subview_15 = memref.subview %subview_11[0, %arg4, 0, 0] [1, 1, 8, 3] [1, 1, 1, 1] : memref<1x8x8x3xf32, strided<[192, 24, 3, 1], offset: ?>> to memref<1x1x8x3xf32, strided<[192, 24, 3, 1], offset: ?>>
-# CHECK-NEXT:          %subview_16 = memref.subview %subview_12[0, %arg4, 0, 0] [1, 1, 8, 3] [1, 1, 1, 1] : memref<1x8x8x3xf32, strided<[432, 36, 3, 1], offset: ?>> to memref<1x1x8x3xf32, strided<[432, 36, 3, 1], offset: ?>>
-# CHECK-NEXT:          %c0_17 = arith.constant 0 : index
-# CHECK-NEXT:          %c8_18 = arith.constant 8 : index
-# CHECK-NEXT:          %c1_19 = arith.constant 1 : index
-# CHECK-NEXT:          scf.for %arg5 = %c0_17 to %c8_18 step %c1_19 {
-# CHECK-NEXT:            %subview_20 = memref.subview %subview_15[0, 0, %arg5, 0] [1, 1, 1, 3] [1, 1, 1, 1] : memref<1x1x8x3xf32, strided<[192, 24, 3, 1], offset: ?>> to memref<1x1x1x3xf32, strided<[192, 24, 3, 1], offset: ?>>
-# CHECK-NEXT:            %subview_21 = memref.subview %subview_16[0, 0, %arg5, 0] [1, 1, 1, 3] [1, 1, 1, 1] : memref<1x1x8x3xf32, strided<[432, 36, 3, 1], offset: ?>> to memref<1x1x1x3xf32, strided<[432, 36, 3, 1], offset: ?>>
-# CHECK-NEXT:            %c0_22 = arith.constant 0 : index
+# CHECK-NEXT:        %c1_8 = arith.constant 1 : index
+# CHECK-NEXT:        scf.for %arg4 = %c0_7 to %c8 step %c1_8 {
+# CHECK-NEXT:          %subview_9 = memref.subview %subview_5[0, %arg4, 0, 0] [1, 1, 8, 3] [1, 1, 1, 1] : memref<1x8x8x3xf32, strided<[192, 24, 3, 1], offset: ?>> to memref<1x1x8x3xf32, strided<[192, 24, 3, 1], offset: ?>>
+# CHECK-NEXT:          %subview_10 = memref.subview %subview_6[0, %arg4, 0, 0] [1, 1, 8, 3] [1, 1, 1, 1] : memref<1x8x8x3xf32, strided<[432, 36, 3, 1], offset: ?>> to memref<1x1x8x3xf32, strided<[432, 36, 3, 1], offset: ?>>
+# CHECK-NEXT:          %c0_11 = arith.constant 0 : index
+# CHECK-NEXT:          %c8_12 = arith.constant 8 : index
+# CHECK-NEXT:          %c1_13 = arith.constant 1 : index
+# CHECK-NEXT:          scf.for %arg5 = %c0_11 to %c8_12 step %c1_13 {
+# CHECK-NEXT:            %subview_14 = memref.subview %subview_9[0, 0, %arg5, 0] [1, 1, 1, 3] [1, 1, 1, 1] : memref<1x1x8x3xf32, strided<[192, 24, 3, 1], offset: ?>> to memref<1x1x1x3xf32, strided<[192, 24, 3, 1], offset: ?>>
+# CHECK-NEXT:            %subview_15 = memref.subview %subview_10[0, 0, %arg5, 0] [1, 1, 1, 3] [1, 1, 1, 1] : memref<1x1x8x3xf32, strided<[432, 36, 3, 1], offset: ?>> to memref<1x1x1x3xf32, strided<[432, 36, 3, 1], offset: ?>>
+# CHECK-NEXT:            %c0_16 = arith.constant 0 : index
 # CHECK-NEXT:            %c3 = arith.constant 3 : index
-# CHECK-NEXT:            %c1_23 = arith.constant 1 : index
-# CHECK-NEXT:            scf.for %arg6 = %c0_22 to %c3 step %c1_23 {
-# CHECK-NEXT:              %subview_24 = memref.subview %subview_20[0, 0, 0, %arg6] [1, 1, 1, 1] [1, 1, 1, 1] : memref<1x1x1x3xf32, strided<[192, 24, 3, 1], offset: ?>> to memref<1x1x1x1xf32, strided<[192, 24, 3, 1], offset: ?>>
-# CHECK-NEXT:              %subview_25 = memref.subview %subview_21[0, 0, 0, %arg6] [1, 1, 1, 1] [1, 1, 1, 1] : memref<1x1x1x3xf32, strided<[432, 36, 3, 1], offset: ?>> to memref<1x1x1x1xf32, strided<[432, 36, 3, 1], offset: ?>>
-# CHECK-NEXT:              linalg.copy {__xtc_id_pad_} ins(%subview_24 : memref<1x1x1x1xf32, strided<[192, 24, 3, 1], offset: ?>>) outs(%subview_25 : memref<1x1x1x1xf32, strided<[432, 36, 3, 1], offset: ?>>)
+# CHECK-NEXT:            %c1_17 = arith.constant 1 : index
+# CHECK-NEXT:            scf.for %arg6 = %c0_16 to %c3 step %c1_17 {
+# CHECK-NEXT:              %subview_18 = memref.subview %subview_14[0, 0, 0, %arg6] [1, 1, 1, 1] [1, 1, 1, 1] : memref<1x1x1x3xf32, strided<[192, 24, 3, 1], offset: ?>> to memref<1x1x1x1xf32, strided<[192, 24, 3, 1], offset: ?>>
+# CHECK-NEXT:              %subview_19 = memref.subview %subview_15[0, 0, 0, %arg6] [1, 1, 1, 1] [1, 1, 1, 1] : memref<1x1x1x3xf32, strided<[432, 36, 3, 1], offset: ?>> to memref<1x1x1x1xf32, strided<[432, 36, 3, 1], offset: ?>>
+# CHECK-NEXT:              linalg.copy {__xtc_id_pad_} ins(%subview_18 : memref<1x1x1x1xf32, strided<[192, 24, 3, 1], offset: ?>>) outs(%subview_19 : memref<1x1x1x1xf32, strided<[432, 36, 3, 1], offset: ?>>)
 # CHECK-NEXT:            } {"./c"}
 # CHECK-NEXT:          } {"./w"}
 # CHECK-NEXT:        } {"./h"}
 # CHECK-NEXT:      } {"./b"}
-# CHECK-NEXT:      %cst_4 = arith.constant 0.000000e+00 : f32
-# CHECK-NEXT:      %c0_5 = arith.constant 0 : index
-# CHECK-NEXT:      %c1_6 = arith.constant 1 : index
-# CHECK-NEXT:      %c1_7 = arith.constant 1 : index
-# CHECK-NEXT:      scf.for %arg3 = %c0_5 to %c1_6 step %c1_7 {
-# CHECK-NEXT:        %subview_11 = memref.subview %arg2[%arg3, 0, 0, 0] [1, 4, 4, 16] [1, 1, 1, 1] : memref<1x4x4x16xf32> to memref<1x4x4x16xf32, strided<[256, 64, 16, 1], offset: ?>>
-# CHECK-NEXT:        %c0_12 = arith.constant 0 : index
+# CHECK-NEXT:      %cst_1 = arith.constant 0.000000e+00 : f32
+# CHECK-NEXT:      linalg.fill {__xtc_id_conv_0_} ins(%cst_1 : f32) outs(%arg2 : memref<1x4x4x16xf32>)
+# CHECK-NEXT:      %c0_2 = arith.constant 0 : index
+# CHECK-NEXT:      %c1_3 = arith.constant 1 : index
+# CHECK-NEXT:      %c1_4 = arith.constant 1 : index
+# CHECK-NEXT:      scf.for %arg3 = %c0_2 to %c1_3 step %c1_4 {
+# CHECK-NEXT:        %subview_5 = memref.subview %alloca[%arg3, 0, 0, 0] [1, 11, 11, 3] [1, 1, 1, 1] : memref<1x12x12x3xf32> to memref<1x11x11x3xf32, strided<[432, 36, 3, 1], offset: ?>>
+# CHECK-NEXT:        %subview_6 = memref.subview %arg1[0, 0, 0, 0] [5, 5, 3, 16] [1, 1, 1, 1] : memref<5x5x3x16xf32> to memref<5x5x3x16xf32, strided<[240, 48, 16, 1]>>
+# CHECK-NEXT:        %subview_7 = memref.subview %arg2[%arg3, 0, 0, 0] [1, 4, 4, 16] [1, 1, 1, 1] : memref<1x4x4x16xf32> to memref<1x4x4x16xf32, strided<[256, 64, 16, 1], offset: ?>>
+# CHECK-NEXT:        %c0_8 = arith.constant 0 : index
 # CHECK-NEXT:        %c4 = arith.constant 4 : index
-# CHECK-NEXT:        %c1_13 = arith.constant 1 : index
-# CHECK-NEXT:        scf.for %arg4 = %c0_12 to %c4 step %c1_13 {
-# CHECK-NEXT:          %subview_14 = memref.subview %subview_11[0, %arg4, 0, 0] [1, 1, 4, 16] [1, 1, 1, 1] : memref<1x4x4x16xf32, strided<[256, 64, 16, 1], offset: ?>> to memref<1x1x4x16xf32, strided<[256, 64, 16, 1], offset: ?>>
-# CHECK-NEXT:          %c0_15 = arith.constant 0 : index
-# CHECK-NEXT:          %c4_16 = arith.constant 4 : index
-# CHECK-NEXT:          %c1_17 = arith.constant 1 : index
-# CHECK-NEXT:          scf.for %arg5 = %c0_15 to %c4_16 step %c1_17 {
-# CHECK-NEXT:            %subview_18 = memref.subview %subview_14[0, 0, %arg5, 0] [1, 1, 1, 16] [1, 1, 1, 1] : memref<1x1x4x16xf32, strided<[256, 64, 16, 1], offset: ?>> to memref<1x1x1x16xf32, strided<[256, 64, 16, 1], offset: ?>>
+# CHECK-NEXT:        %c1_9 = arith.constant 1 : index
+# CHECK-NEXT:        scf.for %arg4 = %c0_8 to %c4 step %c1_9 {
+# CHECK-NEXT:          %0 = affine.apply #map(%arg4)
+# CHECK-NEXT:          %subview_10 = memref.subview %subview_5[0, %0, 0, 0] [1, 5, 11, 3] [1, 1, 1, 1] : memref<1x11x11x3xf32, strided<[432, 36, 3, 1], offset: ?>> to memref<1x5x11x3xf32, strided<[432, 36, 3, 1], offset: ?>>
+# CHECK-NEXT:          %subview_11 = memref.subview %subview_6[0, 0, 0, 0] [5, 5, 3, 16] [1, 1, 1, 1] : memref<5x5x3x16xf32, strided<[240, 48, 16, 1]>> to memref<5x5x3x16xf32, strided<[240, 48, 16, 1]>>
+# CHECK-NEXT:          %subview_12 = memref.subview %subview_7[0, %arg4, 0, 0] [1, 1, 4, 16] [1, 1, 1, 1] : memref<1x4x4x16xf32, strided<[256, 64, 16, 1], offset: ?>> to memref<1x1x4x16xf32, strided<[256, 64, 16, 1], offset: ?>>
+# CHECK-NEXT:          %c0_13 = arith.constant 0 : index
+# CHECK-NEXT:          %c4_14 = arith.constant 4 : index
+# CHECK-NEXT:          %c1_15 = arith.constant 1 : index
+# CHECK-NEXT:          scf.for %arg5 = %c0_13 to %c4_14 step %c1_15 {
+# CHECK-NEXT:            %1 = affine.apply #map(%arg5)
+# CHECK-NEXT:            %subview_16 = memref.subview %subview_10[0, 0, %1, 0] [1, 5, 5, 3] [1, 1, 1, 1] : memref<1x5x11x3xf32, strided<[432, 36, 3, 1], offset: ?>> to memref<1x5x5x3xf32, strided<[432, 36, 3, 1], offset: ?>>
+# CHECK-NEXT:            %subview_17 = memref.subview %subview_11[0, 0, 0, 0] [5, 5, 3, 16] [1, 1, 1, 1] : memref<5x5x3x16xf32, strided<[240, 48, 16, 1]>> to memref<5x5x3x16xf32, strided<[240, 48, 16, 1]>>
+# CHECK-NEXT:            %subview_18 = memref.subview %subview_12[0, 0, %arg5, 0] [1, 1, 1, 16] [1, 1, 1, 1] : memref<1x1x4x16xf32, strided<[256, 64, 16, 1], offset: ?>> to memref<1x1x1x16xf32, strided<[256, 64, 16, 1], offset: ?>>
 # CHECK-NEXT:            %c0_19 = arith.constant 0 : index
 # CHECK-NEXT:            %c16 = arith.constant 16 : index
 # CHECK-NEXT:            %c1_20 = arith.constant 1 : index
 # CHECK-NEXT:            scf.for %arg6 = %c0_19 to %c16 step %c1_20 {
-# CHECK-NEXT:              %subview_21 = memref.subview %subview_18[0, 0, 0, %arg6] [1, 1, 1, 1] [1, 1, 1, 1] : memref<1x1x1x16xf32, strided<[256, 64, 16, 1], offset: ?>> to memref<1x1x1x1xf32, strided<[256, 64, 16, 1], offset: ?>>
-# CHECK-NEXT:              linalg.fill {__xtc_id_conv_0_} ins(%cst_4 : f32) outs(%subview_21 : memref<1x1x1x1xf32, strided<[256, 64, 16, 1], offset: ?>>)
-# CHECK-NEXT:            } {"./f"}
-# CHECK-NEXT:          } {"./w"}
-# CHECK-NEXT:        } {"./h"}
-# CHECK-NEXT:      } {"./b"}
-# CHECK-NEXT:      %c0_8 = arith.constant 0 : index
-# CHECK-NEXT:      %c1_9 = arith.constant 1 : index
-# CHECK-NEXT:      %c1_10 = arith.constant 1 : index
-# CHECK-NEXT:      scf.for %arg3 = %c0_8 to %c1_9 step %c1_10 {
-# CHECK-NEXT:        %subview_11 = memref.subview %alloca[%arg3, 0, 0, 0] [1, 11, 11, 3] [1, 1, 1, 1] : memref<1x12x12x3xf32> to memref<1x11x11x3xf32, strided<[432, 36, 3, 1], offset: ?>>
-# CHECK-NEXT:        %subview_12 = memref.subview %arg1[0, 0, 0, 0] [5, 5, 3, 16] [1, 1, 1, 1] : memref<5x5x3x16xf32> to memref<5x5x3x16xf32, strided<[240, 48, 16, 1]>>
-# CHECK-NEXT:        %subview_13 = memref.subview %arg2[%arg3, 0, 0, 0] [1, 4, 4, 16] [1, 1, 1, 1] : memref<1x4x4x16xf32> to memref<1x4x4x16xf32, strided<[256, 64, 16, 1], offset: ?>>
-# CHECK-NEXT:        %c0_14 = arith.constant 0 : index
-# CHECK-NEXT:        %c4 = arith.constant 4 : index
-# CHECK-NEXT:        %c1_15 = arith.constant 1 : index
-# CHECK-NEXT:        scf.for %arg4 = %c0_14 to %c4 step %c1_15 {
-# CHECK-NEXT:          %0 = affine.apply #map(%arg4)
-# CHECK-NEXT:          %subview_16 = memref.subview %subview_11[0, %0, 0, 0] [1, 5, 11, 3] [1, 1, 1, 1] : memref<1x11x11x3xf32, strided<[432, 36, 3, 1], offset: ?>> to memref<1x5x11x3xf32, strided<[432, 36, 3, 1], offset: ?>>
-# CHECK-NEXT:          %subview_17 = memref.subview %subview_12[0, 0, 0, 0] [5, 5, 3, 16] [1, 1, 1, 1] : memref<5x5x3x16xf32, strided<[240, 48, 16, 1]>> to memref<5x5x3x16xf32, strided<[240, 48, 16, 1]>>
-# CHECK-NEXT:          %subview_18 = memref.subview %subview_13[0, %arg4, 0, 0] [1, 1, 4, 16] [1, 1, 1, 1] : memref<1x4x4x16xf32, strided<[256, 64, 16, 1], offset: ?>> to memref<1x1x4x16xf32, strided<[256, 64, 16, 1], offset: ?>>
-# CHECK-NEXT:          %c0_19 = arith.constant 0 : index
-# CHECK-NEXT:          %c4_20 = arith.constant 4 : index
-# CHECK-NEXT:          %c1_21 = arith.constant 1 : index
-# CHECK-NEXT:          scf.for %arg5 = %c0_19 to %c4_20 step %c1_21 {
-# CHECK-NEXT:            %1 = affine.apply #map(%arg5)
-# CHECK-NEXT:            %subview_22 = memref.subview %subview_16[0, 0, %1, 0] [1, 5, 5, 3] [1, 1, 1, 1] : memref<1x5x11x3xf32, strided<[432, 36, 3, 1], offset: ?>> to memref<1x5x5x3xf32, strided<[432, 36, 3, 1], offset: ?>>
-# CHECK-NEXT:            %subview_23 = memref.subview %subview_17[0, 0, 0, 0] [5, 5, 3, 16] [1, 1, 1, 1] : memref<5x5x3x16xf32, strided<[240, 48, 16, 1]>> to memref<5x5x3x16xf32, strided<[240, 48, 16, 1]>>
-# CHECK-NEXT:            %subview_24 = memref.subview %subview_18[0, 0, %arg5, 0] [1, 1, 1, 16] [1, 1, 1, 1] : memref<1x1x4x16xf32, strided<[256, 64, 16, 1], offset: ?>> to memref<1x1x1x16xf32, strided<[256, 64, 16, 1], offset: ?>>
-# CHECK-NEXT:            %c0_25 = arith.constant 0 : index
-# CHECK-NEXT:            %c16 = arith.constant 16 : index
-# CHECK-NEXT:            %c1_26 = arith.constant 1 : index
-# CHECK-NEXT:            scf.for %arg6 = %c0_25 to %c16 step %c1_26 {
-# CHECK-NEXT:              %subview_27 = memref.subview %subview_22[0, 0, 0, 0] [1, 5, 5, 3] [1, 1, 1, 1] : memref<1x5x5x3xf32, strided<[432, 36, 3, 1], offset: ?>> to memref<1x5x5x3xf32, strided<[432, 36, 3, 1], offset: ?>>
-# CHECK-NEXT:              %subview_28 = memref.subview %subview_23[0, 0, 0, %arg6] [5, 5, 3, 1] [1, 1, 1, 1] : memref<5x5x3x16xf32, strided<[240, 48, 16, 1]>> to memref<5x5x3x1xf32, strided<[240, 48, 16, 1], offset: ?>>
-# CHECK-NEXT:              %subview_29 = memref.subview %subview_24[0, 0, 0, %arg6] [1, 1, 1, 1] [1, 1, 1, 1] : memref<1x1x1x16xf32, strided<[256, 64, 16, 1], offset: ?>> to memref<1x1x1x1xf32, strided<[256, 64, 16, 1], offset: ?>>
-# CHECK-NEXT:              %c0_30 = arith.constant 0 : index
+# CHECK-NEXT:              %subview_21 = memref.subview %subview_16[0, 0, 0, 0] [1, 5, 5, 3] [1, 1, 1, 1] : memref<1x5x5x3xf32, strided<[432, 36, 3, 1], offset: ?>> to memref<1x5x5x3xf32, strided<[432, 36, 3, 1], offset: ?>>
+# CHECK-NEXT:              %subview_22 = memref.subview %subview_17[0, 0, 0, %arg6] [5, 5, 3, 1] [1, 1, 1, 1] : memref<5x5x3x16xf32, strided<[240, 48, 16, 1]>> to memref<5x5x3x1xf32, strided<[240, 48, 16, 1], offset: ?>>
+# CHECK-NEXT:              %subview_23 = memref.subview %subview_18[0, 0, 0, %arg6] [1, 1, 1, 1] [1, 1, 1, 1] : memref<1x1x1x16xf32, strided<[256, 64, 16, 1], offset: ?>> to memref<1x1x1x1xf32, strided<[256, 64, 16, 1], offset: ?>>
+# CHECK-NEXT:              %c0_24 = arith.constant 0 : index
 # CHECK-NEXT:              %c5 = arith.constant 5 : index
-# CHECK-NEXT:              %c1_31 = arith.constant 1 : index
-# CHECK-NEXT:              scf.for %arg7 = %c0_30 to %c5 step %c1_31 {
-# CHECK-NEXT:                %subview_32 = memref.subview %subview_27[0, %arg7, 0, 0] [1, 1, 5, 3] [1, 1, 1, 1] : memref<1x5x5x3xf32, strided<[432, 36, 3, 1], offset: ?>> to memref<1x1x5x3xf32, strided<[432, 36, 3, 1], offset: ?>>
-# CHECK-NEXT:                %subview_33 = memref.subview %subview_28[%arg7, 0, 0, 0] [1, 5, 3, 1] [1, 1, 1, 1] : memref<5x5x3x1xf32, strided<[240, 48, 16, 1], offset: ?>> to memref<1x5x3x1xf32, strided<[240, 48, 16, 1], offset: ?>>
-# CHECK-NEXT:                %subview_34 = memref.subview %subview_29[0, 0, 0, 0] [1, 1, 1, 1] [1, 1, 1, 1] : memref<1x1x1x1xf32, strided<[256, 64, 16, 1], offset: ?>> to memref<1x1x1x1xf32, strided<[256, 64, 16, 1], offset: ?>>
-# CHECK-NEXT:                %c0_35 = arith.constant 0 : index
-# CHECK-NEXT:                %c5_36 = arith.constant 5 : index
-# CHECK-NEXT:                %c1_37 = arith.constant 1 : index
-# CHECK-NEXT:                scf.for %arg8 = %c0_35 to %c5_36 step %c1_37 {
-# CHECK-NEXT:                  %subview_38 = memref.subview %subview_32[0, 0, %arg8, 0] [1, 1, 1, 3] [1, 1, 1, 1] : memref<1x1x5x3xf32, strided<[432, 36, 3, 1], offset: ?>> to memref<1x1x1x3xf32, strided<[432, 36, 3, 1], offset: ?>>
-# CHECK-NEXT:                  %subview_39 = memref.subview %subview_33[0, %arg8, 0, 0] [1, 1, 3, 1] [1, 1, 1, 1] : memref<1x5x3x1xf32, strided<[240, 48, 16, 1], offset: ?>> to memref<1x1x3x1xf32, strided<[240, 48, 16, 1], offset: ?>>
-# CHECK-NEXT:                  %subview_40 = memref.subview %subview_34[0, 0, 0, 0] [1, 1, 1, 1] [1, 1, 1, 1] : memref<1x1x1x1xf32, strided<[256, 64, 16, 1], offset: ?>> to memref<1x1x1x1xf32, strided<[256, 64, 16, 1], offset: ?>>
-# CHECK-NEXT:                  %c0_41 = arith.constant 0 : index
+# CHECK-NEXT:              %c1_25 = arith.constant 1 : index
+# CHECK-NEXT:              scf.for %arg7 = %c0_24 to %c5 step %c1_25 {
+# CHECK-NEXT:                %subview_26 = memref.subview %subview_21[0, %arg7, 0, 0] [1, 1, 5, 3] [1, 1, 1, 1] : memref<1x5x5x3xf32, strided<[432, 36, 3, 1], offset: ?>> to memref<1x1x5x3xf32, strided<[432, 36, 3, 1], offset: ?>>
+# CHECK-NEXT:                %subview_27 = memref.subview %subview_22[%arg7, 0, 0, 0] [1, 5, 3, 1] [1, 1, 1, 1] : memref<5x5x3x1xf32, strided<[240, 48, 16, 1], offset: ?>> to memref<1x5x3x1xf32, strided<[240, 48, 16, 1], offset: ?>>
+# CHECK-NEXT:                %subview_28 = memref.subview %subview_23[0, 0, 0, 0] [1, 1, 1, 1] [1, 1, 1, 1] : memref<1x1x1x1xf32, strided<[256, 64, 16, 1], offset: ?>> to memref<1x1x1x1xf32, strided<[256, 64, 16, 1], offset: ?>>
+# CHECK-NEXT:                %c0_29 = arith.constant 0 : index
+# CHECK-NEXT:                %c5_30 = arith.constant 5 : index
+# CHECK-NEXT:                %c1_31 = arith.constant 1 : index
+# CHECK-NEXT:                scf.for %arg8 = %c0_29 to %c5_30 step %c1_31 {
+# CHECK-NEXT:                  %subview_32 = memref.subview %subview_26[0, 0, %arg8, 0] [1, 1, 1, 3] [1, 1, 1, 1] : memref<1x1x5x3xf32, strided<[432, 36, 3, 1], offset: ?>> to memref<1x1x1x3xf32, strided<[432, 36, 3, 1], offset: ?>>
+# CHECK-NEXT:                  %subview_33 = memref.subview %subview_27[0, %arg8, 0, 0] [1, 1, 3, 1] [1, 1, 1, 1] : memref<1x5x3x1xf32, strided<[240, 48, 16, 1], offset: ?>> to memref<1x1x3x1xf32, strided<[240, 48, 16, 1], offset: ?>>
+# CHECK-NEXT:                  %subview_34 = memref.subview %subview_28[0, 0, 0, 0] [1, 1, 1, 1] [1, 1, 1, 1] : memref<1x1x1x1xf32, strided<[256, 64, 16, 1], offset: ?>> to memref<1x1x1x1xf32, strided<[256, 64, 16, 1], offset: ?>>
+# CHECK-NEXT:                  %c0_35 = arith.constant 0 : index
 # CHECK-NEXT:                  %c3 = arith.constant 3 : index
-# CHECK-NEXT:                  %c1_42 = arith.constant 1 : index
-# CHECK-NEXT:                  scf.for %arg9 = %c0_41 to %c3 step %c1_42 {
-# CHECK-NEXT:                    %subview_43 = memref.subview %subview_38[0, 0, 0, %arg9] [1, 1, 1, 1] [1, 1, 1, 1] : memref<1x1x1x3xf32, strided<[432, 36, 3, 1], offset: ?>> to memref<1x1x1x1xf32, strided<[432, 36, 3, 1], offset: ?>>
-# CHECK-NEXT:                    %subview_44 = memref.subview %subview_39[0, 0, %arg9, 0] [1, 1, 1, 1] [1, 1, 1, 1] : memref<1x1x3x1xf32, strided<[240, 48, 16, 1], offset: ?>> to memref<1x1x1x1xf32, strided<[240, 48, 16, 1], offset: ?>>
-# CHECK-NEXT:                    %subview_45 = memref.subview %subview_40[0, 0, 0, 0] [1, 1, 1, 1] [1, 1, 1, 1] : memref<1x1x1x1xf32, strided<[256, 64, 16, 1], offset: ?>> to memref<1x1x1x1xf32, strided<[256, 64, 16, 1], offset: ?>>
-# CHECK-NEXT:                    linalg.generic {indexing_maps = [#map1, #map2, #map3], iterator_types = ["parallel", "parallel", "parallel", "parallel", "reduction", "reduction", "reduction"]} ins(%subview_43, %subview_44 : memref<1x1x1x1xf32, strided<[432, 36, 3, 1], offset: ?>>, memref<1x1x1x1xf32, strided<[240, 48, 16, 1], offset: ?>>) outs(%subview_45 : memref<1x1x1x1xf32, strided<[256, 64, 16, 1], offset: ?>>) attrs =  {__xtc_id_conv_} {
-# CHECK-NEXT:                    ^bb0(%in: f32, %in_46: f32, %out: f32):
-# CHECK-NEXT:                      %2 = arith.mulf %in, %in_46 fastmath<fast> : f32
+# CHECK-NEXT:                  %c1_36 = arith.constant 1 : index
+# CHECK-NEXT:                  scf.for %arg9 = %c0_35 to %c3 step %c1_36 {
+# CHECK-NEXT:                    %subview_37 = memref.subview %subview_32[0, 0, 0, %arg9] [1, 1, 1, 1] [1, 1, 1, 1] : memref<1x1x1x3xf32, strided<[432, 36, 3, 1], offset: ?>> to memref<1x1x1x1xf32, strided<[432, 36, 3, 1], offset: ?>>
+# CHECK-NEXT:                    %subview_38 = memref.subview %subview_33[0, 0, %arg9, 0] [1, 1, 1, 1] [1, 1, 1, 1] : memref<1x1x3x1xf32, strided<[240, 48, 16, 1], offset: ?>> to memref<1x1x1x1xf32, strided<[240, 48, 16, 1], offset: ?>>
+# CHECK-NEXT:                    %subview_39 = memref.subview %subview_34[0, 0, 0, 0] [1, 1, 1, 1] [1, 1, 1, 1] : memref<1x1x1x1xf32, strided<[256, 64, 16, 1], offset: ?>> to memref<1x1x1x1xf32, strided<[256, 64, 16, 1], offset: ?>>
+# CHECK-NEXT:                    linalg.generic {indexing_maps = [#map1, #map2, #map3], iterator_types = ["parallel", "parallel", "parallel", "parallel", "reduction", "reduction", "reduction"]} ins(%subview_37, %subview_38 : memref<1x1x1x1xf32, strided<[432, 36, 3, 1], offset: ?>>, memref<1x1x1x1xf32, strided<[240, 48, 16, 1], offset: ?>>) outs(%subview_39 : memref<1x1x1x1xf32, strided<[256, 64, 16, 1], offset: ?>>) attrs =  {__xtc_id_conv_} {
+# CHECK-NEXT:                    ^bb0(%in: f32, %in_40: f32, %out: f32):
+# CHECK-NEXT:                      %2 = arith.mulf %in, %in_40 fastmath<fast> : f32
 # CHECK-NEXT:                      %3 = arith.addf %out, %2 fastmath<fast> : f32
 # CHECK-NEXT:                      linalg.yield %3 : f32
 # CHECK-NEXT:                    }

--- a/tests/filecheck/backends/padding/test_pad_conv2d_mlir.py
+++ b/tests/filecheck/backends/padding/test_pad_conv2d_mlir.py
@@ -57,7 +57,7 @@ print(f"CODE: {res}")
 # CHECK-NEXT:      transform.yield 
 # CHECK-NEXT:    }
 # CHECK-NEXT:    transform.named_sequence @__transform_main(%arg0: !transform.any_op {transform.readonly}) {
-# CHECK-NEXT:      %0 = transform.structured.match attributes {__xtc_id_pad_0_} in %arg0 : (!transform.any_op) -> !transform.any_op
+# CHECK-NEXT:      %0 = transform.structured.match attributes {__xtc_id_pad_} in %arg0 : (!transform.any_op) -> !transform.any_op
 # CHECK-NEXT:      %tiled_linalg_op, %loops = transform.structured.tile_using_for %0 tile_sizes [1, 0, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
 # CHECK-NEXT:      transform.annotate %loops "./b" : !transform.any_op
 # CHECK-NEXT:      %tiled_linalg_op_0, %loops_1 = transform.structured.tile_using_for %tiled_linalg_op tile_sizes [0, 1, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
@@ -66,39 +66,21 @@ print(f"CODE: {res}")
 # CHECK-NEXT:      transform.annotate %loops_3 "./w" : !transform.any_op
 # CHECK-NEXT:      %tiled_linalg_op_4, %loops_5 = transform.structured.tile_using_for %tiled_linalg_op_2 tile_sizes [0, 0, 0, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
 # CHECK-NEXT:      transform.annotate %loops_5 "./c" : !transform.any_op
-# CHECK-NEXT:      %1 = transform.structured.match attributes {__xtc_id_pad_} in %arg0 : (!transform.any_op) -> !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_6, %loops_7 = transform.structured.tile_using_for %1 tile_sizes [1, 0, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      %1 = transform.structured.match attributes {__xtc_id_conv_} in %arg0 : (!transform.any_op) -> !transform.any_op
+# CHECK-NEXT:      %tiled_linalg_op_6, %loops_7 = transform.structured.tile_using_for %1 tile_sizes [1, 0, 0, 0, 0, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
 # CHECK-NEXT:      transform.annotate %loops_7 "./b" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_8, %loops_9 = transform.structured.tile_using_for %tiled_linalg_op_6 tile_sizes [0, 1, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      %tiled_linalg_op_8, %loops_9 = transform.structured.tile_using_for %tiled_linalg_op_6 tile_sizes [0, 1, 0, 0, 0, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
 # CHECK-NEXT:      transform.annotate %loops_9 "./h" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_10, %loops_11 = transform.structured.tile_using_for %tiled_linalg_op_8 tile_sizes [0, 0, 1, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      %tiled_linalg_op_10, %loops_11 = transform.structured.tile_using_for %tiled_linalg_op_8 tile_sizes [0, 0, 1, 0, 0, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
 # CHECK-NEXT:      transform.annotate %loops_11 "./w" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_12, %loops_13 = transform.structured.tile_using_for %tiled_linalg_op_10 tile_sizes [0, 0, 0, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_13 "./c" : !transform.any_op
-# CHECK-NEXT:      %2 = transform.structured.match attributes {__xtc_id_conv_0_} in %arg0 : (!transform.any_op) -> !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_14, %loops_15 = transform.structured.tile_using_for %2 tile_sizes [1, 0, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_15 "./b" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_16, %loops_17 = transform.structured.tile_using_for %tiled_linalg_op_14 tile_sizes [0, 1, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_17 "./h" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_18, %loops_19 = transform.structured.tile_using_for %tiled_linalg_op_16 tile_sizes [0, 0, 1, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_19 "./w" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_20, %loops_21 = transform.structured.tile_using_for %tiled_linalg_op_18 tile_sizes [0, 0, 0, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_21 "./f" : !transform.any_op
-# CHECK-NEXT:      %3 = transform.structured.match attributes {__xtc_id_conv_} in %arg0 : (!transform.any_op) -> !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_22, %loops_23 = transform.structured.tile_using_for %3 tile_sizes [1, 0, 0, 0, 0, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_23 "./b" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_24, %loops_25 = transform.structured.tile_using_for %tiled_linalg_op_22 tile_sizes [0, 1, 0, 0, 0, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_25 "./h" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_26, %loops_27 = transform.structured.tile_using_for %tiled_linalg_op_24 tile_sizes [0, 0, 1, 0, 0, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_27 "./w" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_28, %loops_29 = transform.structured.tile_using_for %tiled_linalg_op_26 tile_sizes [0, 0, 0, 1, 0, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_29 "./f" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_30, %loops_31 = transform.structured.tile_using_for %tiled_linalg_op_28 tile_sizes [0, 0, 0, 0, 1, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_31 "./r" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_32, %loops_33 = transform.structured.tile_using_for %tiled_linalg_op_30 tile_sizes [0, 0, 0, 0, 0, 1, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_33 "./s" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_34, %loops_35 = transform.structured.tile_using_for %tiled_linalg_op_32 tile_sizes [0, 0, 0, 0, 0, 0, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_35 "./c" : !transform.any_op
+# CHECK-NEXT:      %tiled_linalg_op_12, %loops_13 = transform.structured.tile_using_for %tiled_linalg_op_10 tile_sizes [0, 0, 0, 1, 0, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      transform.annotate %loops_13 "./f" : !transform.any_op
+# CHECK-NEXT:      %tiled_linalg_op_14, %loops_15 = transform.structured.tile_using_for %tiled_linalg_op_12 tile_sizes [0, 0, 0, 0, 1, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      transform.annotate %loops_15 "./r" : !transform.any_op
+# CHECK-NEXT:      %tiled_linalg_op_16, %loops_17 = transform.structured.tile_using_for %tiled_linalg_op_14 tile_sizes [0, 0, 0, 0, 0, 1, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      transform.annotate %loops_17 "./s" : !transform.any_op
+# CHECK-NEXT:      %tiled_linalg_op_18, %loops_19 = transform.structured.tile_using_for %tiled_linalg_op_16 tile_sizes [0, 0, 0, 0, 0, 0, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      transform.annotate %loops_19 "./c" : !transform.any_op
 # CHECK-NEXT:      transform.yield 
 # CHECK-NEXT:    }
 # CHECK-NEXT:  }
@@ -112,141 +94,93 @@ print(f"CODE: {res}")
 # CHECK-NEXT:    func.func @pad_conv2d_nhwc_mini(%arg0: memref<1x8x8x3xf32> {llvm.noalias}, %arg1: memref<5x5x3x16xf32> {llvm.noalias}, %arg2: memref<1x4x4x16xf32> {llvm.noalias}) {
 # CHECK-NEXT:      %alloca = memref.alloca() {alignment = 256 : i64} : memref<1x12x12x3xf32>
 # CHECK-NEXT:      %cst = arith.constant 0.000000e+00 : f32
+# CHECK-NEXT:      linalg.fill {__xtc_id_pad_0_} ins(%cst : f32) outs(%alloca : memref<1x12x12x3xf32>)
+# CHECK-NEXT:      %subview = memref.subview %alloca[0, 2, 2, 0] [1, 8, 8, 3] [1, 1, 1, 1] : memref<1x12x12x3xf32> to memref<1x8x8x3xf32, strided<[432, 36, 3, 1], offset: 78>>
 # CHECK-NEXT:      %c0 = arith.constant 0 : index
 # CHECK-NEXT:      %c1 = arith.constant 1 : index
 # CHECK-NEXT:      %c1_0 = arith.constant 1 : index
 # CHECK-NEXT:      scf.for %arg3 = %c0 to %c1 step %c1_0 {
-# CHECK-NEXT:        %subview_11 = memref.subview %alloca[%arg3, 0, 0, 0] [1, 12, 12, 3] [1, 1, 1, 1] : memref<1x12x12x3xf32> to memref<1x12x12x3xf32, strided<[432, 36, 3, 1], offset: ?>>
-# CHECK-NEXT:        %c0_12 = arith.constant 0 : index
-# CHECK-NEXT:        %c12 = arith.constant 12 : index
-# CHECK-NEXT:        %c1_13 = arith.constant 1 : index
-# CHECK-NEXT:        scf.for %arg4 = %c0_12 to %c12 step %c1_13 {
-# CHECK-NEXT:          %subview_14 = memref.subview %subview_11[0, %arg4, 0, 0] [1, 1, 12, 3] [1, 1, 1, 1] : memref<1x12x12x3xf32, strided<[432, 36, 3, 1], offset: ?>> to memref<1x1x12x3xf32, strided<[432, 36, 3, 1], offset: ?>>
-# CHECK-NEXT:          %c0_15 = arith.constant 0 : index
-# CHECK-NEXT:          %c12_16 = arith.constant 12 : index
-# CHECK-NEXT:          %c1_17 = arith.constant 1 : index
-# CHECK-NEXT:          scf.for %arg5 = %c0_15 to %c12_16 step %c1_17 {
-# CHECK-NEXT:            %subview_18 = memref.subview %subview_14[0, 0, %arg5, 0] [1, 1, 1, 3] [1, 1, 1, 1] : memref<1x1x12x3xf32, strided<[432, 36, 3, 1], offset: ?>> to memref<1x1x1x3xf32, strided<[432, 36, 3, 1], offset: ?>>
-# CHECK-NEXT:            %c0_19 = arith.constant 0 : index
-# CHECK-NEXT:            %c3 = arith.constant 3 : index
-# CHECK-NEXT:            %c1_20 = arith.constant 1 : index
-# CHECK-NEXT:            scf.for %arg6 = %c0_19 to %c3 step %c1_20 {
-# CHECK-NEXT:              %subview_21 = memref.subview %subview_18[0, 0, 0, %arg6] [1, 1, 1, 1] [1, 1, 1, 1] : memref<1x1x1x3xf32, strided<[432, 36, 3, 1], offset: ?>> to memref<1x1x1x1xf32, strided<[432, 36, 3, 1], offset: ?>>
-# CHECK-NEXT:              linalg.fill {__xtc_id_pad_0_} ins(%cst : f32) outs(%subview_21 : memref<1x1x1x1xf32, strided<[432, 36, 3, 1], offset: ?>>)
-# CHECK-NEXT:            } {"./c"}
-# CHECK-NEXT:          } {"./w"}
-# CHECK-NEXT:        } {"./h"}
-# CHECK-NEXT:      } {"./b"}
-# CHECK-NEXT:      %subview = memref.subview %alloca[0, 2, 2, 0] [1, 8, 8, 3] [1, 1, 1, 1] : memref<1x12x12x3xf32> to memref<1x8x8x3xf32, strided<[432, 36, 3, 1], offset: 78>>
-# CHECK-NEXT:      %c0_1 = arith.constant 0 : index
-# CHECK-NEXT:      %c1_2 = arith.constant 1 : index
-# CHECK-NEXT:      %c1_3 = arith.constant 1 : index
-# CHECK-NEXT:      scf.for %arg3 = %c0_1 to %c1_2 step %c1_3 {
-# CHECK-NEXT:        %subview_11 = memref.subview %arg0[%arg3, 0, 0, 0] [1, 8, 8, 3] [1, 1, 1, 1] : memref<1x8x8x3xf32> to memref<1x8x8x3xf32, strided<[192, 24, 3, 1], offset: ?>>
-# CHECK-NEXT:        %subview_12 = memref.subview %subview[%arg3, 0, 0, 0] [1, 8, 8, 3] [1, 1, 1, 1] : memref<1x8x8x3xf32, strided<[432, 36, 3, 1], offset: 78>> to memref<1x8x8x3xf32, strided<[432, 36, 3, 1], offset: ?>>
-# CHECK-NEXT:        %c0_13 = arith.constant 0 : index
+# CHECK-NEXT:        %subview_5 = memref.subview %arg0[%arg3, 0, 0, 0] [1, 8, 8, 3] [1, 1, 1, 1] : memref<1x8x8x3xf32> to memref<1x8x8x3xf32, strided<[192, 24, 3, 1], offset: ?>>
+# CHECK-NEXT:        %subview_6 = memref.subview %subview[%arg3, 0, 0, 0] [1, 8, 8, 3] [1, 1, 1, 1] : memref<1x8x8x3xf32, strided<[432, 36, 3, 1], offset: 78>> to memref<1x8x8x3xf32, strided<[432, 36, 3, 1], offset: ?>>
+# CHECK-NEXT:        %c0_7 = arith.constant 0 : index
 # CHECK-NEXT:        %c8 = arith.constant 8 : index
-# CHECK-NEXT:        %c1_14 = arith.constant 1 : index
-# CHECK-NEXT:        scf.for %arg4 = %c0_13 to %c8 step %c1_14 {
-# CHECK-NEXT:          %subview_15 = memref.subview %subview_11[0, %arg4, 0, 0] [1, 1, 8, 3] [1, 1, 1, 1] : memref<1x8x8x3xf32, strided<[192, 24, 3, 1], offset: ?>> to memref<1x1x8x3xf32, strided<[192, 24, 3, 1], offset: ?>>
-# CHECK-NEXT:          %subview_16 = memref.subview %subview_12[0, %arg4, 0, 0] [1, 1, 8, 3] [1, 1, 1, 1] : memref<1x8x8x3xf32, strided<[432, 36, 3, 1], offset: ?>> to memref<1x1x8x3xf32, strided<[432, 36, 3, 1], offset: ?>>
-# CHECK-NEXT:          %c0_17 = arith.constant 0 : index
-# CHECK-NEXT:          %c8_18 = arith.constant 8 : index
-# CHECK-NEXT:          %c1_19 = arith.constant 1 : index
-# CHECK-NEXT:          scf.for %arg5 = %c0_17 to %c8_18 step %c1_19 {
-# CHECK-NEXT:            %subview_20 = memref.subview %subview_15[0, 0, %arg5, 0] [1, 1, 1, 3] [1, 1, 1, 1] : memref<1x1x8x3xf32, strided<[192, 24, 3, 1], offset: ?>> to memref<1x1x1x3xf32, strided<[192, 24, 3, 1], offset: ?>>
-# CHECK-NEXT:            %subview_21 = memref.subview %subview_16[0, 0, %arg5, 0] [1, 1, 1, 3] [1, 1, 1, 1] : memref<1x1x8x3xf32, strided<[432, 36, 3, 1], offset: ?>> to memref<1x1x1x3xf32, strided<[432, 36, 3, 1], offset: ?>>
-# CHECK-NEXT:            %c0_22 = arith.constant 0 : index
+# CHECK-NEXT:        %c1_8 = arith.constant 1 : index
+# CHECK-NEXT:        scf.for %arg4 = %c0_7 to %c8 step %c1_8 {
+# CHECK-NEXT:          %subview_9 = memref.subview %subview_5[0, %arg4, 0, 0] [1, 1, 8, 3] [1, 1, 1, 1] : memref<1x8x8x3xf32, strided<[192, 24, 3, 1], offset: ?>> to memref<1x1x8x3xf32, strided<[192, 24, 3, 1], offset: ?>>
+# CHECK-NEXT:          %subview_10 = memref.subview %subview_6[0, %arg4, 0, 0] [1, 1, 8, 3] [1, 1, 1, 1] : memref<1x8x8x3xf32, strided<[432, 36, 3, 1], offset: ?>> to memref<1x1x8x3xf32, strided<[432, 36, 3, 1], offset: ?>>
+# CHECK-NEXT:          %c0_11 = arith.constant 0 : index
+# CHECK-NEXT:          %c8_12 = arith.constant 8 : index
+# CHECK-NEXT:          %c1_13 = arith.constant 1 : index
+# CHECK-NEXT:          scf.for %arg5 = %c0_11 to %c8_12 step %c1_13 {
+# CHECK-NEXT:            %subview_14 = memref.subview %subview_9[0, 0, %arg5, 0] [1, 1, 1, 3] [1, 1, 1, 1] : memref<1x1x8x3xf32, strided<[192, 24, 3, 1], offset: ?>> to memref<1x1x1x3xf32, strided<[192, 24, 3, 1], offset: ?>>
+# CHECK-NEXT:            %subview_15 = memref.subview %subview_10[0, 0, %arg5, 0] [1, 1, 1, 3] [1, 1, 1, 1] : memref<1x1x8x3xf32, strided<[432, 36, 3, 1], offset: ?>> to memref<1x1x1x3xf32, strided<[432, 36, 3, 1], offset: ?>>
+# CHECK-NEXT:            %c0_16 = arith.constant 0 : index
 # CHECK-NEXT:            %c3 = arith.constant 3 : index
-# CHECK-NEXT:            %c1_23 = arith.constant 1 : index
-# CHECK-NEXT:            scf.for %arg6 = %c0_22 to %c3 step %c1_23 {
-# CHECK-NEXT:              %subview_24 = memref.subview %subview_20[0, 0, 0, %arg6] [1, 1, 1, 1] [1, 1, 1, 1] : memref<1x1x1x3xf32, strided<[192, 24, 3, 1], offset: ?>> to memref<1x1x1x1xf32, strided<[192, 24, 3, 1], offset: ?>>
-# CHECK-NEXT:              %subview_25 = memref.subview %subview_21[0, 0, 0, %arg6] [1, 1, 1, 1] [1, 1, 1, 1] : memref<1x1x1x3xf32, strided<[432, 36, 3, 1], offset: ?>> to memref<1x1x1x1xf32, strided<[432, 36, 3, 1], offset: ?>>
-# CHECK-NEXT:              linalg.copy {__xtc_id_pad_} ins(%subview_24 : memref<1x1x1x1xf32, strided<[192, 24, 3, 1], offset: ?>>) outs(%subview_25 : memref<1x1x1x1xf32, strided<[432, 36, 3, 1], offset: ?>>)
+# CHECK-NEXT:            %c1_17 = arith.constant 1 : index
+# CHECK-NEXT:            scf.for %arg6 = %c0_16 to %c3 step %c1_17 {
+# CHECK-NEXT:              %subview_18 = memref.subview %subview_14[0, 0, 0, %arg6] [1, 1, 1, 1] [1, 1, 1, 1] : memref<1x1x1x3xf32, strided<[192, 24, 3, 1], offset: ?>> to memref<1x1x1x1xf32, strided<[192, 24, 3, 1], offset: ?>>
+# CHECK-NEXT:              %subview_19 = memref.subview %subview_15[0, 0, 0, %arg6] [1, 1, 1, 1] [1, 1, 1, 1] : memref<1x1x1x3xf32, strided<[432, 36, 3, 1], offset: ?>> to memref<1x1x1x1xf32, strided<[432, 36, 3, 1], offset: ?>>
+# CHECK-NEXT:              linalg.copy {__xtc_id_pad_} ins(%subview_18 : memref<1x1x1x1xf32, strided<[192, 24, 3, 1], offset: ?>>) outs(%subview_19 : memref<1x1x1x1xf32, strided<[432, 36, 3, 1], offset: ?>>)
 # CHECK-NEXT:            } {"./c"}
 # CHECK-NEXT:          } {"./w"}
 # CHECK-NEXT:        } {"./h"}
 # CHECK-NEXT:      } {"./b"}
-# CHECK-NEXT:      %cst_4 = arith.constant 0.000000e+00 : f32
-# CHECK-NEXT:      %c0_5 = arith.constant 0 : index
-# CHECK-NEXT:      %c1_6 = arith.constant 1 : index
-# CHECK-NEXT:      %c1_7 = arith.constant 1 : index
-# CHECK-NEXT:      scf.for %arg3 = %c0_5 to %c1_6 step %c1_7 {
-# CHECK-NEXT:        %subview_11 = memref.subview %arg2[%arg3, 0, 0, 0] [1, 4, 4, 16] [1, 1, 1, 1] : memref<1x4x4x16xf32> to memref<1x4x4x16xf32, strided<[256, 64, 16, 1], offset: ?>>
-# CHECK-NEXT:        %c0_12 = arith.constant 0 : index
+# CHECK-NEXT:      %cst_1 = arith.constant 0.000000e+00 : f32
+# CHECK-NEXT:      linalg.fill {__xtc_id_conv_0_} ins(%cst_1 : f32) outs(%arg2 : memref<1x4x4x16xf32>)
+# CHECK-NEXT:      %c0_2 = arith.constant 0 : index
+# CHECK-NEXT:      %c1_3 = arith.constant 1 : index
+# CHECK-NEXT:      %c1_4 = arith.constant 1 : index
+# CHECK-NEXT:      scf.for %arg3 = %c0_2 to %c1_3 step %c1_4 {
+# CHECK-NEXT:        %subview_5 = memref.subview %alloca[%arg3, 0, 0, 0] [1, 11, 11, 3] [1, 1, 1, 1] : memref<1x12x12x3xf32> to memref<1x11x11x3xf32, strided<[432, 36, 3, 1], offset: ?>>
+# CHECK-NEXT:        %subview_6 = memref.subview %arg1[0, 0, 0, 0] [5, 5, 3, 16] [1, 1, 1, 1] : memref<5x5x3x16xf32> to memref<5x5x3x16xf32, strided<[240, 48, 16, 1]>>
+# CHECK-NEXT:        %subview_7 = memref.subview %arg2[%arg3, 0, 0, 0] [1, 4, 4, 16] [1, 1, 1, 1] : memref<1x4x4x16xf32> to memref<1x4x4x16xf32, strided<[256, 64, 16, 1], offset: ?>>
+# CHECK-NEXT:        %c0_8 = arith.constant 0 : index
 # CHECK-NEXT:        %c4 = arith.constant 4 : index
-# CHECK-NEXT:        %c1_13 = arith.constant 1 : index
-# CHECK-NEXT:        scf.for %arg4 = %c0_12 to %c4 step %c1_13 {
-# CHECK-NEXT:          %subview_14 = memref.subview %subview_11[0, %arg4, 0, 0] [1, 1, 4, 16] [1, 1, 1, 1] : memref<1x4x4x16xf32, strided<[256, 64, 16, 1], offset: ?>> to memref<1x1x4x16xf32, strided<[256, 64, 16, 1], offset: ?>>
-# CHECK-NEXT:          %c0_15 = arith.constant 0 : index
-# CHECK-NEXT:          %c4_16 = arith.constant 4 : index
-# CHECK-NEXT:          %c1_17 = arith.constant 1 : index
-# CHECK-NEXT:          scf.for %arg5 = %c0_15 to %c4_16 step %c1_17 {
-# CHECK-NEXT:            %subview_18 = memref.subview %subview_14[0, 0, %arg5, 0] [1, 1, 1, 16] [1, 1, 1, 1] : memref<1x1x4x16xf32, strided<[256, 64, 16, 1], offset: ?>> to memref<1x1x1x16xf32, strided<[256, 64, 16, 1], offset: ?>>
+# CHECK-NEXT:        %c1_9 = arith.constant 1 : index
+# CHECK-NEXT:        scf.for %arg4 = %c0_8 to %c4 step %c1_9 {
+# CHECK-NEXT:          %0 = affine.apply #map(%arg4)
+# CHECK-NEXT:          %subview_10 = memref.subview %subview_5[0, %0, 0, 0] [1, 5, 11, 3] [1, 1, 1, 1] : memref<1x11x11x3xf32, strided<[432, 36, 3, 1], offset: ?>> to memref<1x5x11x3xf32, strided<[432, 36, 3, 1], offset: ?>>
+# CHECK-NEXT:          %subview_11 = memref.subview %subview_6[0, 0, 0, 0] [5, 5, 3, 16] [1, 1, 1, 1] : memref<5x5x3x16xf32, strided<[240, 48, 16, 1]>> to memref<5x5x3x16xf32, strided<[240, 48, 16, 1]>>
+# CHECK-NEXT:          %subview_12 = memref.subview %subview_7[0, %arg4, 0, 0] [1, 1, 4, 16] [1, 1, 1, 1] : memref<1x4x4x16xf32, strided<[256, 64, 16, 1], offset: ?>> to memref<1x1x4x16xf32, strided<[256, 64, 16, 1], offset: ?>>
+# CHECK-NEXT:          %c0_13 = arith.constant 0 : index
+# CHECK-NEXT:          %c4_14 = arith.constant 4 : index
+# CHECK-NEXT:          %c1_15 = arith.constant 1 : index
+# CHECK-NEXT:          scf.for %arg5 = %c0_13 to %c4_14 step %c1_15 {
+# CHECK-NEXT:            %1 = affine.apply #map(%arg5)
+# CHECK-NEXT:            %subview_16 = memref.subview %subview_10[0, 0, %1, 0] [1, 5, 5, 3] [1, 1, 1, 1] : memref<1x5x11x3xf32, strided<[432, 36, 3, 1], offset: ?>> to memref<1x5x5x3xf32, strided<[432, 36, 3, 1], offset: ?>>
+# CHECK-NEXT:            %subview_17 = memref.subview %subview_11[0, 0, 0, 0] [5, 5, 3, 16] [1, 1, 1, 1] : memref<5x5x3x16xf32, strided<[240, 48, 16, 1]>> to memref<5x5x3x16xf32, strided<[240, 48, 16, 1]>>
+# CHECK-NEXT:            %subview_18 = memref.subview %subview_12[0, 0, %arg5, 0] [1, 1, 1, 16] [1, 1, 1, 1] : memref<1x1x4x16xf32, strided<[256, 64, 16, 1], offset: ?>> to memref<1x1x1x16xf32, strided<[256, 64, 16, 1], offset: ?>>
 # CHECK-NEXT:            %c0_19 = arith.constant 0 : index
 # CHECK-NEXT:            %c16 = arith.constant 16 : index
 # CHECK-NEXT:            %c1_20 = arith.constant 1 : index
 # CHECK-NEXT:            scf.for %arg6 = %c0_19 to %c16 step %c1_20 {
-# CHECK-NEXT:              %subview_21 = memref.subview %subview_18[0, 0, 0, %arg6] [1, 1, 1, 1] [1, 1, 1, 1] : memref<1x1x1x16xf32, strided<[256, 64, 16, 1], offset: ?>> to memref<1x1x1x1xf32, strided<[256, 64, 16, 1], offset: ?>>
-# CHECK-NEXT:              linalg.fill {__xtc_id_conv_0_} ins(%cst_4 : f32) outs(%subview_21 : memref<1x1x1x1xf32, strided<[256, 64, 16, 1], offset: ?>>)
-# CHECK-NEXT:            } {"./f"}
-# CHECK-NEXT:          } {"./w"}
-# CHECK-NEXT:        } {"./h"}
-# CHECK-NEXT:      } {"./b"}
-# CHECK-NEXT:      %c0_8 = arith.constant 0 : index
-# CHECK-NEXT:      %c1_9 = arith.constant 1 : index
-# CHECK-NEXT:      %c1_10 = arith.constant 1 : index
-# CHECK-NEXT:      scf.for %arg3 = %c0_8 to %c1_9 step %c1_10 {
-# CHECK-NEXT:        %subview_11 = memref.subview %alloca[%arg3, 0, 0, 0] [1, 11, 11, 3] [1, 1, 1, 1] : memref<1x12x12x3xf32> to memref<1x11x11x3xf32, strided<[432, 36, 3, 1], offset: ?>>
-# CHECK-NEXT:        %subview_12 = memref.subview %arg1[0, 0, 0, 0] [5, 5, 3, 16] [1, 1, 1, 1] : memref<5x5x3x16xf32> to memref<5x5x3x16xf32, strided<[240, 48, 16, 1]>>
-# CHECK-NEXT:        %subview_13 = memref.subview %arg2[%arg3, 0, 0, 0] [1, 4, 4, 16] [1, 1, 1, 1] : memref<1x4x4x16xf32> to memref<1x4x4x16xf32, strided<[256, 64, 16, 1], offset: ?>>
-# CHECK-NEXT:        %c0_14 = arith.constant 0 : index
-# CHECK-NEXT:        %c4 = arith.constant 4 : index
-# CHECK-NEXT:        %c1_15 = arith.constant 1 : index
-# CHECK-NEXT:        scf.for %arg4 = %c0_14 to %c4 step %c1_15 {
-# CHECK-NEXT:          %0 = affine.apply #map(%arg4)
-# CHECK-NEXT:          %subview_16 = memref.subview %subview_11[0, %0, 0, 0] [1, 5, 11, 3] [1, 1, 1, 1] : memref<1x11x11x3xf32, strided<[432, 36, 3, 1], offset: ?>> to memref<1x5x11x3xf32, strided<[432, 36, 3, 1], offset: ?>>
-# CHECK-NEXT:          %subview_17 = memref.subview %subview_12[0, 0, 0, 0] [5, 5, 3, 16] [1, 1, 1, 1] : memref<5x5x3x16xf32, strided<[240, 48, 16, 1]>> to memref<5x5x3x16xf32, strided<[240, 48, 16, 1]>>
-# CHECK-NEXT:          %subview_18 = memref.subview %subview_13[0, %arg4, 0, 0] [1, 1, 4, 16] [1, 1, 1, 1] : memref<1x4x4x16xf32, strided<[256, 64, 16, 1], offset: ?>> to memref<1x1x4x16xf32, strided<[256, 64, 16, 1], offset: ?>>
-# CHECK-NEXT:          %c0_19 = arith.constant 0 : index
-# CHECK-NEXT:          %c4_20 = arith.constant 4 : index
-# CHECK-NEXT:          %c1_21 = arith.constant 1 : index
-# CHECK-NEXT:          scf.for %arg5 = %c0_19 to %c4_20 step %c1_21 {
-# CHECK-NEXT:            %1 = affine.apply #map(%arg5)
-# CHECK-NEXT:            %subview_22 = memref.subview %subview_16[0, 0, %1, 0] [1, 5, 5, 3] [1, 1, 1, 1] : memref<1x5x11x3xf32, strided<[432, 36, 3, 1], offset: ?>> to memref<1x5x5x3xf32, strided<[432, 36, 3, 1], offset: ?>>
-# CHECK-NEXT:            %subview_23 = memref.subview %subview_17[0, 0, 0, 0] [5, 5, 3, 16] [1, 1, 1, 1] : memref<5x5x3x16xf32, strided<[240, 48, 16, 1]>> to memref<5x5x3x16xf32, strided<[240, 48, 16, 1]>>
-# CHECK-NEXT:            %subview_24 = memref.subview %subview_18[0, 0, %arg5, 0] [1, 1, 1, 16] [1, 1, 1, 1] : memref<1x1x4x16xf32, strided<[256, 64, 16, 1], offset: ?>> to memref<1x1x1x16xf32, strided<[256, 64, 16, 1], offset: ?>>
-# CHECK-NEXT:            %c0_25 = arith.constant 0 : index
-# CHECK-NEXT:            %c16 = arith.constant 16 : index
-# CHECK-NEXT:            %c1_26 = arith.constant 1 : index
-# CHECK-NEXT:            scf.for %arg6 = %c0_25 to %c16 step %c1_26 {
-# CHECK-NEXT:              %subview_27 = memref.subview %subview_22[0, 0, 0, 0] [1, 5, 5, 3] [1, 1, 1, 1] : memref<1x5x5x3xf32, strided<[432, 36, 3, 1], offset: ?>> to memref<1x5x5x3xf32, strided<[432, 36, 3, 1], offset: ?>>
-# CHECK-NEXT:              %subview_28 = memref.subview %subview_23[0, 0, 0, %arg6] [5, 5, 3, 1] [1, 1, 1, 1] : memref<5x5x3x16xf32, strided<[240, 48, 16, 1]>> to memref<5x5x3x1xf32, strided<[240, 48, 16, 1], offset: ?>>
-# CHECK-NEXT:              %subview_29 = memref.subview %subview_24[0, 0, 0, %arg6] [1, 1, 1, 1] [1, 1, 1, 1] : memref<1x1x1x16xf32, strided<[256, 64, 16, 1], offset: ?>> to memref<1x1x1x1xf32, strided<[256, 64, 16, 1], offset: ?>>
-# CHECK-NEXT:              %c0_30 = arith.constant 0 : index
+# CHECK-NEXT:              %subview_21 = memref.subview %subview_16[0, 0, 0, 0] [1, 5, 5, 3] [1, 1, 1, 1] : memref<1x5x5x3xf32, strided<[432, 36, 3, 1], offset: ?>> to memref<1x5x5x3xf32, strided<[432, 36, 3, 1], offset: ?>>
+# CHECK-NEXT:              %subview_22 = memref.subview %subview_17[0, 0, 0, %arg6] [5, 5, 3, 1] [1, 1, 1, 1] : memref<5x5x3x16xf32, strided<[240, 48, 16, 1]>> to memref<5x5x3x1xf32, strided<[240, 48, 16, 1], offset: ?>>
+# CHECK-NEXT:              %subview_23 = memref.subview %subview_18[0, 0, 0, %arg6] [1, 1, 1, 1] [1, 1, 1, 1] : memref<1x1x1x16xf32, strided<[256, 64, 16, 1], offset: ?>> to memref<1x1x1x1xf32, strided<[256, 64, 16, 1], offset: ?>>
+# CHECK-NEXT:              %c0_24 = arith.constant 0 : index
 # CHECK-NEXT:              %c5 = arith.constant 5 : index
-# CHECK-NEXT:              %c1_31 = arith.constant 1 : index
-# CHECK-NEXT:              scf.for %arg7 = %c0_30 to %c5 step %c1_31 {
-# CHECK-NEXT:                %subview_32 = memref.subview %subview_27[0, %arg7, 0, 0] [1, 1, 5, 3] [1, 1, 1, 1] : memref<1x5x5x3xf32, strided<[432, 36, 3, 1], offset: ?>> to memref<1x1x5x3xf32, strided<[432, 36, 3, 1], offset: ?>>
-# CHECK-NEXT:                %subview_33 = memref.subview %subview_28[%arg7, 0, 0, 0] [1, 5, 3, 1] [1, 1, 1, 1] : memref<5x5x3x1xf32, strided<[240, 48, 16, 1], offset: ?>> to memref<1x5x3x1xf32, strided<[240, 48, 16, 1], offset: ?>>
-# CHECK-NEXT:                %subview_34 = memref.subview %subview_29[0, 0, 0, 0] [1, 1, 1, 1] [1, 1, 1, 1] : memref<1x1x1x1xf32, strided<[256, 64, 16, 1], offset: ?>> to memref<1x1x1x1xf32, strided<[256, 64, 16, 1], offset: ?>>
-# CHECK-NEXT:                %c0_35 = arith.constant 0 : index
-# CHECK-NEXT:                %c5_36 = arith.constant 5 : index
-# CHECK-NEXT:                %c1_37 = arith.constant 1 : index
-# CHECK-NEXT:                scf.for %arg8 = %c0_35 to %c5_36 step %c1_37 {
-# CHECK-NEXT:                  %subview_38 = memref.subview %subview_32[0, 0, %arg8, 0] [1, 1, 1, 3] [1, 1, 1, 1] : memref<1x1x5x3xf32, strided<[432, 36, 3, 1], offset: ?>> to memref<1x1x1x3xf32, strided<[432, 36, 3, 1], offset: ?>>
-# CHECK-NEXT:                  %subview_39 = memref.subview %subview_33[0, %arg8, 0, 0] [1, 1, 3, 1] [1, 1, 1, 1] : memref<1x5x3x1xf32, strided<[240, 48, 16, 1], offset: ?>> to memref<1x1x3x1xf32, strided<[240, 48, 16, 1], offset: ?>>
-# CHECK-NEXT:                  %subview_40 = memref.subview %subview_34[0, 0, 0, 0] [1, 1, 1, 1] [1, 1, 1, 1] : memref<1x1x1x1xf32, strided<[256, 64, 16, 1], offset: ?>> to memref<1x1x1x1xf32, strided<[256, 64, 16, 1], offset: ?>>
-# CHECK-NEXT:                  %c0_41 = arith.constant 0 : index
+# CHECK-NEXT:              %c1_25 = arith.constant 1 : index
+# CHECK-NEXT:              scf.for %arg7 = %c0_24 to %c5 step %c1_25 {
+# CHECK-NEXT:                %subview_26 = memref.subview %subview_21[0, %arg7, 0, 0] [1, 1, 5, 3] [1, 1, 1, 1] : memref<1x5x5x3xf32, strided<[432, 36, 3, 1], offset: ?>> to memref<1x1x5x3xf32, strided<[432, 36, 3, 1], offset: ?>>
+# CHECK-NEXT:                %subview_27 = memref.subview %subview_22[%arg7, 0, 0, 0] [1, 5, 3, 1] [1, 1, 1, 1] : memref<5x5x3x1xf32, strided<[240, 48, 16, 1], offset: ?>> to memref<1x5x3x1xf32, strided<[240, 48, 16, 1], offset: ?>>
+# CHECK-NEXT:                %subview_28 = memref.subview %subview_23[0, 0, 0, 0] [1, 1, 1, 1] [1, 1, 1, 1] : memref<1x1x1x1xf32, strided<[256, 64, 16, 1], offset: ?>> to memref<1x1x1x1xf32, strided<[256, 64, 16, 1], offset: ?>>
+# CHECK-NEXT:                %c0_29 = arith.constant 0 : index
+# CHECK-NEXT:                %c5_30 = arith.constant 5 : index
+# CHECK-NEXT:                %c1_31 = arith.constant 1 : index
+# CHECK-NEXT:                scf.for %arg8 = %c0_29 to %c5_30 step %c1_31 {
+# CHECK-NEXT:                  %subview_32 = memref.subview %subview_26[0, 0, %arg8, 0] [1, 1, 1, 3] [1, 1, 1, 1] : memref<1x1x5x3xf32, strided<[432, 36, 3, 1], offset: ?>> to memref<1x1x1x3xf32, strided<[432, 36, 3, 1], offset: ?>>
+# CHECK-NEXT:                  %subview_33 = memref.subview %subview_27[0, %arg8, 0, 0] [1, 1, 3, 1] [1, 1, 1, 1] : memref<1x5x3x1xf32, strided<[240, 48, 16, 1], offset: ?>> to memref<1x1x3x1xf32, strided<[240, 48, 16, 1], offset: ?>>
+# CHECK-NEXT:                  %subview_34 = memref.subview %subview_28[0, 0, 0, 0] [1, 1, 1, 1] [1, 1, 1, 1] : memref<1x1x1x1xf32, strided<[256, 64, 16, 1], offset: ?>> to memref<1x1x1x1xf32, strided<[256, 64, 16, 1], offset: ?>>
+# CHECK-NEXT:                  %c0_35 = arith.constant 0 : index
 # CHECK-NEXT:                  %c3 = arith.constant 3 : index
-# CHECK-NEXT:                  %c1_42 = arith.constant 1 : index
-# CHECK-NEXT:                  scf.for %arg9 = %c0_41 to %c3 step %c1_42 {
-# CHECK-NEXT:                    %subview_43 = memref.subview %subview_38[0, 0, 0, %arg9] [1, 1, 1, 1] [1, 1, 1, 1] : memref<1x1x1x3xf32, strided<[432, 36, 3, 1], offset: ?>> to memref<1x1x1x1xf32, strided<[432, 36, 3, 1], offset: ?>>
-# CHECK-NEXT:                    %subview_44 = memref.subview %subview_39[0, 0, %arg9, 0] [1, 1, 1, 1] [1, 1, 1, 1] : memref<1x1x3x1xf32, strided<[240, 48, 16, 1], offset: ?>> to memref<1x1x1x1xf32, strided<[240, 48, 16, 1], offset: ?>>
-# CHECK-NEXT:                    %subview_45 = memref.subview %subview_40[0, 0, 0, 0] [1, 1, 1, 1] [1, 1, 1, 1] : memref<1x1x1x1xf32, strided<[256, 64, 16, 1], offset: ?>> to memref<1x1x1x1xf32, strided<[256, 64, 16, 1], offset: ?>>
-# CHECK-NEXT:                    linalg.generic {indexing_maps = [#map1, #map2, #map3], iterator_types = ["parallel", "parallel", "parallel", "parallel", "reduction", "reduction", "reduction"]} ins(%subview_43, %subview_44 : memref<1x1x1x1xf32, strided<[432, 36, 3, 1], offset: ?>>, memref<1x1x1x1xf32, strided<[240, 48, 16, 1], offset: ?>>) outs(%subview_45 : memref<1x1x1x1xf32, strided<[256, 64, 16, 1], offset: ?>>) attrs =  {__xtc_id_conv_} {
-# CHECK-NEXT:                    ^bb0(%in: f32, %in_46: f32, %out: f32):
-# CHECK-NEXT:                      %2 = arith.mulf %in, %in_46 : f32
+# CHECK-NEXT:                  %c1_36 = arith.constant 1 : index
+# CHECK-NEXT:                  scf.for %arg9 = %c0_35 to %c3 step %c1_36 {
+# CHECK-NEXT:                    %subview_37 = memref.subview %subview_32[0, 0, 0, %arg9] [1, 1, 1, 1] [1, 1, 1, 1] : memref<1x1x1x3xf32, strided<[432, 36, 3, 1], offset: ?>> to memref<1x1x1x1xf32, strided<[432, 36, 3, 1], offset: ?>>
+# CHECK-NEXT:                    %subview_38 = memref.subview %subview_33[0, 0, %arg9, 0] [1, 1, 1, 1] [1, 1, 1, 1] : memref<1x1x3x1xf32, strided<[240, 48, 16, 1], offset: ?>> to memref<1x1x1x1xf32, strided<[240, 48, 16, 1], offset: ?>>
+# CHECK-NEXT:                    %subview_39 = memref.subview %subview_34[0, 0, 0, 0] [1, 1, 1, 1] [1, 1, 1, 1] : memref<1x1x1x1xf32, strided<[256, 64, 16, 1], offset: ?>> to memref<1x1x1x1xf32, strided<[256, 64, 16, 1], offset: ?>>
+# CHECK-NEXT:                    linalg.generic {indexing_maps = [#map1, #map2, #map3], iterator_types = ["parallel", "parallel", "parallel", "parallel", "reduction", "reduction", "reduction"]} ins(%subview_37, %subview_38 : memref<1x1x1x1xf32, strided<[432, 36, 3, 1], offset: ?>>, memref<1x1x1x1xf32, strided<[240, 48, 16, 1], offset: ?>>) outs(%subview_39 : memref<1x1x1x1xf32, strided<[256, 64, 16, 1], offset: ?>>) attrs =  {__xtc_id_conv_} {
+# CHECK-NEXT:                    ^bb0(%in: f32, %in_40: f32, %out: f32):
+# CHECK-NEXT:                      %2 = arith.mulf %in, %in_40 : f32
 # CHECK-NEXT:                      %3 = arith.addf %out, %2 : f32
 # CHECK-NEXT:                      linalg.yield %3 : f32
 # CHECK-NEXT:                    }

--- a/tests/filecheck/backends/padding/test_pad_conv2d_mlir.py
+++ b/tests/filecheck/backends/padding/test_pad_conv2d_mlir.py
@@ -57,7 +57,7 @@ print(f"CODE: {res}")
 # CHECK-NEXT:      transform.yield 
 # CHECK-NEXT:    }
 # CHECK-NEXT:    transform.named_sequence @__transform_main(%arg0: !transform.any_op {transform.readonly}) {
-# CHECK-NEXT:      %0 = transform.structured.match attributes {__xtc_id_pad_0_} in %arg0 : (!transform.any_op) -> !transform.any_op
+# CHECK-NEXT:      %0 = transform.structured.match attributes {__xtc_id_pad_} in %arg0 : (!transform.any_op) -> !transform.any_op
 # CHECK-NEXT:      %tiled_linalg_op, %loops = transform.structured.tile_using_for %0 tile_sizes [1, 0, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
 # CHECK-NEXT:      transform.annotate %loops "./b" : !transform.any_op
 # CHECK-NEXT:      %tiled_linalg_op_0, %loops_1 = transform.structured.tile_using_for %tiled_linalg_op tile_sizes [0, 1, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
@@ -66,39 +66,21 @@ print(f"CODE: {res}")
 # CHECK-NEXT:      transform.annotate %loops_3 "./w" : !transform.any_op
 # CHECK-NEXT:      %tiled_linalg_op_4, %loops_5 = transform.structured.tile_using_for %tiled_linalg_op_2 tile_sizes [0, 0, 0, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
 # CHECK-NEXT:      transform.annotate %loops_5 "./c" : !transform.any_op
-# CHECK-NEXT:      %1 = transform.structured.match attributes {__xtc_id_pad_} in %arg0 : (!transform.any_op) -> !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_6, %loops_7 = transform.structured.tile_using_for %1 tile_sizes [1, 0, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      %1 = transform.structured.match attributes {__xtc_id_conv_} in %arg0 : (!transform.any_op) -> !transform.any_op
+# CHECK-NEXT:      %tiled_linalg_op_6, %loops_7 = transform.structured.tile_using_for %1 tile_sizes [1, 0, 0, 0, 0, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
 # CHECK-NEXT:      transform.annotate %loops_7 "./b" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_8, %loops_9 = transform.structured.tile_using_for %tiled_linalg_op_6 tile_sizes [0, 1, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      %tiled_linalg_op_8, %loops_9 = transform.structured.tile_using_for %tiled_linalg_op_6 tile_sizes [0, 1, 0, 0, 0, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
 # CHECK-NEXT:      transform.annotate %loops_9 "./h" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_10, %loops_11 = transform.structured.tile_using_for %tiled_linalg_op_8 tile_sizes [0, 0, 1, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      %tiled_linalg_op_10, %loops_11 = transform.structured.tile_using_for %tiled_linalg_op_8 tile_sizes [0, 0, 1, 0, 0, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
 # CHECK-NEXT:      transform.annotate %loops_11 "./w" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_12, %loops_13 = transform.structured.tile_using_for %tiled_linalg_op_10 tile_sizes [0, 0, 0, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_13 "./c" : !transform.any_op
-# CHECK-NEXT:      %2 = transform.structured.match attributes {__xtc_id_conv_0_} in %arg0 : (!transform.any_op) -> !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_14, %loops_15 = transform.structured.tile_using_for %2 tile_sizes [1, 0, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_15 "./b" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_16, %loops_17 = transform.structured.tile_using_for %tiled_linalg_op_14 tile_sizes [0, 1, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_17 "./h" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_18, %loops_19 = transform.structured.tile_using_for %tiled_linalg_op_16 tile_sizes [0, 0, 1, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_19 "./w" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_20, %loops_21 = transform.structured.tile_using_for %tiled_linalg_op_18 tile_sizes [0, 0, 0, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_21 "./f" : !transform.any_op
-# CHECK-NEXT:      %3 = transform.structured.match attributes {__xtc_id_conv_} in %arg0 : (!transform.any_op) -> !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_22, %loops_23 = transform.structured.tile_using_for %3 tile_sizes [1, 0, 0, 0, 0, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_23 "./b" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_24, %loops_25 = transform.structured.tile_using_for %tiled_linalg_op_22 tile_sizes [0, 1, 0, 0, 0, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_25 "./h" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_26, %loops_27 = transform.structured.tile_using_for %tiled_linalg_op_24 tile_sizes [0, 0, 1, 0, 0, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_27 "./w" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_28, %loops_29 = transform.structured.tile_using_for %tiled_linalg_op_26 tile_sizes [0, 0, 0, 1, 0, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_29 "./f" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_30, %loops_31 = transform.structured.tile_using_for %tiled_linalg_op_28 tile_sizes [0, 0, 0, 0, 1, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_31 "./r" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_32, %loops_33 = transform.structured.tile_using_for %tiled_linalg_op_30 tile_sizes [0, 0, 0, 0, 0, 1, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_33 "./s" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_34, %loops_35 = transform.structured.tile_using_for %tiled_linalg_op_32 tile_sizes [0, 0, 0, 0, 0, 0, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_35 "./c" : !transform.any_op
+# CHECK-NEXT:      %tiled_linalg_op_12, %loops_13 = transform.structured.tile_using_for %tiled_linalg_op_10 tile_sizes [0, 0, 0, 1, 0, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      transform.annotate %loops_13 "./f" : !transform.any_op
+# CHECK-NEXT:      %tiled_linalg_op_14, %loops_15 = transform.structured.tile_using_for %tiled_linalg_op_12 tile_sizes [0, 0, 0, 0, 1, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      transform.annotate %loops_15 "./r" : !transform.any_op
+# CHECK-NEXT:      %tiled_linalg_op_16, %loops_17 = transform.structured.tile_using_for %tiled_linalg_op_14 tile_sizes [0, 0, 0, 0, 0, 1, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      transform.annotate %loops_17 "./s" : !transform.any_op
+# CHECK-NEXT:      %tiled_linalg_op_18, %loops_19 = transform.structured.tile_using_for %tiled_linalg_op_16 tile_sizes [0, 0, 0, 0, 0, 0, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      transform.annotate %loops_19 "./c" : !transform.any_op
 # CHECK-NEXT:      transform.yield 
 # CHECK-NEXT:    }
 # CHECK-NEXT:  }
@@ -112,141 +94,93 @@ print(f"CODE: {res}")
 # CHECK-NEXT:    func.func @pad_conv2d_nhwc_mini(%arg0: memref<1x8x8x3xf32> {llvm.noalias}, %arg1: memref<5x5x3x16xf32> {llvm.noalias}, %arg2: memref<1x4x4x16xf32> {llvm.noalias}) {
 # CHECK-NEXT:      %alloca = memref.alloca() {alignment = 256 : i64} : memref<1x12x12x3xf32>
 # CHECK-NEXT:      %cst = arith.constant 0.000000e+00 : f32
+# CHECK-NEXT:      linalg.fill {__xtc_id_pad_0_} ins(%cst : f32) outs(%alloca : memref<1x12x12x3xf32>)
+# CHECK-NEXT:      %subview = memref.subview %alloca[0, 2, 2, 0] [1, 8, 8, 3] [1, 1, 1, 1] : memref<1x12x12x3xf32> to memref<1x8x8x3xf32, strided<[432, 36, 3, 1], offset: 78>>
 # CHECK-NEXT:      %c0 = arith.constant 0 : index
 # CHECK-NEXT:      %c1 = arith.constant 1 : index
 # CHECK-NEXT:      %c1_0 = arith.constant 1 : index
 # CHECK-NEXT:      scf.for %arg3 = %c0 to %c1 step %c1_0 {
-# CHECK-NEXT:        %subview_11 = memref.subview %alloca[%arg3, 0, 0, 0] [1, 12, 12, 3] [1, 1, 1, 1] : memref<1x12x12x3xf32> to memref<1x12x12x3xf32, strided<[432, 36, 3, 1], offset: ?>>
-# CHECK-NEXT:        %c0_12 = arith.constant 0 : index
-# CHECK-NEXT:        %c12 = arith.constant 12 : index
-# CHECK-NEXT:        %c1_13 = arith.constant 1 : index
-# CHECK-NEXT:        scf.for %arg4 = %c0_12 to %c12 step %c1_13 {
-# CHECK-NEXT:          %subview_14 = memref.subview %subview_11[0, %arg4, 0, 0] [1, 1, 12, 3] [1, 1, 1, 1] : memref<1x12x12x3xf32, strided<[432, 36, 3, 1], offset: ?>> to memref<1x1x12x3xf32, strided<[432, 36, 3, 1], offset: ?>>
-# CHECK-NEXT:          %c0_15 = arith.constant 0 : index
-# CHECK-NEXT:          %c12_16 = arith.constant 12 : index
-# CHECK-NEXT:          %c1_17 = arith.constant 1 : index
-# CHECK-NEXT:          scf.for %arg5 = %c0_15 to %c12_16 step %c1_17 {
-# CHECK-NEXT:            %subview_18 = memref.subview %subview_14[0, 0, %arg5, 0] [1, 1, 1, 3] [1, 1, 1, 1] : memref<1x1x12x3xf32, strided<[432, 36, 3, 1], offset: ?>> to memref<1x1x1x3xf32, strided<[432, 36, 3, 1], offset: ?>>
-# CHECK-NEXT:            %c0_19 = arith.constant 0 : index
-# CHECK-NEXT:            %c3 = arith.constant 3 : index
-# CHECK-NEXT:            %c1_20 = arith.constant 1 : index
-# CHECK-NEXT:            scf.for %arg6 = %c0_19 to %c3 step %c1_20 {
-# CHECK-NEXT:              %subview_21 = memref.subview %subview_18[0, 0, 0, %arg6] [1, 1, 1, 1] [1, 1, 1, 1] : memref<1x1x1x3xf32, strided<[432, 36, 3, 1], offset: ?>> to memref<1x1x1x1xf32, strided<[432, 36, 3, 1], offset: ?>>
-# CHECK-NEXT:              linalg.fill {__xtc_id_pad_0_} ins(%cst : f32) outs(%subview_21 : memref<1x1x1x1xf32, strided<[432, 36, 3, 1], offset: ?>>)
-# CHECK-NEXT:            } {"./c"}
-# CHECK-NEXT:          } {"./w"}
-# CHECK-NEXT:        } {"./h"}
-# CHECK-NEXT:      } {"./b"}
-# CHECK-NEXT:      %subview = memref.subview %alloca[0, 2, 2, 0] [1, 8, 8, 3] [1, 1, 1, 1] : memref<1x12x12x3xf32> to memref<1x8x8x3xf32, strided<[432, 36, 3, 1], offset: 78>>
-# CHECK-NEXT:      %c0_1 = arith.constant 0 : index
-# CHECK-NEXT:      %c1_2 = arith.constant 1 : index
-# CHECK-NEXT:      %c1_3 = arith.constant 1 : index
-# CHECK-NEXT:      scf.for %arg3 = %c0_1 to %c1_2 step %c1_3 {
-# CHECK-NEXT:        %subview_11 = memref.subview %arg0[%arg3, 0, 0, 0] [1, 8, 8, 3] [1, 1, 1, 1] : memref<1x8x8x3xf32> to memref<1x8x8x3xf32, strided<[192, 24, 3, 1], offset: ?>>
-# CHECK-NEXT:        %subview_12 = memref.subview %subview[%arg3, 0, 0, 0] [1, 8, 8, 3] [1, 1, 1, 1] : memref<1x8x8x3xf32, strided<[432, 36, 3, 1], offset: 78>> to memref<1x8x8x3xf32, strided<[432, 36, 3, 1], offset: ?>>
-# CHECK-NEXT:        %c0_13 = arith.constant 0 : index
+# CHECK-NEXT:        %subview_5 = memref.subview %arg0[%arg3, 0, 0, 0] [1, 8, 8, 3] [1, 1, 1, 1] : memref<1x8x8x3xf32> to memref<1x8x8x3xf32, strided<[192, 24, 3, 1], offset: ?>>
+# CHECK-NEXT:        %subview_6 = memref.subview %subview[%arg3, 0, 0, 0] [1, 8, 8, 3] [1, 1, 1, 1] : memref<1x8x8x3xf32, strided<[432, 36, 3, 1], offset: 78>> to memref<1x8x8x3xf32, strided<[432, 36, 3, 1], offset: ?>>
+# CHECK-NEXT:        %c0_7 = arith.constant 0 : index
 # CHECK-NEXT:        %c8 = arith.constant 8 : index
-# CHECK-NEXT:        %c1_14 = arith.constant 1 : index
-# CHECK-NEXT:        scf.for %arg4 = %c0_13 to %c8 step %c1_14 {
-# CHECK-NEXT:          %subview_15 = memref.subview %subview_11[0, %arg4, 0, 0] [1, 1, 8, 3] [1, 1, 1, 1] : memref<1x8x8x3xf32, strided<[192, 24, 3, 1], offset: ?>> to memref<1x1x8x3xf32, strided<[192, 24, 3, 1], offset: ?>>
-# CHECK-NEXT:          %subview_16 = memref.subview %subview_12[0, %arg4, 0, 0] [1, 1, 8, 3] [1, 1, 1, 1] : memref<1x8x8x3xf32, strided<[432, 36, 3, 1], offset: ?>> to memref<1x1x8x3xf32, strided<[432, 36, 3, 1], offset: ?>>
-# CHECK-NEXT:          %c0_17 = arith.constant 0 : index
-# CHECK-NEXT:          %c8_18 = arith.constant 8 : index
-# CHECK-NEXT:          %c1_19 = arith.constant 1 : index
-# CHECK-NEXT:          scf.for %arg5 = %c0_17 to %c8_18 step %c1_19 {
-# CHECK-NEXT:            %subview_20 = memref.subview %subview_15[0, 0, %arg5, 0] [1, 1, 1, 3] [1, 1, 1, 1] : memref<1x1x8x3xf32, strided<[192, 24, 3, 1], offset: ?>> to memref<1x1x1x3xf32, strided<[192, 24, 3, 1], offset: ?>>
-# CHECK-NEXT:            %subview_21 = memref.subview %subview_16[0, 0, %arg5, 0] [1, 1, 1, 3] [1, 1, 1, 1] : memref<1x1x8x3xf32, strided<[432, 36, 3, 1], offset: ?>> to memref<1x1x1x3xf32, strided<[432, 36, 3, 1], offset: ?>>
-# CHECK-NEXT:            %c0_22 = arith.constant 0 : index
+# CHECK-NEXT:        %c1_8 = arith.constant 1 : index
+# CHECK-NEXT:        scf.for %arg4 = %c0_7 to %c8 step %c1_8 {
+# CHECK-NEXT:          %subview_9 = memref.subview %subview_5[0, %arg4, 0, 0] [1, 1, 8, 3] [1, 1, 1, 1] : memref<1x8x8x3xf32, strided<[192, 24, 3, 1], offset: ?>> to memref<1x1x8x3xf32, strided<[192, 24, 3, 1], offset: ?>>
+# CHECK-NEXT:          %subview_10 = memref.subview %subview_6[0, %arg4, 0, 0] [1, 1, 8, 3] [1, 1, 1, 1] : memref<1x8x8x3xf32, strided<[432, 36, 3, 1], offset: ?>> to memref<1x1x8x3xf32, strided<[432, 36, 3, 1], offset: ?>>
+# CHECK-NEXT:          %c0_11 = arith.constant 0 : index
+# CHECK-NEXT:          %c8_12 = arith.constant 8 : index
+# CHECK-NEXT:          %c1_13 = arith.constant 1 : index
+# CHECK-NEXT:          scf.for %arg5 = %c0_11 to %c8_12 step %c1_13 {
+# CHECK-NEXT:            %subview_14 = memref.subview %subview_9[0, 0, %arg5, 0] [1, 1, 1, 3] [1, 1, 1, 1] : memref<1x1x8x3xf32, strided<[192, 24, 3, 1], offset: ?>> to memref<1x1x1x3xf32, strided<[192, 24, 3, 1], offset: ?>>
+# CHECK-NEXT:            %subview_15 = memref.subview %subview_10[0, 0, %arg5, 0] [1, 1, 1, 3] [1, 1, 1, 1] : memref<1x1x8x3xf32, strided<[432, 36, 3, 1], offset: ?>> to memref<1x1x1x3xf32, strided<[432, 36, 3, 1], offset: ?>>
+# CHECK-NEXT:            %c0_16 = arith.constant 0 : index
 # CHECK-NEXT:            %c3 = arith.constant 3 : index
-# CHECK-NEXT:            %c1_23 = arith.constant 1 : index
-# CHECK-NEXT:            scf.for %arg6 = %c0_22 to %c3 step %c1_23 {
-# CHECK-NEXT:              %subview_24 = memref.subview %subview_20[0, 0, 0, %arg6] [1, 1, 1, 1] [1, 1, 1, 1] : memref<1x1x1x3xf32, strided<[192, 24, 3, 1], offset: ?>> to memref<1x1x1x1xf32, strided<[192, 24, 3, 1], offset: ?>>
-# CHECK-NEXT:              %subview_25 = memref.subview %subview_21[0, 0, 0, %arg6] [1, 1, 1, 1] [1, 1, 1, 1] : memref<1x1x1x3xf32, strided<[432, 36, 3, 1], offset: ?>> to memref<1x1x1x1xf32, strided<[432, 36, 3, 1], offset: ?>>
-# CHECK-NEXT:              linalg.copy {__xtc_id_pad_} ins(%subview_24 : memref<1x1x1x1xf32, strided<[192, 24, 3, 1], offset: ?>>) outs(%subview_25 : memref<1x1x1x1xf32, strided<[432, 36, 3, 1], offset: ?>>)
+# CHECK-NEXT:            %c1_17 = arith.constant 1 : index
+# CHECK-NEXT:            scf.for %arg6 = %c0_16 to %c3 step %c1_17 {
+# CHECK-NEXT:              %subview_18 = memref.subview %subview_14[0, 0, 0, %arg6] [1, 1, 1, 1] [1, 1, 1, 1] : memref<1x1x1x3xf32, strided<[192, 24, 3, 1], offset: ?>> to memref<1x1x1x1xf32, strided<[192, 24, 3, 1], offset: ?>>
+# CHECK-NEXT:              %subview_19 = memref.subview %subview_15[0, 0, 0, %arg6] [1, 1, 1, 1] [1, 1, 1, 1] : memref<1x1x1x3xf32, strided<[432, 36, 3, 1], offset: ?>> to memref<1x1x1x1xf32, strided<[432, 36, 3, 1], offset: ?>>
+# CHECK-NEXT:              linalg.copy {__xtc_id_pad_} ins(%subview_18 : memref<1x1x1x1xf32, strided<[192, 24, 3, 1], offset: ?>>) outs(%subview_19 : memref<1x1x1x1xf32, strided<[432, 36, 3, 1], offset: ?>>)
 # CHECK-NEXT:            } {"./c"}
 # CHECK-NEXT:          } {"./w"}
 # CHECK-NEXT:        } {"./h"}
 # CHECK-NEXT:      } {"./b"}
-# CHECK-NEXT:      %cst_4 = arith.constant 0.000000e+00 : f32
-# CHECK-NEXT:      %c0_5 = arith.constant 0 : index
-# CHECK-NEXT:      %c1_6 = arith.constant 1 : index
-# CHECK-NEXT:      %c1_7 = arith.constant 1 : index
-# CHECK-NEXT:      scf.for %arg3 = %c0_5 to %c1_6 step %c1_7 {
-# CHECK-NEXT:        %subview_11 = memref.subview %arg2[%arg3, 0, 0, 0] [1, 4, 4, 16] [1, 1, 1, 1] : memref<1x4x4x16xf32> to memref<1x4x4x16xf32, strided<[256, 64, 16, 1], offset: ?>>
-# CHECK-NEXT:        %c0_12 = arith.constant 0 : index
+# CHECK-NEXT:      %cst_1 = arith.constant 0.000000e+00 : f32
+# CHECK-NEXT:      linalg.fill {__xtc_id_conv_0_} ins(%cst_1 : f32) outs(%arg2 : memref<1x4x4x16xf32>)
+# CHECK-NEXT:      %c0_2 = arith.constant 0 : index
+# CHECK-NEXT:      %c1_3 = arith.constant 1 : index
+# CHECK-NEXT:      %c1_4 = arith.constant 1 : index
+# CHECK-NEXT:      scf.for %arg3 = %c0_2 to %c1_3 step %c1_4 {
+# CHECK-NEXT:        %subview_5 = memref.subview %alloca[%arg3, 0, 0, 0] [1, 11, 11, 3] [1, 1, 1, 1] : memref<1x12x12x3xf32> to memref<1x11x11x3xf32, strided<[432, 36, 3, 1], offset: ?>>
+# CHECK-NEXT:        %subview_6 = memref.subview %arg1[0, 0, 0, 0] [5, 5, 3, 16] [1, 1, 1, 1] : memref<5x5x3x16xf32> to memref<5x5x3x16xf32, strided<[240, 48, 16, 1]>>
+# CHECK-NEXT:        %subview_7 = memref.subview %arg2[%arg3, 0, 0, 0] [1, 4, 4, 16] [1, 1, 1, 1] : memref<1x4x4x16xf32> to memref<1x4x4x16xf32, strided<[256, 64, 16, 1], offset: ?>>
+# CHECK-NEXT:        %c0_8 = arith.constant 0 : index
 # CHECK-NEXT:        %c4 = arith.constant 4 : index
-# CHECK-NEXT:        %c1_13 = arith.constant 1 : index
-# CHECK-NEXT:        scf.for %arg4 = %c0_12 to %c4 step %c1_13 {
-# CHECK-NEXT:          %subview_14 = memref.subview %subview_11[0, %arg4, 0, 0] [1, 1, 4, 16] [1, 1, 1, 1] : memref<1x4x4x16xf32, strided<[256, 64, 16, 1], offset: ?>> to memref<1x1x4x16xf32, strided<[256, 64, 16, 1], offset: ?>>
-# CHECK-NEXT:          %c0_15 = arith.constant 0 : index
-# CHECK-NEXT:          %c4_16 = arith.constant 4 : index
-# CHECK-NEXT:          %c1_17 = arith.constant 1 : index
-# CHECK-NEXT:          scf.for %arg5 = %c0_15 to %c4_16 step %c1_17 {
-# CHECK-NEXT:            %subview_18 = memref.subview %subview_14[0, 0, %arg5, 0] [1, 1, 1, 16] [1, 1, 1, 1] : memref<1x1x4x16xf32, strided<[256, 64, 16, 1], offset: ?>> to memref<1x1x1x16xf32, strided<[256, 64, 16, 1], offset: ?>>
+# CHECK-NEXT:        %c1_9 = arith.constant 1 : index
+# CHECK-NEXT:        scf.for %arg4 = %c0_8 to %c4 step %c1_9 {
+# CHECK-NEXT:          %0 = affine.apply #map(%arg4)
+# CHECK-NEXT:          %subview_10 = memref.subview %subview_5[0, %0, 0, 0] [1, 5, 11, 3] [1, 1, 1, 1] : memref<1x11x11x3xf32, strided<[432, 36, 3, 1], offset: ?>> to memref<1x5x11x3xf32, strided<[432, 36, 3, 1], offset: ?>>
+# CHECK-NEXT:          %subview_11 = memref.subview %subview_6[0, 0, 0, 0] [5, 5, 3, 16] [1, 1, 1, 1] : memref<5x5x3x16xf32, strided<[240, 48, 16, 1]>> to memref<5x5x3x16xf32, strided<[240, 48, 16, 1]>>
+# CHECK-NEXT:          %subview_12 = memref.subview %subview_7[0, %arg4, 0, 0] [1, 1, 4, 16] [1, 1, 1, 1] : memref<1x4x4x16xf32, strided<[256, 64, 16, 1], offset: ?>> to memref<1x1x4x16xf32, strided<[256, 64, 16, 1], offset: ?>>
+# CHECK-NEXT:          %c0_13 = arith.constant 0 : index
+# CHECK-NEXT:          %c4_14 = arith.constant 4 : index
+# CHECK-NEXT:          %c1_15 = arith.constant 1 : index
+# CHECK-NEXT:          scf.for %arg5 = %c0_13 to %c4_14 step %c1_15 {
+# CHECK-NEXT:            %1 = affine.apply #map(%arg5)
+# CHECK-NEXT:            %subview_16 = memref.subview %subview_10[0, 0, %1, 0] [1, 5, 5, 3] [1, 1, 1, 1] : memref<1x5x11x3xf32, strided<[432, 36, 3, 1], offset: ?>> to memref<1x5x5x3xf32, strided<[432, 36, 3, 1], offset: ?>>
+# CHECK-NEXT:            %subview_17 = memref.subview %subview_11[0, 0, 0, 0] [5, 5, 3, 16] [1, 1, 1, 1] : memref<5x5x3x16xf32, strided<[240, 48, 16, 1]>> to memref<5x5x3x16xf32, strided<[240, 48, 16, 1]>>
+# CHECK-NEXT:            %subview_18 = memref.subview %subview_12[0, 0, %arg5, 0] [1, 1, 1, 16] [1, 1, 1, 1] : memref<1x1x4x16xf32, strided<[256, 64, 16, 1], offset: ?>> to memref<1x1x1x16xf32, strided<[256, 64, 16, 1], offset: ?>>
 # CHECK-NEXT:            %c0_19 = arith.constant 0 : index
 # CHECK-NEXT:            %c16 = arith.constant 16 : index
 # CHECK-NEXT:            %c1_20 = arith.constant 1 : index
 # CHECK-NEXT:            scf.for %arg6 = %c0_19 to %c16 step %c1_20 {
-# CHECK-NEXT:              %subview_21 = memref.subview %subview_18[0, 0, 0, %arg6] [1, 1, 1, 1] [1, 1, 1, 1] : memref<1x1x1x16xf32, strided<[256, 64, 16, 1], offset: ?>> to memref<1x1x1x1xf32, strided<[256, 64, 16, 1], offset: ?>>
-# CHECK-NEXT:              linalg.fill {__xtc_id_conv_0_} ins(%cst_4 : f32) outs(%subview_21 : memref<1x1x1x1xf32, strided<[256, 64, 16, 1], offset: ?>>)
-# CHECK-NEXT:            } {"./f"}
-# CHECK-NEXT:          } {"./w"}
-# CHECK-NEXT:        } {"./h"}
-# CHECK-NEXT:      } {"./b"}
-# CHECK-NEXT:      %c0_8 = arith.constant 0 : index
-# CHECK-NEXT:      %c1_9 = arith.constant 1 : index
-# CHECK-NEXT:      %c1_10 = arith.constant 1 : index
-# CHECK-NEXT:      scf.for %arg3 = %c0_8 to %c1_9 step %c1_10 {
-# CHECK-NEXT:        %subview_11 = memref.subview %alloca[%arg3, 0, 0, 0] [1, 11, 11, 3] [1, 1, 1, 1] : memref<1x12x12x3xf32> to memref<1x11x11x3xf32, strided<[432, 36, 3, 1], offset: ?>>
-# CHECK-NEXT:        %subview_12 = memref.subview %arg1[0, 0, 0, 0] [5, 5, 3, 16] [1, 1, 1, 1] : memref<5x5x3x16xf32> to memref<5x5x3x16xf32, strided<[240, 48, 16, 1]>>
-# CHECK-NEXT:        %subview_13 = memref.subview %arg2[%arg3, 0, 0, 0] [1, 4, 4, 16] [1, 1, 1, 1] : memref<1x4x4x16xf32> to memref<1x4x4x16xf32, strided<[256, 64, 16, 1], offset: ?>>
-# CHECK-NEXT:        %c0_14 = arith.constant 0 : index
-# CHECK-NEXT:        %c4 = arith.constant 4 : index
-# CHECK-NEXT:        %c1_15 = arith.constant 1 : index
-# CHECK-NEXT:        scf.for %arg4 = %c0_14 to %c4 step %c1_15 {
-# CHECK-NEXT:          %0 = affine.apply #map(%arg4)
-# CHECK-NEXT:          %subview_16 = memref.subview %subview_11[0, %0, 0, 0] [1, 5, 11, 3] [1, 1, 1, 1] : memref<1x11x11x3xf32, strided<[432, 36, 3, 1], offset: ?>> to memref<1x5x11x3xf32, strided<[432, 36, 3, 1], offset: ?>>
-# CHECK-NEXT:          %subview_17 = memref.subview %subview_12[0, 0, 0, 0] [5, 5, 3, 16] [1, 1, 1, 1] : memref<5x5x3x16xf32, strided<[240, 48, 16, 1]>> to memref<5x5x3x16xf32, strided<[240, 48, 16, 1]>>
-# CHECK-NEXT:          %subview_18 = memref.subview %subview_13[0, %arg4, 0, 0] [1, 1, 4, 16] [1, 1, 1, 1] : memref<1x4x4x16xf32, strided<[256, 64, 16, 1], offset: ?>> to memref<1x1x4x16xf32, strided<[256, 64, 16, 1], offset: ?>>
-# CHECK-NEXT:          %c0_19 = arith.constant 0 : index
-# CHECK-NEXT:          %c4_20 = arith.constant 4 : index
-# CHECK-NEXT:          %c1_21 = arith.constant 1 : index
-# CHECK-NEXT:          scf.for %arg5 = %c0_19 to %c4_20 step %c1_21 {
-# CHECK-NEXT:            %1 = affine.apply #map(%arg5)
-# CHECK-NEXT:            %subview_22 = memref.subview %subview_16[0, 0, %1, 0] [1, 5, 5, 3] [1, 1, 1, 1] : memref<1x5x11x3xf32, strided<[432, 36, 3, 1], offset: ?>> to memref<1x5x5x3xf32, strided<[432, 36, 3, 1], offset: ?>>
-# CHECK-NEXT:            %subview_23 = memref.subview %subview_17[0, 0, 0, 0] [5, 5, 3, 16] [1, 1, 1, 1] : memref<5x5x3x16xf32, strided<[240, 48, 16, 1]>> to memref<5x5x3x16xf32, strided<[240, 48, 16, 1]>>
-# CHECK-NEXT:            %subview_24 = memref.subview %subview_18[0, 0, %arg5, 0] [1, 1, 1, 16] [1, 1, 1, 1] : memref<1x1x4x16xf32, strided<[256, 64, 16, 1], offset: ?>> to memref<1x1x1x16xf32, strided<[256, 64, 16, 1], offset: ?>>
-# CHECK-NEXT:            %c0_25 = arith.constant 0 : index
-# CHECK-NEXT:            %c16 = arith.constant 16 : index
-# CHECK-NEXT:            %c1_26 = arith.constant 1 : index
-# CHECK-NEXT:            scf.for %arg6 = %c0_25 to %c16 step %c1_26 {
-# CHECK-NEXT:              %subview_27 = memref.subview %subview_22[0, 0, 0, 0] [1, 5, 5, 3] [1, 1, 1, 1] : memref<1x5x5x3xf32, strided<[432, 36, 3, 1], offset: ?>> to memref<1x5x5x3xf32, strided<[432, 36, 3, 1], offset: ?>>
-# CHECK-NEXT:              %subview_28 = memref.subview %subview_23[0, 0, 0, %arg6] [5, 5, 3, 1] [1, 1, 1, 1] : memref<5x5x3x16xf32, strided<[240, 48, 16, 1]>> to memref<5x5x3x1xf32, strided<[240, 48, 16, 1], offset: ?>>
-# CHECK-NEXT:              %subview_29 = memref.subview %subview_24[0, 0, 0, %arg6] [1, 1, 1, 1] [1, 1, 1, 1] : memref<1x1x1x16xf32, strided<[256, 64, 16, 1], offset: ?>> to memref<1x1x1x1xf32, strided<[256, 64, 16, 1], offset: ?>>
-# CHECK-NEXT:              %c0_30 = arith.constant 0 : index
+# CHECK-NEXT:              %subview_21 = memref.subview %subview_16[0, 0, 0, 0] [1, 5, 5, 3] [1, 1, 1, 1] : memref<1x5x5x3xf32, strided<[432, 36, 3, 1], offset: ?>> to memref<1x5x5x3xf32, strided<[432, 36, 3, 1], offset: ?>>
+# CHECK-NEXT:              %subview_22 = memref.subview %subview_17[0, 0, 0, %arg6] [5, 5, 3, 1] [1, 1, 1, 1] : memref<5x5x3x16xf32, strided<[240, 48, 16, 1]>> to memref<5x5x3x1xf32, strided<[240, 48, 16, 1], offset: ?>>
+# CHECK-NEXT:              %subview_23 = memref.subview %subview_18[0, 0, 0, %arg6] [1, 1, 1, 1] [1, 1, 1, 1] : memref<1x1x1x16xf32, strided<[256, 64, 16, 1], offset: ?>> to memref<1x1x1x1xf32, strided<[256, 64, 16, 1], offset: ?>>
+# CHECK-NEXT:              %c0_24 = arith.constant 0 : index
 # CHECK-NEXT:              %c5 = arith.constant 5 : index
-# CHECK-NEXT:              %c1_31 = arith.constant 1 : index
-# CHECK-NEXT:              scf.for %arg7 = %c0_30 to %c5 step %c1_31 {
-# CHECK-NEXT:                %subview_32 = memref.subview %subview_27[0, %arg7, 0, 0] [1, 1, 5, 3] [1, 1, 1, 1] : memref<1x5x5x3xf32, strided<[432, 36, 3, 1], offset: ?>> to memref<1x1x5x3xf32, strided<[432, 36, 3, 1], offset: ?>>
-# CHECK-NEXT:                %subview_33 = memref.subview %subview_28[%arg7, 0, 0, 0] [1, 5, 3, 1] [1, 1, 1, 1] : memref<5x5x3x1xf32, strided<[240, 48, 16, 1], offset: ?>> to memref<1x5x3x1xf32, strided<[240, 48, 16, 1], offset: ?>>
-# CHECK-NEXT:                %subview_34 = memref.subview %subview_29[0, 0, 0, 0] [1, 1, 1, 1] [1, 1, 1, 1] : memref<1x1x1x1xf32, strided<[256, 64, 16, 1], offset: ?>> to memref<1x1x1x1xf32, strided<[256, 64, 16, 1], offset: ?>>
-# CHECK-NEXT:                %c0_35 = arith.constant 0 : index
-# CHECK-NEXT:                %c5_36 = arith.constant 5 : index
-# CHECK-NEXT:                %c1_37 = arith.constant 1 : index
-# CHECK-NEXT:                scf.for %arg8 = %c0_35 to %c5_36 step %c1_37 {
-# CHECK-NEXT:                  %subview_38 = memref.subview %subview_32[0, 0, %arg8, 0] [1, 1, 1, 3] [1, 1, 1, 1] : memref<1x1x5x3xf32, strided<[432, 36, 3, 1], offset: ?>> to memref<1x1x1x3xf32, strided<[432, 36, 3, 1], offset: ?>>
-# CHECK-NEXT:                  %subview_39 = memref.subview %subview_33[0, %arg8, 0, 0] [1, 1, 3, 1] [1, 1, 1, 1] : memref<1x5x3x1xf32, strided<[240, 48, 16, 1], offset: ?>> to memref<1x1x3x1xf32, strided<[240, 48, 16, 1], offset: ?>>
-# CHECK-NEXT:                  %subview_40 = memref.subview %subview_34[0, 0, 0, 0] [1, 1, 1, 1] [1, 1, 1, 1] : memref<1x1x1x1xf32, strided<[256, 64, 16, 1], offset: ?>> to memref<1x1x1x1xf32, strided<[256, 64, 16, 1], offset: ?>>
-# CHECK-NEXT:                  %c0_41 = arith.constant 0 : index
+# CHECK-NEXT:              %c1_25 = arith.constant 1 : index
+# CHECK-NEXT:              scf.for %arg7 = %c0_24 to %c5 step %c1_25 {
+# CHECK-NEXT:                %subview_26 = memref.subview %subview_21[0, %arg7, 0, 0] [1, 1, 5, 3] [1, 1, 1, 1] : memref<1x5x5x3xf32, strided<[432, 36, 3, 1], offset: ?>> to memref<1x1x5x3xf32, strided<[432, 36, 3, 1], offset: ?>>
+# CHECK-NEXT:                %subview_27 = memref.subview %subview_22[%arg7, 0, 0, 0] [1, 5, 3, 1] [1, 1, 1, 1] : memref<5x5x3x1xf32, strided<[240, 48, 16, 1], offset: ?>> to memref<1x5x3x1xf32, strided<[240, 48, 16, 1], offset: ?>>
+# CHECK-NEXT:                %subview_28 = memref.subview %subview_23[0, 0, 0, 0] [1, 1, 1, 1] [1, 1, 1, 1] : memref<1x1x1x1xf32, strided<[256, 64, 16, 1], offset: ?>> to memref<1x1x1x1xf32, strided<[256, 64, 16, 1], offset: ?>>
+# CHECK-NEXT:                %c0_29 = arith.constant 0 : index
+# CHECK-NEXT:                %c5_30 = arith.constant 5 : index
+# CHECK-NEXT:                %c1_31 = arith.constant 1 : index
+# CHECK-NEXT:                scf.for %arg8 = %c0_29 to %c5_30 step %c1_31 {
+# CHECK-NEXT:                  %subview_32 = memref.subview %subview_26[0, 0, %arg8, 0] [1, 1, 1, 3] [1, 1, 1, 1] : memref<1x1x5x3xf32, strided<[432, 36, 3, 1], offset: ?>> to memref<1x1x1x3xf32, strided<[432, 36, 3, 1], offset: ?>>
+# CHECK-NEXT:                  %subview_33 = memref.subview %subview_27[0, %arg8, 0, 0] [1, 1, 3, 1] [1, 1, 1, 1] : memref<1x5x3x1xf32, strided<[240, 48, 16, 1], offset: ?>> to memref<1x1x3x1xf32, strided<[240, 48, 16, 1], offset: ?>>
+# CHECK-NEXT:                  %subview_34 = memref.subview %subview_28[0, 0, 0, 0] [1, 1, 1, 1] [1, 1, 1, 1] : memref<1x1x1x1xf32, strided<[256, 64, 16, 1], offset: ?>> to memref<1x1x1x1xf32, strided<[256, 64, 16, 1], offset: ?>>
+# CHECK-NEXT:                  %c0_35 = arith.constant 0 : index
 # CHECK-NEXT:                  %c3 = arith.constant 3 : index
-# CHECK-NEXT:                  %c1_42 = arith.constant 1 : index
-# CHECK-NEXT:                  scf.for %arg9 = %c0_41 to %c3 step %c1_42 {
-# CHECK-NEXT:                    %subview_43 = memref.subview %subview_38[0, 0, 0, %arg9] [1, 1, 1, 1] [1, 1, 1, 1] : memref<1x1x1x3xf32, strided<[432, 36, 3, 1], offset: ?>> to memref<1x1x1x1xf32, strided<[432, 36, 3, 1], offset: ?>>
-# CHECK-NEXT:                    %subview_44 = memref.subview %subview_39[0, 0, %arg9, 0] [1, 1, 1, 1] [1, 1, 1, 1] : memref<1x1x3x1xf32, strided<[240, 48, 16, 1], offset: ?>> to memref<1x1x1x1xf32, strided<[240, 48, 16, 1], offset: ?>>
-# CHECK-NEXT:                    %subview_45 = memref.subview %subview_40[0, 0, 0, 0] [1, 1, 1, 1] [1, 1, 1, 1] : memref<1x1x1x1xf32, strided<[256, 64, 16, 1], offset: ?>> to memref<1x1x1x1xf32, strided<[256, 64, 16, 1], offset: ?>>
-# CHECK-NEXT:                    linalg.generic {indexing_maps = [#map1, #map2, #map3], iterator_types = ["parallel", "parallel", "parallel", "parallel", "reduction", "reduction", "reduction"]} ins(%subview_43, %subview_44 : memref<1x1x1x1xf32, strided<[432, 36, 3, 1], offset: ?>>, memref<1x1x1x1xf32, strided<[240, 48, 16, 1], offset: ?>>) outs(%subview_45 : memref<1x1x1x1xf32, strided<[256, 64, 16, 1], offset: ?>>) attrs =  {__xtc_id_conv_} {
-# CHECK-NEXT:                    ^bb0(%in: f32, %in_46: f32, %out: f32):
-# CHECK-NEXT:                      %2 = arith.mulf %in, %in_46 fastmath<fast> : f32
+# CHECK-NEXT:                  %c1_36 = arith.constant 1 : index
+# CHECK-NEXT:                  scf.for %arg9 = %c0_35 to %c3 step %c1_36 {
+# CHECK-NEXT:                    %subview_37 = memref.subview %subview_32[0, 0, 0, %arg9] [1, 1, 1, 1] [1, 1, 1, 1] : memref<1x1x1x3xf32, strided<[432, 36, 3, 1], offset: ?>> to memref<1x1x1x1xf32, strided<[432, 36, 3, 1], offset: ?>>
+# CHECK-NEXT:                    %subview_38 = memref.subview %subview_33[0, 0, %arg9, 0] [1, 1, 1, 1] [1, 1, 1, 1] : memref<1x1x3x1xf32, strided<[240, 48, 16, 1], offset: ?>> to memref<1x1x1x1xf32, strided<[240, 48, 16, 1], offset: ?>>
+# CHECK-NEXT:                    %subview_39 = memref.subview %subview_34[0, 0, 0, 0] [1, 1, 1, 1] [1, 1, 1, 1] : memref<1x1x1x1xf32, strided<[256, 64, 16, 1], offset: ?>> to memref<1x1x1x1xf32, strided<[256, 64, 16, 1], offset: ?>>
+# CHECK-NEXT:                    linalg.generic {indexing_maps = [#map1, #map2, #map3], iterator_types = ["parallel", "parallel", "parallel", "parallel", "reduction", "reduction", "reduction"]} ins(%subview_37, %subview_38 : memref<1x1x1x1xf32, strided<[432, 36, 3, 1], offset: ?>>, memref<1x1x1x1xf32, strided<[240, 48, 16, 1], offset: ?>>) outs(%subview_39 : memref<1x1x1x1xf32, strided<[256, 64, 16, 1], offset: ?>>) attrs =  {__xtc_id_conv_} {
+# CHECK-NEXT:                    ^bb0(%in: f32, %in_40: f32, %out: f32):
+# CHECK-NEXT:                      %2 = arith.mulf %in, %in_40 fastmath<fast> : f32
 # CHECK-NEXT:                      %3 = arith.addf %out, %2 fastmath<fast> : f32
 # CHECK-NEXT:                      linalg.yield %3 : f32
 # CHECK-NEXT:                    }

--- a/tests/filecheck/backends/padding/test_pad_matmul_unpad_mlir.py
+++ b/tests/filecheck/backends/padding/test_pad_matmul_unpad_mlir.py
@@ -57,43 +57,28 @@ print(f"CODE: {res}")
 # CHECK-NEXT:      transform.yield 
 # CHECK-NEXT:    }
 # CHECK-NEXT:    transform.named_sequence @__transform_main(%arg0: !transform.any_op {transform.readonly}) {
-# CHECK-NEXT:      %0 = transform.structured.match attributes {__xtc_id_A_pad_0_} in %arg0 : (!transform.any_op) -> !transform.any_op
+# CHECK-NEXT:      %0 = transform.structured.match attributes {__xtc_id_A_pad_} in %arg0 : (!transform.any_op) -> !transform.any_op
 # CHECK-NEXT:      %tiled_linalg_op, %loops = transform.structured.tile_using_for %0 tile_sizes [1, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
 # CHECK-NEXT:      transform.annotate %loops "./b" : !transform.any_op
 # CHECK-NEXT:      %tiled_linalg_op_0, %loops_1 = transform.structured.tile_using_for %tiled_linalg_op tile_sizes [0, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
 # CHECK-NEXT:      transform.annotate %loops_1 "./h" : !transform.any_op
-# CHECK-NEXT:      %1 = transform.structured.match attributes {__xtc_id_A_pad_} in %arg0 : (!transform.any_op) -> !transform.any_op
+# CHECK-NEXT:      %1 = transform.structured.match attributes {__xtc_id_B_pad_} in %arg0 : (!transform.any_op) -> !transform.any_op
 # CHECK-NEXT:      %tiled_linalg_op_2, %loops_3 = transform.structured.tile_using_for %1 tile_sizes [1, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
 # CHECK-NEXT:      transform.annotate %loops_3 "./b" : !transform.any_op
 # CHECK-NEXT:      %tiled_linalg_op_4, %loops_5 = transform.structured.tile_using_for %tiled_linalg_op_2 tile_sizes [0, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
 # CHECK-NEXT:      transform.annotate %loops_5 "./h" : !transform.any_op
-# CHECK-NEXT:      %2 = transform.structured.match attributes {__xtc_id_B_pad_0_} in %arg0 : (!transform.any_op) -> !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_6, %loops_7 = transform.structured.tile_using_for %2 tile_sizes [1, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_7 "./b" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_8, %loops_9 = transform.structured.tile_using_for %tiled_linalg_op_6 tile_sizes [0, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_9 "./h" : !transform.any_op
-# CHECK-NEXT:      %3 = transform.structured.match attributes {__xtc_id_B_pad_} in %arg0 : (!transform.any_op) -> !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_10, %loops_11 = transform.structured.tile_using_for %3 tile_sizes [1, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_11 "./b" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_12, %loops_13 = transform.structured.tile_using_for %tiled_linalg_op_10 tile_sizes [0, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_13 "./h" : !transform.any_op
-# CHECK-NEXT:      %4 = transform.structured.match attributes {__xtc_id_matmul_padded_0_} in %arg0 : (!transform.any_op) -> !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_14, %loops_15 = transform.structured.tile_using_for %4 tile_sizes [1, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_15 "./i" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_16, %loops_17 = transform.structured.tile_using_for %tiled_linalg_op_14 tile_sizes [0, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_17 "./j" : !transform.any_op
-# CHECK-NEXT:      %5 = transform.structured.match attributes {__xtc_id_matmul_padded_} in %arg0 : (!transform.any_op) -> !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_18, %loops_19 = transform.structured.tile_using_for %5 tile_sizes [1, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_19 "./i" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_20, %loops_21 = transform.structured.tile_using_for %tiled_linalg_op_18 tile_sizes [0, 1, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_21 "./j" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_22, %loops_23 = transform.structured.tile_using_for %tiled_linalg_op_20 tile_sizes [0, 0, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_23 "./k" : !transform.any_op
-# CHECK-NEXT:      %6 = transform.structured.match attributes {__xtc_id_C_} in %arg0 : (!transform.any_op) -> !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_24, %loops_25 = transform.structured.tile_using_for %6 tile_sizes [1, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_25 "./i" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_26, %loops_27 = transform.structured.tile_using_for %tiled_linalg_op_24 tile_sizes [0, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_27 "./j" : !transform.any_op
+# CHECK-NEXT:      %2 = transform.structured.match attributes {__xtc_id_matmul_padded_} in %arg0 : (!transform.any_op) -> !transform.any_op
+# CHECK-NEXT:      %tiled_linalg_op_6, %loops_7 = transform.structured.tile_using_for %2 tile_sizes [1, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      transform.annotate %loops_7 "./i" : !transform.any_op
+# CHECK-NEXT:      %tiled_linalg_op_8, %loops_9 = transform.structured.tile_using_for %tiled_linalg_op_6 tile_sizes [0, 1, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      transform.annotate %loops_9 "./j" : !transform.any_op
+# CHECK-NEXT:      %tiled_linalg_op_10, %loops_11 = transform.structured.tile_using_for %tiled_linalg_op_8 tile_sizes [0, 0, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      transform.annotate %loops_11 "./k" : !transform.any_op
+# CHECK-NEXT:      %3 = transform.structured.match attributes {__xtc_id_C_} in %arg0 : (!transform.any_op) -> !transform.any_op
+# CHECK-NEXT:      %tiled_linalg_op_12, %loops_13 = transform.structured.tile_using_for %3 tile_sizes [1, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      transform.annotate %loops_13 "./i" : !transform.any_op
+# CHECK-NEXT:      %tiled_linalg_op_14, %loops_15 = transform.structured.tile_using_for %tiled_linalg_op_12 tile_sizes [0, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      transform.annotate %loops_15 "./j" : !transform.any_op
 # CHECK-NEXT:      transform.yield 
 # CHECK-NEXT:    }
 # CHECK-NEXT:  }
@@ -103,120 +88,84 @@ print(f"CODE: {res}")
 # CHECK-NEXT:    func.func @pad_matmul_unpad(%arg0: memref<14x14xf32> {llvm.noalias}, %arg1: memref<14x14xf32> {llvm.noalias}, %arg2: memref<14x14xf32> {llvm.noalias}) {
 # CHECK-NEXT:      %alloca = memref.alloca() {alignment = 256 : i64} : memref<16x16xf32>
 # CHECK-NEXT:      %cst = arith.constant 0.000000e+00 : f32
-# CHECK-NEXT:      %c0 = arith.constant 0 : index
-# CHECK-NEXT:      %c16 = arith.constant 16 : index
-# CHECK-NEXT:      %c1 = arith.constant 1 : index
-# CHECK-NEXT:      scf.for %arg3 = %c0 to %c16 step %c1 {
-# CHECK-NEXT:        %subview_23 = memref.subview %alloca[%arg3, 0] [1, 16] [1, 1] : memref<16x16xf32> to memref<1x16xf32, strided<[16, 1], offset: ?>>
-# CHECK-NEXT:        %c0_24 = arith.constant 0 : index
-# CHECK-NEXT:        %c16_25 = arith.constant 16 : index
-# CHECK-NEXT:        %c1_26 = arith.constant 1 : index
-# CHECK-NEXT:        scf.for %arg4 = %c0_24 to %c16_25 step %c1_26 {
-# CHECK-NEXT:          %subview_27 = memref.subview %subview_23[0, %arg4] [1, 1] [1, 1] : memref<1x16xf32, strided<[16, 1], offset: ?>> to memref<1x1xf32, strided<[16, 1], offset: ?>>
-# CHECK-NEXT:          linalg.fill {__xtc_id_A_pad_0_} ins(%cst : f32) outs(%subview_27 : memref<1x1xf32, strided<[16, 1], offset: ?>>)
-# CHECK-NEXT:        } {"./h"}
-# CHECK-NEXT:      } {"./b"}
+# CHECK-NEXT:      linalg.fill {__xtc_id_A_pad_0_} ins(%cst : f32) outs(%alloca : memref<16x16xf32>)
 # CHECK-NEXT:      %subview = memref.subview %alloca[0, 0] [14, 14] [1, 1] : memref<16x16xf32> to memref<14x14xf32, strided<[16, 1]>>
-# CHECK-NEXT:      %c0_0 = arith.constant 0 : index
+# CHECK-NEXT:      %c0 = arith.constant 0 : index
 # CHECK-NEXT:      %c14 = arith.constant 14 : index
-# CHECK-NEXT:      %c1_1 = arith.constant 1 : index
-# CHECK-NEXT:      scf.for %arg3 = %c0_0 to %c14 step %c1_1 {
-# CHECK-NEXT:        %subview_23 = memref.subview %arg0[%arg3, 0] [1, 14] [1, 1] : memref<14x14xf32> to memref<1x14xf32, strided<[14, 1], offset: ?>>
-# CHECK-NEXT:        %subview_24 = memref.subview %subview[%arg3, 0] [1, 14] [1, 1] : memref<14x14xf32, strided<[16, 1]>> to memref<1x14xf32, strided<[16, 1], offset: ?>>
-# CHECK-NEXT:        %c0_25 = arith.constant 0 : index
-# CHECK-NEXT:        %c14_26 = arith.constant 14 : index
-# CHECK-NEXT:        %c1_27 = arith.constant 1 : index
-# CHECK-NEXT:        scf.for %arg4 = %c0_25 to %c14_26 step %c1_27 {
-# CHECK-NEXT:          %subview_28 = memref.subview %subview_23[0, %arg4] [1, 1] [1, 1] : memref<1x14xf32, strided<[14, 1], offset: ?>> to memref<1x1xf32, strided<[14, 1], offset: ?>>
-# CHECK-NEXT:          %subview_29 = memref.subview %subview_24[0, %arg4] [1, 1] [1, 1] : memref<1x14xf32, strided<[16, 1], offset: ?>> to memref<1x1xf32, strided<[16, 1], offset: ?>>
-# CHECK-NEXT:          linalg.copy {__xtc_id_A_pad_} ins(%subview_28 : memref<1x1xf32, strided<[14, 1], offset: ?>>) outs(%subview_29 : memref<1x1xf32, strided<[16, 1], offset: ?>>)
+# CHECK-NEXT:      %c1 = arith.constant 1 : index
+# CHECK-NEXT:      scf.for %arg3 = %c0 to %c14 step %c1 {
+# CHECK-NEXT:        %subview_14 = memref.subview %arg0[%arg3, 0] [1, 14] [1, 1] : memref<14x14xf32> to memref<1x14xf32, strided<[14, 1], offset: ?>>
+# CHECK-NEXT:        %subview_15 = memref.subview %subview[%arg3, 0] [1, 14] [1, 1] : memref<14x14xf32, strided<[16, 1]>> to memref<1x14xf32, strided<[16, 1], offset: ?>>
+# CHECK-NEXT:        %c0_16 = arith.constant 0 : index
+# CHECK-NEXT:        %c14_17 = arith.constant 14 : index
+# CHECK-NEXT:        %c1_18 = arith.constant 1 : index
+# CHECK-NEXT:        scf.for %arg4 = %c0_16 to %c14_17 step %c1_18 {
+# CHECK-NEXT:          %subview_19 = memref.subview %subview_14[0, %arg4] [1, 1] [1, 1] : memref<1x14xf32, strided<[14, 1], offset: ?>> to memref<1x1xf32, strided<[14, 1], offset: ?>>
+# CHECK-NEXT:          %subview_20 = memref.subview %subview_15[0, %arg4] [1, 1] [1, 1] : memref<1x14xf32, strided<[16, 1], offset: ?>> to memref<1x1xf32, strided<[16, 1], offset: ?>>
+# CHECK-NEXT:          linalg.copy {__xtc_id_A_pad_} ins(%subview_19 : memref<1x1xf32, strided<[14, 1], offset: ?>>) outs(%subview_20 : memref<1x1xf32, strided<[16, 1], offset: ?>>)
 # CHECK-NEXT:        } {"./h"}
 # CHECK-NEXT:      } {"./b"}
-# CHECK-NEXT:      %alloca_2 = memref.alloca() {alignment = 256 : i64} : memref<16x16xf32>
-# CHECK-NEXT:      %cst_3 = arith.constant 0.000000e+00 : f32
-# CHECK-NEXT:      %c0_4 = arith.constant 0 : index
-# CHECK-NEXT:      %c16_5 = arith.constant 16 : index
-# CHECK-NEXT:      %c1_6 = arith.constant 1 : index
-# CHECK-NEXT:      scf.for %arg3 = %c0_4 to %c16_5 step %c1_6 {
-# CHECK-NEXT:        %subview_23 = memref.subview %alloca_2[%arg3, 0] [1, 16] [1, 1] : memref<16x16xf32> to memref<1x16xf32, strided<[16, 1], offset: ?>>
-# CHECK-NEXT:        %c0_24 = arith.constant 0 : index
-# CHECK-NEXT:        %c16_25 = arith.constant 16 : index
-# CHECK-NEXT:        %c1_26 = arith.constant 1 : index
-# CHECK-NEXT:        scf.for %arg4 = %c0_24 to %c16_25 step %c1_26 {
-# CHECK-NEXT:          %subview_27 = memref.subview %subview_23[0, %arg4] [1, 1] [1, 1] : memref<1x16xf32, strided<[16, 1], offset: ?>> to memref<1x1xf32, strided<[16, 1], offset: ?>>
-# CHECK-NEXT:          linalg.fill {__xtc_id_B_pad_0_} ins(%cst_3 : f32) outs(%subview_27 : memref<1x1xf32, strided<[16, 1], offset: ?>>)
+# CHECK-NEXT:      %alloca_0 = memref.alloca() {alignment = 256 : i64} : memref<16x16xf32>
+# CHECK-NEXT:      %cst_1 = arith.constant 0.000000e+00 : f32
+# CHECK-NEXT:      linalg.fill {__xtc_id_B_pad_0_} ins(%cst_1 : f32) outs(%alloca_0 : memref<16x16xf32>)
+# CHECK-NEXT:      %subview_2 = memref.subview %alloca_0[0, 0] [14, 14] [1, 1] : memref<16x16xf32> to memref<14x14xf32, strided<[16, 1]>>
+# CHECK-NEXT:      %c0_3 = arith.constant 0 : index
+# CHECK-NEXT:      %c14_4 = arith.constant 14 : index
+# CHECK-NEXT:      %c1_5 = arith.constant 1 : index
+# CHECK-NEXT:      scf.for %arg3 = %c0_3 to %c14_4 step %c1_5 {
+# CHECK-NEXT:        %subview_14 = memref.subview %arg1[%arg3, 0] [1, 14] [1, 1] : memref<14x14xf32> to memref<1x14xf32, strided<[14, 1], offset: ?>>
+# CHECK-NEXT:        %subview_15 = memref.subview %subview_2[%arg3, 0] [1, 14] [1, 1] : memref<14x14xf32, strided<[16, 1]>> to memref<1x14xf32, strided<[16, 1], offset: ?>>
+# CHECK-NEXT:        %c0_16 = arith.constant 0 : index
+# CHECK-NEXT:        %c14_17 = arith.constant 14 : index
+# CHECK-NEXT:        %c1_18 = arith.constant 1 : index
+# CHECK-NEXT:        scf.for %arg4 = %c0_16 to %c14_17 step %c1_18 {
+# CHECK-NEXT:          %subview_19 = memref.subview %subview_14[0, %arg4] [1, 1] [1, 1] : memref<1x14xf32, strided<[14, 1], offset: ?>> to memref<1x1xf32, strided<[14, 1], offset: ?>>
+# CHECK-NEXT:          %subview_20 = memref.subview %subview_15[0, %arg4] [1, 1] [1, 1] : memref<1x14xf32, strided<[16, 1], offset: ?>> to memref<1x1xf32, strided<[16, 1], offset: ?>>
+# CHECK-NEXT:          linalg.copy {__xtc_id_B_pad_} ins(%subview_19 : memref<1x1xf32, strided<[14, 1], offset: ?>>) outs(%subview_20 : memref<1x1xf32, strided<[16, 1], offset: ?>>)
 # CHECK-NEXT:        } {"./h"}
 # CHECK-NEXT:      } {"./b"}
-# CHECK-NEXT:      %subview_7 = memref.subview %alloca_2[0, 0] [14, 14] [1, 1] : memref<16x16xf32> to memref<14x14xf32, strided<[16, 1]>>
+# CHECK-NEXT:      %alloca_6 = memref.alloca() {alignment = 256 : i64} : memref<16x16xf32>
+# CHECK-NEXT:      %cst_7 = arith.constant 0.000000e+00 : f32
+# CHECK-NEXT:      linalg.fill {__xtc_id_matmul_padded_0_} ins(%cst_7 : f32) outs(%alloca_6 : memref<16x16xf32>)
 # CHECK-NEXT:      %c0_8 = arith.constant 0 : index
-# CHECK-NEXT:      %c14_9 = arith.constant 14 : index
-# CHECK-NEXT:      %c1_10 = arith.constant 1 : index
-# CHECK-NEXT:      scf.for %arg3 = %c0_8 to %c14_9 step %c1_10 {
-# CHECK-NEXT:        %subview_23 = memref.subview %arg1[%arg3, 0] [1, 14] [1, 1] : memref<14x14xf32> to memref<1x14xf32, strided<[14, 1], offset: ?>>
-# CHECK-NEXT:        %subview_24 = memref.subview %subview_7[%arg3, 0] [1, 14] [1, 1] : memref<14x14xf32, strided<[16, 1]>> to memref<1x14xf32, strided<[16, 1], offset: ?>>
-# CHECK-NEXT:        %c0_25 = arith.constant 0 : index
-# CHECK-NEXT:        %c14_26 = arith.constant 14 : index
-# CHECK-NEXT:        %c1_27 = arith.constant 1 : index
-# CHECK-NEXT:        scf.for %arg4 = %c0_25 to %c14_26 step %c1_27 {
-# CHECK-NEXT:          %subview_28 = memref.subview %subview_23[0, %arg4] [1, 1] [1, 1] : memref<1x14xf32, strided<[14, 1], offset: ?>> to memref<1x1xf32, strided<[14, 1], offset: ?>>
-# CHECK-NEXT:          %subview_29 = memref.subview %subview_24[0, %arg4] [1, 1] [1, 1] : memref<1x14xf32, strided<[16, 1], offset: ?>> to memref<1x1xf32, strided<[16, 1], offset: ?>>
-# CHECK-NEXT:          linalg.copy {__xtc_id_B_pad_} ins(%subview_28 : memref<1x1xf32, strided<[14, 1], offset: ?>>) outs(%subview_29 : memref<1x1xf32, strided<[16, 1], offset: ?>>)
-# CHECK-NEXT:        } {"./h"}
-# CHECK-NEXT:      } {"./b"}
-# CHECK-NEXT:      %alloca_11 = memref.alloca() {alignment = 256 : i64} : memref<16x16xf32>
-# CHECK-NEXT:      %cst_12 = arith.constant 0.000000e+00 : f32
-# CHECK-NEXT:      %c0_13 = arith.constant 0 : index
-# CHECK-NEXT:      %c16_14 = arith.constant 16 : index
-# CHECK-NEXT:      %c1_15 = arith.constant 1 : index
-# CHECK-NEXT:      scf.for %arg3 = %c0_13 to %c16_14 step %c1_15 {
-# CHECK-NEXT:        %subview_23 = memref.subview %alloca_11[%arg3, 0] [1, 16] [1, 1] : memref<16x16xf32> to memref<1x16xf32, strided<[16, 1], offset: ?>>
-# CHECK-NEXT:        %c0_24 = arith.constant 0 : index
-# CHECK-NEXT:        %c16_25 = arith.constant 16 : index
-# CHECK-NEXT:        %c1_26 = arith.constant 1 : index
-# CHECK-NEXT:        scf.for %arg4 = %c0_24 to %c16_25 step %c1_26 {
-# CHECK-NEXT:          %subview_27 = memref.subview %subview_23[0, %arg4] [1, 1] [1, 1] : memref<1x16xf32, strided<[16, 1], offset: ?>> to memref<1x1xf32, strided<[16, 1], offset: ?>>
-# CHECK-NEXT:          linalg.fill {__xtc_id_matmul_padded_0_} ins(%cst_12 : f32) outs(%subview_27 : memref<1x1xf32, strided<[16, 1], offset: ?>>)
-# CHECK-NEXT:        } {"./j"}
-# CHECK-NEXT:      } {"./i"}
-# CHECK-NEXT:      %c0_16 = arith.constant 0 : index
-# CHECK-NEXT:      %c16_17 = arith.constant 16 : index
-# CHECK-NEXT:      %c1_18 = arith.constant 1 : index
-# CHECK-NEXT:      scf.for %arg3 = %c0_16 to %c16_17 step %c1_18 {
-# CHECK-NEXT:        %subview_23 = memref.subview %alloca[%arg3, 0] [1, 16] [1, 1] : memref<16x16xf32> to memref<1x16xf32, strided<[16, 1], offset: ?>>
-# CHECK-NEXT:        %subview_24 = memref.subview %alloca_2[0, 0] [16, 16] [1, 1] : memref<16x16xf32> to memref<16x16xf32, strided<[16, 1]>>
-# CHECK-NEXT:        %subview_25 = memref.subview %alloca_11[%arg3, 0] [1, 16] [1, 1] : memref<16x16xf32> to memref<1x16xf32, strided<[16, 1], offset: ?>>
-# CHECK-NEXT:        %c0_26 = arith.constant 0 : index
-# CHECK-NEXT:        %c16_27 = arith.constant 16 : index
-# CHECK-NEXT:        %c1_28 = arith.constant 1 : index
-# CHECK-NEXT:        scf.for %arg4 = %c0_26 to %c16_27 step %c1_28 {
-# CHECK-NEXT:          %subview_29 = memref.subview %subview_23[0, 0] [1, 16] [1, 1] : memref<1x16xf32, strided<[16, 1], offset: ?>> to memref<1x16xf32, strided<[16, 1], offset: ?>>
-# CHECK-NEXT:          %subview_30 = memref.subview %subview_24[0, %arg4] [16, 1] [1, 1] : memref<16x16xf32, strided<[16, 1]>> to memref<16x1xf32, strided<[16, 1], offset: ?>>
-# CHECK-NEXT:          %subview_31 = memref.subview %subview_25[0, %arg4] [1, 1] [1, 1] : memref<1x16xf32, strided<[16, 1], offset: ?>> to memref<1x1xf32, strided<[16, 1], offset: ?>>
-# CHECK-NEXT:          %c0_32 = arith.constant 0 : index
-# CHECK-NEXT:          %c16_33 = arith.constant 16 : index
-# CHECK-NEXT:          %c1_34 = arith.constant 1 : index
-# CHECK-NEXT:          scf.for %arg5 = %c0_32 to %c16_33 step %c1_34 {
-# CHECK-NEXT:            %subview_35 = memref.subview %subview_29[0, %arg5] [1, 1] [1, 1] : memref<1x16xf32, strided<[16, 1], offset: ?>> to memref<1x1xf32, strided<[16, 1], offset: ?>>
-# CHECK-NEXT:            %subview_36 = memref.subview %subview_30[%arg5, 0] [1, 1] [1, 1] : memref<16x1xf32, strided<[16, 1], offset: ?>> to memref<1x1xf32, strided<[16, 1], offset: ?>>
-# CHECK-NEXT:            %subview_37 = memref.subview %subview_31[0, 0] [1, 1] [1, 1] : memref<1x1xf32, strided<[16, 1], offset: ?>> to memref<1x1xf32, strided<[16, 1], offset: ?>>
-# CHECK-NEXT:            linalg.matmul {__xtc_id_matmul_padded_} ins(%subview_35, %subview_36 : memref<1x1xf32, strided<[16, 1], offset: ?>>, memref<1x1xf32, strided<[16, 1], offset: ?>>) outs(%subview_37 : memref<1x1xf32, strided<[16, 1], offset: ?>>)
+# CHECK-NEXT:      %c16 = arith.constant 16 : index
+# CHECK-NEXT:      %c1_9 = arith.constant 1 : index
+# CHECK-NEXT:      scf.for %arg3 = %c0_8 to %c16 step %c1_9 {
+# CHECK-NEXT:        %subview_14 = memref.subview %alloca[%arg3, 0] [1, 16] [1, 1] : memref<16x16xf32> to memref<1x16xf32, strided<[16, 1], offset: ?>>
+# CHECK-NEXT:        %subview_15 = memref.subview %alloca_0[0, 0] [16, 16] [1, 1] : memref<16x16xf32> to memref<16x16xf32, strided<[16, 1]>>
+# CHECK-NEXT:        %subview_16 = memref.subview %alloca_6[%arg3, 0] [1, 16] [1, 1] : memref<16x16xf32> to memref<1x16xf32, strided<[16, 1], offset: ?>>
+# CHECK-NEXT:        %c0_17 = arith.constant 0 : index
+# CHECK-NEXT:        %c16_18 = arith.constant 16 : index
+# CHECK-NEXT:        %c1_19 = arith.constant 1 : index
+# CHECK-NEXT:        scf.for %arg4 = %c0_17 to %c16_18 step %c1_19 {
+# CHECK-NEXT:          %subview_20 = memref.subview %subview_14[0, 0] [1, 16] [1, 1] : memref<1x16xf32, strided<[16, 1], offset: ?>> to memref<1x16xf32, strided<[16, 1], offset: ?>>
+# CHECK-NEXT:          %subview_21 = memref.subview %subview_15[0, %arg4] [16, 1] [1, 1] : memref<16x16xf32, strided<[16, 1]>> to memref<16x1xf32, strided<[16, 1], offset: ?>>
+# CHECK-NEXT:          %subview_22 = memref.subview %subview_16[0, %arg4] [1, 1] [1, 1] : memref<1x16xf32, strided<[16, 1], offset: ?>> to memref<1x1xf32, strided<[16, 1], offset: ?>>
+# CHECK-NEXT:          %c0_23 = arith.constant 0 : index
+# CHECK-NEXT:          %c16_24 = arith.constant 16 : index
+# CHECK-NEXT:          %c1_25 = arith.constant 1 : index
+# CHECK-NEXT:          scf.for %arg5 = %c0_23 to %c16_24 step %c1_25 {
+# CHECK-NEXT:            %subview_26 = memref.subview %subview_20[0, %arg5] [1, 1] [1, 1] : memref<1x16xf32, strided<[16, 1], offset: ?>> to memref<1x1xf32, strided<[16, 1], offset: ?>>
+# CHECK-NEXT:            %subview_27 = memref.subview %subview_21[%arg5, 0] [1, 1] [1, 1] : memref<16x1xf32, strided<[16, 1], offset: ?>> to memref<1x1xf32, strided<[16, 1], offset: ?>>
+# CHECK-NEXT:            %subview_28 = memref.subview %subview_22[0, 0] [1, 1] [1, 1] : memref<1x1xf32, strided<[16, 1], offset: ?>> to memref<1x1xf32, strided<[16, 1], offset: ?>>
+# CHECK-NEXT:            linalg.matmul {__xtc_id_matmul_padded_} ins(%subview_26, %subview_27 : memref<1x1xf32, strided<[16, 1], offset: ?>>, memref<1x1xf32, strided<[16, 1], offset: ?>>) outs(%subview_28 : memref<1x1xf32, strided<[16, 1], offset: ?>>)
 # CHECK-NEXT:          } {"./k"}
 # CHECK-NEXT:        } {"./j"}
 # CHECK-NEXT:      } {"./i"}
-# CHECK-NEXT:      %subview_19 = memref.subview %alloca_11[0, 0] [14, 14] [1, 1] : memref<16x16xf32> to memref<14x14xf32, strided<[16, 1]>>
-# CHECK-NEXT:      %c0_20 = arith.constant 0 : index
-# CHECK-NEXT:      %c14_21 = arith.constant 14 : index
-# CHECK-NEXT:      %c1_22 = arith.constant 1 : index
-# CHECK-NEXT:      scf.for %arg3 = %c0_20 to %c14_21 step %c1_22 {
-# CHECK-NEXT:        %subview_23 = memref.subview %subview_19[%arg3, 0] [1, 14] [1, 1] : memref<14x14xf32, strided<[16, 1]>> to memref<1x14xf32, strided<[16, 1], offset: ?>>
-# CHECK-NEXT:        %subview_24 = memref.subview %arg2[%arg3, 0] [1, 14] [1, 1] : memref<14x14xf32> to memref<1x14xf32, strided<[14, 1], offset: ?>>
-# CHECK-NEXT:        %c0_25 = arith.constant 0 : index
-# CHECK-NEXT:        %c14_26 = arith.constant 14 : index
-# CHECK-NEXT:        %c1_27 = arith.constant 1 : index
-# CHECK-NEXT:        scf.for %arg4 = %c0_25 to %c14_26 step %c1_27 {
-# CHECK-NEXT:          %subview_28 = memref.subview %subview_23[0, %arg4] [1, 1] [1, 1] : memref<1x14xf32, strided<[16, 1], offset: ?>> to memref<1x1xf32, strided<[16, 1], offset: ?>>
-# CHECK-NEXT:          %subview_29 = memref.subview %subview_24[0, %arg4] [1, 1] [1, 1] : memref<1x14xf32, strided<[14, 1], offset: ?>> to memref<1x1xf32, strided<[14, 1], offset: ?>>
-# CHECK-NEXT:          linalg.copy {__xtc_id_C_} ins(%subview_28 : memref<1x1xf32, strided<[16, 1], offset: ?>>) outs(%subview_29 : memref<1x1xf32, strided<[14, 1], offset: ?>>)
+# CHECK-NEXT:      %subview_10 = memref.subview %alloca_6[0, 0] [14, 14] [1, 1] : memref<16x16xf32> to memref<14x14xf32, strided<[16, 1]>>
+# CHECK-NEXT:      %c0_11 = arith.constant 0 : index
+# CHECK-NEXT:      %c14_12 = arith.constant 14 : index
+# CHECK-NEXT:      %c1_13 = arith.constant 1 : index
+# CHECK-NEXT:      scf.for %arg3 = %c0_11 to %c14_12 step %c1_13 {
+# CHECK-NEXT:        %subview_14 = memref.subview %subview_10[%arg3, 0] [1, 14] [1, 1] : memref<14x14xf32, strided<[16, 1]>> to memref<1x14xf32, strided<[16, 1], offset: ?>>
+# CHECK-NEXT:        %subview_15 = memref.subview %arg2[%arg3, 0] [1, 14] [1, 1] : memref<14x14xf32> to memref<1x14xf32, strided<[14, 1], offset: ?>>
+# CHECK-NEXT:        %c0_16 = arith.constant 0 : index
+# CHECK-NEXT:        %c14_17 = arith.constant 14 : index
+# CHECK-NEXT:        %c1_18 = arith.constant 1 : index
+# CHECK-NEXT:        scf.for %arg4 = %c0_16 to %c14_17 step %c1_18 {
+# CHECK-NEXT:          %subview_19 = memref.subview %subview_14[0, %arg4] [1, 1] [1, 1] : memref<1x14xf32, strided<[16, 1], offset: ?>> to memref<1x1xf32, strided<[16, 1], offset: ?>>
+# CHECK-NEXT:          %subview_20 = memref.subview %subview_15[0, %arg4] [1, 1] [1, 1] : memref<1x14xf32, strided<[14, 1], offset: ?>> to memref<1x1xf32, strided<[14, 1], offset: ?>>
+# CHECK-NEXT:          linalg.copy {__xtc_id_C_} ins(%subview_19 : memref<1x1xf32, strided<[16, 1], offset: ?>>) outs(%subview_20 : memref<1x1xf32, strided<[14, 1], offset: ?>>)
 # CHECK-NEXT:        } {"./j"}
 # CHECK-NEXT:      } {"./i"}
 # CHECK-NEXT:      return

--- a/tests/filecheck/backends/padding/test_pad_tuple_matmul_unpad_mlir.py
+++ b/tests/filecheck/backends/padding/test_pad_tuple_matmul_unpad_mlir.py
@@ -57,43 +57,28 @@ print(f"CODE: {res}")
 # CHECK-NEXT:      transform.yield 
 # CHECK-NEXT:    }
 # CHECK-NEXT:    transform.named_sequence @__transform_main(%arg0: !transform.any_op {transform.readonly}) {
-# CHECK-NEXT:      %0 = transform.structured.match attributes {__xtc_id_A_pad_0_} in %arg0 : (!transform.any_op) -> !transform.any_op
+# CHECK-NEXT:      %0 = transform.structured.match attributes {__xtc_id_A_pad_} in %arg0 : (!transform.any_op) -> !transform.any_op
 # CHECK-NEXT:      %tiled_linalg_op, %loops = transform.structured.tile_using_for %0 tile_sizes [1, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
 # CHECK-NEXT:      transform.annotate %loops "./b" : !transform.any_op
 # CHECK-NEXT:      %tiled_linalg_op_0, %loops_1 = transform.structured.tile_using_for %tiled_linalg_op tile_sizes [0, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
 # CHECK-NEXT:      transform.annotate %loops_1 "./h" : !transform.any_op
-# CHECK-NEXT:      %1 = transform.structured.match attributes {__xtc_id_A_pad_} in %arg0 : (!transform.any_op) -> !transform.any_op
+# CHECK-NEXT:      %1 = transform.structured.match attributes {__xtc_id_B_pad_} in %arg0 : (!transform.any_op) -> !transform.any_op
 # CHECK-NEXT:      %tiled_linalg_op_2, %loops_3 = transform.structured.tile_using_for %1 tile_sizes [1, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
 # CHECK-NEXT:      transform.annotate %loops_3 "./b" : !transform.any_op
 # CHECK-NEXT:      %tiled_linalg_op_4, %loops_5 = transform.structured.tile_using_for %tiled_linalg_op_2 tile_sizes [0, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
 # CHECK-NEXT:      transform.annotate %loops_5 "./h" : !transform.any_op
-# CHECK-NEXT:      %2 = transform.structured.match attributes {__xtc_id_B_pad_0_} in %arg0 : (!transform.any_op) -> !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_6, %loops_7 = transform.structured.tile_using_for %2 tile_sizes [1, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_7 "./b" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_8, %loops_9 = transform.structured.tile_using_for %tiled_linalg_op_6 tile_sizes [0, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_9 "./h" : !transform.any_op
-# CHECK-NEXT:      %3 = transform.structured.match attributes {__xtc_id_B_pad_} in %arg0 : (!transform.any_op) -> !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_10, %loops_11 = transform.structured.tile_using_for %3 tile_sizes [1, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_11 "./b" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_12, %loops_13 = transform.structured.tile_using_for %tiled_linalg_op_10 tile_sizes [0, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_13 "./h" : !transform.any_op
-# CHECK-NEXT:      %4 = transform.structured.match attributes {__xtc_id_matmul_padded_0_} in %arg0 : (!transform.any_op) -> !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_14, %loops_15 = transform.structured.tile_using_for %4 tile_sizes [1, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_15 "./i" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_16, %loops_17 = transform.structured.tile_using_for %tiled_linalg_op_14 tile_sizes [0, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_17 "./j" : !transform.any_op
-# CHECK-NEXT:      %5 = transform.structured.match attributes {__xtc_id_matmul_padded_} in %arg0 : (!transform.any_op) -> !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_18, %loops_19 = transform.structured.tile_using_for %5 tile_sizes [1, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_19 "./i" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_20, %loops_21 = transform.structured.tile_using_for %tiled_linalg_op_18 tile_sizes [0, 1, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_21 "./j" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_22, %loops_23 = transform.structured.tile_using_for %tiled_linalg_op_20 tile_sizes [0, 0, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_23 "./k" : !transform.any_op
-# CHECK-NEXT:      %6 = transform.structured.match attributes {__xtc_id_C_} in %arg0 : (!transform.any_op) -> !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_24, %loops_25 = transform.structured.tile_using_for %6 tile_sizes [1, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_25 "./i" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_26, %loops_27 = transform.structured.tile_using_for %tiled_linalg_op_24 tile_sizes [0, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_27 "./j" : !transform.any_op
+# CHECK-NEXT:      %2 = transform.structured.match attributes {__xtc_id_matmul_padded_} in %arg0 : (!transform.any_op) -> !transform.any_op
+# CHECK-NEXT:      %tiled_linalg_op_6, %loops_7 = transform.structured.tile_using_for %2 tile_sizes [1, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      transform.annotate %loops_7 "./i" : !transform.any_op
+# CHECK-NEXT:      %tiled_linalg_op_8, %loops_9 = transform.structured.tile_using_for %tiled_linalg_op_6 tile_sizes [0, 1, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      transform.annotate %loops_9 "./j" : !transform.any_op
+# CHECK-NEXT:      %tiled_linalg_op_10, %loops_11 = transform.structured.tile_using_for %tiled_linalg_op_8 tile_sizes [0, 0, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      transform.annotate %loops_11 "./k" : !transform.any_op
+# CHECK-NEXT:      %3 = transform.structured.match attributes {__xtc_id_C_} in %arg0 : (!transform.any_op) -> !transform.any_op
+# CHECK-NEXT:      %tiled_linalg_op_12, %loops_13 = transform.structured.tile_using_for %3 tile_sizes [1, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      transform.annotate %loops_13 "./i" : !transform.any_op
+# CHECK-NEXT:      %tiled_linalg_op_14, %loops_15 = transform.structured.tile_using_for %tiled_linalg_op_12 tile_sizes [0, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      transform.annotate %loops_15 "./j" : !transform.any_op
 # CHECK-NEXT:      transform.yield 
 # CHECK-NEXT:    }
 # CHECK-NEXT:  }
@@ -103,120 +88,84 @@ print(f"CODE: {res}")
 # CHECK-NEXT:    func.func @pad_matmul_unpad(%arg0: memref<14x14xf32> {llvm.noalias}, %arg1: memref<14x14xf32> {llvm.noalias}, %arg2: memref<14x14xf32> {llvm.noalias}) {
 # CHECK-NEXT:      %alloca = memref.alloca() {alignment = 256 : i64} : memref<16x16xf32>
 # CHECK-NEXT:      %cst = arith.constant 0.000000e+00 : f32
-# CHECK-NEXT:      %c0 = arith.constant 0 : index
-# CHECK-NEXT:      %c16 = arith.constant 16 : index
-# CHECK-NEXT:      %c1 = arith.constant 1 : index
-# CHECK-NEXT:      scf.for %arg3 = %c0 to %c16 step %c1 {
-# CHECK-NEXT:        %subview_23 = memref.subview %alloca[%arg3, 0] [1, 16] [1, 1] : memref<16x16xf32> to memref<1x16xf32, strided<[16, 1], offset: ?>>
-# CHECK-NEXT:        %c0_24 = arith.constant 0 : index
-# CHECK-NEXT:        %c16_25 = arith.constant 16 : index
-# CHECK-NEXT:        %c1_26 = arith.constant 1 : index
-# CHECK-NEXT:        scf.for %arg4 = %c0_24 to %c16_25 step %c1_26 {
-# CHECK-NEXT:          %subview_27 = memref.subview %subview_23[0, %arg4] [1, 1] [1, 1] : memref<1x16xf32, strided<[16, 1], offset: ?>> to memref<1x1xf32, strided<[16, 1], offset: ?>>
-# CHECK-NEXT:          linalg.fill {__xtc_id_A_pad_0_} ins(%cst : f32) outs(%subview_27 : memref<1x1xf32, strided<[16, 1], offset: ?>>)
-# CHECK-NEXT:        } {"./h"}
-# CHECK-NEXT:      } {"./b"}
+# CHECK-NEXT:      linalg.fill {__xtc_id_A_pad_0_} ins(%cst : f32) outs(%alloca : memref<16x16xf32>)
 # CHECK-NEXT:      %subview = memref.subview %alloca[0, 0] [14, 14] [1, 1] : memref<16x16xf32> to memref<14x14xf32, strided<[16, 1]>>
-# CHECK-NEXT:      %c0_0 = arith.constant 0 : index
+# CHECK-NEXT:      %c0 = arith.constant 0 : index
 # CHECK-NEXT:      %c14 = arith.constant 14 : index
-# CHECK-NEXT:      %c1_1 = arith.constant 1 : index
-# CHECK-NEXT:      scf.for %arg3 = %c0_0 to %c14 step %c1_1 {
-# CHECK-NEXT:        %subview_23 = memref.subview %arg0[%arg3, 0] [1, 14] [1, 1] : memref<14x14xf32> to memref<1x14xf32, strided<[14, 1], offset: ?>>
-# CHECK-NEXT:        %subview_24 = memref.subview %subview[%arg3, 0] [1, 14] [1, 1] : memref<14x14xf32, strided<[16, 1]>> to memref<1x14xf32, strided<[16, 1], offset: ?>>
-# CHECK-NEXT:        %c0_25 = arith.constant 0 : index
-# CHECK-NEXT:        %c14_26 = arith.constant 14 : index
-# CHECK-NEXT:        %c1_27 = arith.constant 1 : index
-# CHECK-NEXT:        scf.for %arg4 = %c0_25 to %c14_26 step %c1_27 {
-# CHECK-NEXT:          %subview_28 = memref.subview %subview_23[0, %arg4] [1, 1] [1, 1] : memref<1x14xf32, strided<[14, 1], offset: ?>> to memref<1x1xf32, strided<[14, 1], offset: ?>>
-# CHECK-NEXT:          %subview_29 = memref.subview %subview_24[0, %arg4] [1, 1] [1, 1] : memref<1x14xf32, strided<[16, 1], offset: ?>> to memref<1x1xf32, strided<[16, 1], offset: ?>>
-# CHECK-NEXT:          linalg.copy {__xtc_id_A_pad_} ins(%subview_28 : memref<1x1xf32, strided<[14, 1], offset: ?>>) outs(%subview_29 : memref<1x1xf32, strided<[16, 1], offset: ?>>)
+# CHECK-NEXT:      %c1 = arith.constant 1 : index
+# CHECK-NEXT:      scf.for %arg3 = %c0 to %c14 step %c1 {
+# CHECK-NEXT:        %subview_14 = memref.subview %arg0[%arg3, 0] [1, 14] [1, 1] : memref<14x14xf32> to memref<1x14xf32, strided<[14, 1], offset: ?>>
+# CHECK-NEXT:        %subview_15 = memref.subview %subview[%arg3, 0] [1, 14] [1, 1] : memref<14x14xf32, strided<[16, 1]>> to memref<1x14xf32, strided<[16, 1], offset: ?>>
+# CHECK-NEXT:        %c0_16 = arith.constant 0 : index
+# CHECK-NEXT:        %c14_17 = arith.constant 14 : index
+# CHECK-NEXT:        %c1_18 = arith.constant 1 : index
+# CHECK-NEXT:        scf.for %arg4 = %c0_16 to %c14_17 step %c1_18 {
+# CHECK-NEXT:          %subview_19 = memref.subview %subview_14[0, %arg4] [1, 1] [1, 1] : memref<1x14xf32, strided<[14, 1], offset: ?>> to memref<1x1xf32, strided<[14, 1], offset: ?>>
+# CHECK-NEXT:          %subview_20 = memref.subview %subview_15[0, %arg4] [1, 1] [1, 1] : memref<1x14xf32, strided<[16, 1], offset: ?>> to memref<1x1xf32, strided<[16, 1], offset: ?>>
+# CHECK-NEXT:          linalg.copy {__xtc_id_A_pad_} ins(%subview_19 : memref<1x1xf32, strided<[14, 1], offset: ?>>) outs(%subview_20 : memref<1x1xf32, strided<[16, 1], offset: ?>>)
 # CHECK-NEXT:        } {"./h"}
 # CHECK-NEXT:      } {"./b"}
-# CHECK-NEXT:      %alloca_2 = memref.alloca() {alignment = 256 : i64} : memref<16x16xf32>
-# CHECK-NEXT:      %cst_3 = arith.constant 0.000000e+00 : f32
-# CHECK-NEXT:      %c0_4 = arith.constant 0 : index
-# CHECK-NEXT:      %c16_5 = arith.constant 16 : index
-# CHECK-NEXT:      %c1_6 = arith.constant 1 : index
-# CHECK-NEXT:      scf.for %arg3 = %c0_4 to %c16_5 step %c1_6 {
-# CHECK-NEXT:        %subview_23 = memref.subview %alloca_2[%arg3, 0] [1, 16] [1, 1] : memref<16x16xf32> to memref<1x16xf32, strided<[16, 1], offset: ?>>
-# CHECK-NEXT:        %c0_24 = arith.constant 0 : index
-# CHECK-NEXT:        %c16_25 = arith.constant 16 : index
-# CHECK-NEXT:        %c1_26 = arith.constant 1 : index
-# CHECK-NEXT:        scf.for %arg4 = %c0_24 to %c16_25 step %c1_26 {
-# CHECK-NEXT:          %subview_27 = memref.subview %subview_23[0, %arg4] [1, 1] [1, 1] : memref<1x16xf32, strided<[16, 1], offset: ?>> to memref<1x1xf32, strided<[16, 1], offset: ?>>
-# CHECK-NEXT:          linalg.fill {__xtc_id_B_pad_0_} ins(%cst_3 : f32) outs(%subview_27 : memref<1x1xf32, strided<[16, 1], offset: ?>>)
+# CHECK-NEXT:      %alloca_0 = memref.alloca() {alignment = 256 : i64} : memref<16x16xf32>
+# CHECK-NEXT:      %cst_1 = arith.constant 0.000000e+00 : f32
+# CHECK-NEXT:      linalg.fill {__xtc_id_B_pad_0_} ins(%cst_1 : f32) outs(%alloca_0 : memref<16x16xf32>)
+# CHECK-NEXT:      %subview_2 = memref.subview %alloca_0[0, 0] [14, 14] [1, 1] : memref<16x16xf32> to memref<14x14xf32, strided<[16, 1]>>
+# CHECK-NEXT:      %c0_3 = arith.constant 0 : index
+# CHECK-NEXT:      %c14_4 = arith.constant 14 : index
+# CHECK-NEXT:      %c1_5 = arith.constant 1 : index
+# CHECK-NEXT:      scf.for %arg3 = %c0_3 to %c14_4 step %c1_5 {
+# CHECK-NEXT:        %subview_14 = memref.subview %arg1[%arg3, 0] [1, 14] [1, 1] : memref<14x14xf32> to memref<1x14xf32, strided<[14, 1], offset: ?>>
+# CHECK-NEXT:        %subview_15 = memref.subview %subview_2[%arg3, 0] [1, 14] [1, 1] : memref<14x14xf32, strided<[16, 1]>> to memref<1x14xf32, strided<[16, 1], offset: ?>>
+# CHECK-NEXT:        %c0_16 = arith.constant 0 : index
+# CHECK-NEXT:        %c14_17 = arith.constant 14 : index
+# CHECK-NEXT:        %c1_18 = arith.constant 1 : index
+# CHECK-NEXT:        scf.for %arg4 = %c0_16 to %c14_17 step %c1_18 {
+# CHECK-NEXT:          %subview_19 = memref.subview %subview_14[0, %arg4] [1, 1] [1, 1] : memref<1x14xf32, strided<[14, 1], offset: ?>> to memref<1x1xf32, strided<[14, 1], offset: ?>>
+# CHECK-NEXT:          %subview_20 = memref.subview %subview_15[0, %arg4] [1, 1] [1, 1] : memref<1x14xf32, strided<[16, 1], offset: ?>> to memref<1x1xf32, strided<[16, 1], offset: ?>>
+# CHECK-NEXT:          linalg.copy {__xtc_id_B_pad_} ins(%subview_19 : memref<1x1xf32, strided<[14, 1], offset: ?>>) outs(%subview_20 : memref<1x1xf32, strided<[16, 1], offset: ?>>)
 # CHECK-NEXT:        } {"./h"}
 # CHECK-NEXT:      } {"./b"}
-# CHECK-NEXT:      %subview_7 = memref.subview %alloca_2[0, 0] [14, 14] [1, 1] : memref<16x16xf32> to memref<14x14xf32, strided<[16, 1]>>
+# CHECK-NEXT:      %alloca_6 = memref.alloca() {alignment = 256 : i64} : memref<16x16xf32>
+# CHECK-NEXT:      %cst_7 = arith.constant 0.000000e+00 : f32
+# CHECK-NEXT:      linalg.fill {__xtc_id_matmul_padded_0_} ins(%cst_7 : f32) outs(%alloca_6 : memref<16x16xf32>)
 # CHECK-NEXT:      %c0_8 = arith.constant 0 : index
-# CHECK-NEXT:      %c14_9 = arith.constant 14 : index
-# CHECK-NEXT:      %c1_10 = arith.constant 1 : index
-# CHECK-NEXT:      scf.for %arg3 = %c0_8 to %c14_9 step %c1_10 {
-# CHECK-NEXT:        %subview_23 = memref.subview %arg1[%arg3, 0] [1, 14] [1, 1] : memref<14x14xf32> to memref<1x14xf32, strided<[14, 1], offset: ?>>
-# CHECK-NEXT:        %subview_24 = memref.subview %subview_7[%arg3, 0] [1, 14] [1, 1] : memref<14x14xf32, strided<[16, 1]>> to memref<1x14xf32, strided<[16, 1], offset: ?>>
-# CHECK-NEXT:        %c0_25 = arith.constant 0 : index
-# CHECK-NEXT:        %c14_26 = arith.constant 14 : index
-# CHECK-NEXT:        %c1_27 = arith.constant 1 : index
-# CHECK-NEXT:        scf.for %arg4 = %c0_25 to %c14_26 step %c1_27 {
-# CHECK-NEXT:          %subview_28 = memref.subview %subview_23[0, %arg4] [1, 1] [1, 1] : memref<1x14xf32, strided<[14, 1], offset: ?>> to memref<1x1xf32, strided<[14, 1], offset: ?>>
-# CHECK-NEXT:          %subview_29 = memref.subview %subview_24[0, %arg4] [1, 1] [1, 1] : memref<1x14xf32, strided<[16, 1], offset: ?>> to memref<1x1xf32, strided<[16, 1], offset: ?>>
-# CHECK-NEXT:          linalg.copy {__xtc_id_B_pad_} ins(%subview_28 : memref<1x1xf32, strided<[14, 1], offset: ?>>) outs(%subview_29 : memref<1x1xf32, strided<[16, 1], offset: ?>>)
-# CHECK-NEXT:        } {"./h"}
-# CHECK-NEXT:      } {"./b"}
-# CHECK-NEXT:      %alloca_11 = memref.alloca() {alignment = 256 : i64} : memref<16x16xf32>
-# CHECK-NEXT:      %cst_12 = arith.constant 0.000000e+00 : f32
-# CHECK-NEXT:      %c0_13 = arith.constant 0 : index
-# CHECK-NEXT:      %c16_14 = arith.constant 16 : index
-# CHECK-NEXT:      %c1_15 = arith.constant 1 : index
-# CHECK-NEXT:      scf.for %arg3 = %c0_13 to %c16_14 step %c1_15 {
-# CHECK-NEXT:        %subview_23 = memref.subview %alloca_11[%arg3, 0] [1, 16] [1, 1] : memref<16x16xf32> to memref<1x16xf32, strided<[16, 1], offset: ?>>
-# CHECK-NEXT:        %c0_24 = arith.constant 0 : index
-# CHECK-NEXT:        %c16_25 = arith.constant 16 : index
-# CHECK-NEXT:        %c1_26 = arith.constant 1 : index
-# CHECK-NEXT:        scf.for %arg4 = %c0_24 to %c16_25 step %c1_26 {
-# CHECK-NEXT:          %subview_27 = memref.subview %subview_23[0, %arg4] [1, 1] [1, 1] : memref<1x16xf32, strided<[16, 1], offset: ?>> to memref<1x1xf32, strided<[16, 1], offset: ?>>
-# CHECK-NEXT:          linalg.fill {__xtc_id_matmul_padded_0_} ins(%cst_12 : f32) outs(%subview_27 : memref<1x1xf32, strided<[16, 1], offset: ?>>)
-# CHECK-NEXT:        } {"./j"}
-# CHECK-NEXT:      } {"./i"}
-# CHECK-NEXT:      %c0_16 = arith.constant 0 : index
-# CHECK-NEXT:      %c16_17 = arith.constant 16 : index
-# CHECK-NEXT:      %c1_18 = arith.constant 1 : index
-# CHECK-NEXT:      scf.for %arg3 = %c0_16 to %c16_17 step %c1_18 {
-# CHECK-NEXT:        %subview_23 = memref.subview %alloca[%arg3, 0] [1, 16] [1, 1] : memref<16x16xf32> to memref<1x16xf32, strided<[16, 1], offset: ?>>
-# CHECK-NEXT:        %subview_24 = memref.subview %alloca_2[0, 0] [16, 16] [1, 1] : memref<16x16xf32> to memref<16x16xf32, strided<[16, 1]>>
-# CHECK-NEXT:        %subview_25 = memref.subview %alloca_11[%arg3, 0] [1, 16] [1, 1] : memref<16x16xf32> to memref<1x16xf32, strided<[16, 1], offset: ?>>
-# CHECK-NEXT:        %c0_26 = arith.constant 0 : index
-# CHECK-NEXT:        %c16_27 = arith.constant 16 : index
-# CHECK-NEXT:        %c1_28 = arith.constant 1 : index
-# CHECK-NEXT:        scf.for %arg4 = %c0_26 to %c16_27 step %c1_28 {
-# CHECK-NEXT:          %subview_29 = memref.subview %subview_23[0, 0] [1, 16] [1, 1] : memref<1x16xf32, strided<[16, 1], offset: ?>> to memref<1x16xf32, strided<[16, 1], offset: ?>>
-# CHECK-NEXT:          %subview_30 = memref.subview %subview_24[0, %arg4] [16, 1] [1, 1] : memref<16x16xf32, strided<[16, 1]>> to memref<16x1xf32, strided<[16, 1], offset: ?>>
-# CHECK-NEXT:          %subview_31 = memref.subview %subview_25[0, %arg4] [1, 1] [1, 1] : memref<1x16xf32, strided<[16, 1], offset: ?>> to memref<1x1xf32, strided<[16, 1], offset: ?>>
-# CHECK-NEXT:          %c0_32 = arith.constant 0 : index
-# CHECK-NEXT:          %c16_33 = arith.constant 16 : index
-# CHECK-NEXT:          %c1_34 = arith.constant 1 : index
-# CHECK-NEXT:          scf.for %arg5 = %c0_32 to %c16_33 step %c1_34 {
-# CHECK-NEXT:            %subview_35 = memref.subview %subview_29[0, %arg5] [1, 1] [1, 1] : memref<1x16xf32, strided<[16, 1], offset: ?>> to memref<1x1xf32, strided<[16, 1], offset: ?>>
-# CHECK-NEXT:            %subview_36 = memref.subview %subview_30[%arg5, 0] [1, 1] [1, 1] : memref<16x1xf32, strided<[16, 1], offset: ?>> to memref<1x1xf32, strided<[16, 1], offset: ?>>
-# CHECK-NEXT:            %subview_37 = memref.subview %subview_31[0, 0] [1, 1] [1, 1] : memref<1x1xf32, strided<[16, 1], offset: ?>> to memref<1x1xf32, strided<[16, 1], offset: ?>>
-# CHECK-NEXT:            linalg.matmul {__xtc_id_matmul_padded_} ins(%subview_35, %subview_36 : memref<1x1xf32, strided<[16, 1], offset: ?>>, memref<1x1xf32, strided<[16, 1], offset: ?>>) outs(%subview_37 : memref<1x1xf32, strided<[16, 1], offset: ?>>)
+# CHECK-NEXT:      %c16 = arith.constant 16 : index
+# CHECK-NEXT:      %c1_9 = arith.constant 1 : index
+# CHECK-NEXT:      scf.for %arg3 = %c0_8 to %c16 step %c1_9 {
+# CHECK-NEXT:        %subview_14 = memref.subview %alloca[%arg3, 0] [1, 16] [1, 1] : memref<16x16xf32> to memref<1x16xf32, strided<[16, 1], offset: ?>>
+# CHECK-NEXT:        %subview_15 = memref.subview %alloca_0[0, 0] [16, 16] [1, 1] : memref<16x16xf32> to memref<16x16xf32, strided<[16, 1]>>
+# CHECK-NEXT:        %subview_16 = memref.subview %alloca_6[%arg3, 0] [1, 16] [1, 1] : memref<16x16xf32> to memref<1x16xf32, strided<[16, 1], offset: ?>>
+# CHECK-NEXT:        %c0_17 = arith.constant 0 : index
+# CHECK-NEXT:        %c16_18 = arith.constant 16 : index
+# CHECK-NEXT:        %c1_19 = arith.constant 1 : index
+# CHECK-NEXT:        scf.for %arg4 = %c0_17 to %c16_18 step %c1_19 {
+# CHECK-NEXT:          %subview_20 = memref.subview %subview_14[0, 0] [1, 16] [1, 1] : memref<1x16xf32, strided<[16, 1], offset: ?>> to memref<1x16xf32, strided<[16, 1], offset: ?>>
+# CHECK-NEXT:          %subview_21 = memref.subview %subview_15[0, %arg4] [16, 1] [1, 1] : memref<16x16xf32, strided<[16, 1]>> to memref<16x1xf32, strided<[16, 1], offset: ?>>
+# CHECK-NEXT:          %subview_22 = memref.subview %subview_16[0, %arg4] [1, 1] [1, 1] : memref<1x16xf32, strided<[16, 1], offset: ?>> to memref<1x1xf32, strided<[16, 1], offset: ?>>
+# CHECK-NEXT:          %c0_23 = arith.constant 0 : index
+# CHECK-NEXT:          %c16_24 = arith.constant 16 : index
+# CHECK-NEXT:          %c1_25 = arith.constant 1 : index
+# CHECK-NEXT:          scf.for %arg5 = %c0_23 to %c16_24 step %c1_25 {
+# CHECK-NEXT:            %subview_26 = memref.subview %subview_20[0, %arg5] [1, 1] [1, 1] : memref<1x16xf32, strided<[16, 1], offset: ?>> to memref<1x1xf32, strided<[16, 1], offset: ?>>
+# CHECK-NEXT:            %subview_27 = memref.subview %subview_21[%arg5, 0] [1, 1] [1, 1] : memref<16x1xf32, strided<[16, 1], offset: ?>> to memref<1x1xf32, strided<[16, 1], offset: ?>>
+# CHECK-NEXT:            %subview_28 = memref.subview %subview_22[0, 0] [1, 1] [1, 1] : memref<1x1xf32, strided<[16, 1], offset: ?>> to memref<1x1xf32, strided<[16, 1], offset: ?>>
+# CHECK-NEXT:            linalg.matmul {__xtc_id_matmul_padded_} ins(%subview_26, %subview_27 : memref<1x1xf32, strided<[16, 1], offset: ?>>, memref<1x1xf32, strided<[16, 1], offset: ?>>) outs(%subview_28 : memref<1x1xf32, strided<[16, 1], offset: ?>>)
 # CHECK-NEXT:          } {"./k"}
 # CHECK-NEXT:        } {"./j"}
 # CHECK-NEXT:      } {"./i"}
-# CHECK-NEXT:      %subview_19 = memref.subview %alloca_11[0, 0] [14, 14] [1, 1] : memref<16x16xf32> to memref<14x14xf32, strided<[16, 1]>>
-# CHECK-NEXT:      %c0_20 = arith.constant 0 : index
-# CHECK-NEXT:      %c14_21 = arith.constant 14 : index
-# CHECK-NEXT:      %c1_22 = arith.constant 1 : index
-# CHECK-NEXT:      scf.for %arg3 = %c0_20 to %c14_21 step %c1_22 {
-# CHECK-NEXT:        %subview_23 = memref.subview %subview_19[%arg3, 0] [1, 14] [1, 1] : memref<14x14xf32, strided<[16, 1]>> to memref<1x14xf32, strided<[16, 1], offset: ?>>
-# CHECK-NEXT:        %subview_24 = memref.subview %arg2[%arg3, 0] [1, 14] [1, 1] : memref<14x14xf32> to memref<1x14xf32, strided<[14, 1], offset: ?>>
-# CHECK-NEXT:        %c0_25 = arith.constant 0 : index
-# CHECK-NEXT:        %c14_26 = arith.constant 14 : index
-# CHECK-NEXT:        %c1_27 = arith.constant 1 : index
-# CHECK-NEXT:        scf.for %arg4 = %c0_25 to %c14_26 step %c1_27 {
-# CHECK-NEXT:          %subview_28 = memref.subview %subview_23[0, %arg4] [1, 1] [1, 1] : memref<1x14xf32, strided<[16, 1], offset: ?>> to memref<1x1xf32, strided<[16, 1], offset: ?>>
-# CHECK-NEXT:          %subview_29 = memref.subview %subview_24[0, %arg4] [1, 1] [1, 1] : memref<1x14xf32, strided<[14, 1], offset: ?>> to memref<1x1xf32, strided<[14, 1], offset: ?>>
-# CHECK-NEXT:          linalg.copy {__xtc_id_C_} ins(%subview_28 : memref<1x1xf32, strided<[16, 1], offset: ?>>) outs(%subview_29 : memref<1x1xf32, strided<[14, 1], offset: ?>>)
+# CHECK-NEXT:      %subview_10 = memref.subview %alloca_6[0, 0] [14, 14] [1, 1] : memref<16x16xf32> to memref<14x14xf32, strided<[16, 1]>>
+# CHECK-NEXT:      %c0_11 = arith.constant 0 : index
+# CHECK-NEXT:      %c14_12 = arith.constant 14 : index
+# CHECK-NEXT:      %c1_13 = arith.constant 1 : index
+# CHECK-NEXT:      scf.for %arg3 = %c0_11 to %c14_12 step %c1_13 {
+# CHECK-NEXT:        %subview_14 = memref.subview %subview_10[%arg3, 0] [1, 14] [1, 1] : memref<14x14xf32, strided<[16, 1]>> to memref<1x14xf32, strided<[16, 1], offset: ?>>
+# CHECK-NEXT:        %subview_15 = memref.subview %arg2[%arg3, 0] [1, 14] [1, 1] : memref<14x14xf32> to memref<1x14xf32, strided<[14, 1], offset: ?>>
+# CHECK-NEXT:        %c0_16 = arith.constant 0 : index
+# CHECK-NEXT:        %c14_17 = arith.constant 14 : index
+# CHECK-NEXT:        %c1_18 = arith.constant 1 : index
+# CHECK-NEXT:        scf.for %arg4 = %c0_16 to %c14_17 step %c1_18 {
+# CHECK-NEXT:          %subview_19 = memref.subview %subview_14[0, %arg4] [1, 1] [1, 1] : memref<1x14xf32, strided<[16, 1], offset: ?>> to memref<1x1xf32, strided<[16, 1], offset: ?>>
+# CHECK-NEXT:          %subview_20 = memref.subview %subview_15[0, %arg4] [1, 1] [1, 1] : memref<1x14xf32, strided<[14, 1], offset: ?>> to memref<1x1xf32, strided<[14, 1], offset: ?>>
+# CHECK-NEXT:          linalg.copy {__xtc_id_C_} ins(%subview_19 : memref<1x1xf32, strided<[16, 1], offset: ?>>) outs(%subview_20 : memref<1x1xf32, strided<[14, 1], offset: ?>>)
 # CHECK-NEXT:        } {"./j"}
 # CHECK-NEXT:      } {"./i"}
 # CHECK-NEXT:      return

--- a/tests/filecheck/backends/tensor_dialect/test_conv2d_mini_mlir_tensor.py
+++ b/tests/filecheck/backends/tensor_dialect/test_conv2d_mini_mlir_tensor.py
@@ -58,30 +58,21 @@ print(f"CODE: {res}")
 # CHECK-NEXT:      transform.yield 
 # CHECK-NEXT:    }
 # CHECK-NEXT:    transform.named_sequence @__transform_main(%arg0: !transform.any_op {transform.readonly}) {
-# CHECK-NEXT:      %0 = transform.structured.match attributes {__xtc_id_O_0_} in %arg0 : (!transform.any_op) -> !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op, %loops = transform.structured.tile_using_for %0 tile_sizes [1, 0, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      %0 = transform.structured.match attributes {__xtc_id_O_} in %arg0 : (!transform.any_op) -> !transform.any_op
+# CHECK-NEXT:      %tiled_linalg_op, %loops = transform.structured.tile_using_for %0 tile_sizes [1, 0, 0, 0, 0, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
 # CHECK-NEXT:      transform.annotate %loops "./b" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_0, %loops_1 = transform.structured.tile_using_for %tiled_linalg_op tile_sizes [0, 1, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      %tiled_linalg_op_0, %loops_1 = transform.structured.tile_using_for %tiled_linalg_op tile_sizes [0, 1, 0, 0, 0, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
 # CHECK-NEXT:      transform.annotate %loops_1 "./h" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_2, %loops_3 = transform.structured.tile_using_for %tiled_linalg_op_0 tile_sizes [0, 0, 1, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      %tiled_linalg_op_2, %loops_3 = transform.structured.tile_using_for %tiled_linalg_op_0 tile_sizes [0, 0, 1, 0, 0, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
 # CHECK-NEXT:      transform.annotate %loops_3 "./w" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_4, %loops_5 = transform.structured.tile_using_for %tiled_linalg_op_2 tile_sizes [0, 0, 0, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      %tiled_linalg_op_4, %loops_5 = transform.structured.tile_using_for %tiled_linalg_op_2 tile_sizes [0, 0, 0, 1, 0, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
 # CHECK-NEXT:      transform.annotate %loops_5 "./f" : !transform.any_op
-# CHECK-NEXT:      %1 = transform.structured.match attributes {__xtc_id_O_} in %arg0 : (!transform.any_op) -> !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_6, %loops_7 = transform.structured.tile_using_for %1 tile_sizes [1, 0, 0, 0, 0, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_7 "./b" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_8, %loops_9 = transform.structured.tile_using_for %tiled_linalg_op_6 tile_sizes [0, 1, 0, 0, 0, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_9 "./h" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_10, %loops_11 = transform.structured.tile_using_for %tiled_linalg_op_8 tile_sizes [0, 0, 1, 0, 0, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_11 "./w" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_12, %loops_13 = transform.structured.tile_using_for %tiled_linalg_op_10 tile_sizes [0, 0, 0, 1, 0, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_13 "./f" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_14, %loops_15 = transform.structured.tile_using_for %tiled_linalg_op_12 tile_sizes [0, 0, 0, 0, 1, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_15 "./r" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_16, %loops_17 = transform.structured.tile_using_for %tiled_linalg_op_14 tile_sizes [0, 0, 0, 0, 0, 1, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_17 "./s" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_18, %loops_19 = transform.structured.tile_using_for %tiled_linalg_op_16 tile_sizes [0, 0, 0, 0, 0, 0, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_19 "./c" : !transform.any_op
+# CHECK-NEXT:      %tiled_linalg_op_6, %loops_7 = transform.structured.tile_using_for %tiled_linalg_op_4 tile_sizes [0, 0, 0, 0, 1, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      transform.annotate %loops_7 "./r" : !transform.any_op
+# CHECK-NEXT:      %tiled_linalg_op_8, %loops_9 = transform.structured.tile_using_for %tiled_linalg_op_6 tile_sizes [0, 0, 0, 0, 0, 1, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      transform.annotate %loops_9 "./s" : !transform.any_op
+# CHECK-NEXT:      %tiled_linalg_op_10, %loops_11 = transform.structured.tile_using_for %tiled_linalg_op_8 tile_sizes [0, 0, 0, 0, 0, 0, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      transform.annotate %loops_11 "./c" : !transform.any_op
 # CHECK-NEXT:      transform.yield 
 # CHECK-NEXT:    }
 # CHECK-NEXT:  }
@@ -94,111 +85,79 @@ print(f"CODE: {res}")
 # CHECK-NEXT:    func.func @conv2d_nhwc_mini(%arg0: tensor<1x10x10x3xf32> {llvm.noalias}, %arg1: tensor<3x3x3x16xf32> {llvm.noalias}, %arg2: memref<1x8x8x16xf32> {llvm.noalias}) {
 # CHECK-NEXT:      %0 = tensor.empty() : tensor<1x8x8x16xf32>
 # CHECK-NEXT:      %cst = arith.constant 0.000000e+00 : f32
+# CHECK-NEXT:      %1 = linalg.fill {__xtc_id_O_0_} ins(%cst : f32) outs(%0 : tensor<1x8x8x16xf32>) -> tensor<1x8x8x16xf32>
 # CHECK-NEXT:      %c0 = arith.constant 0 : index
 # CHECK-NEXT:      %c1 = arith.constant 1 : index
 # CHECK-NEXT:      %c1_0 = arith.constant 1 : index
-# CHECK-NEXT:      %1 = scf.for %arg3 = %c0 to %c1 step %c1_0 iter_args(%arg4 = %0) -> (tensor<1x8x8x16xf32>) {
-# CHECK-NEXT:        %extracted_slice = tensor.extract_slice %arg4[%arg3, 0, 0, 0] [1, 8, 8, 16] [1, 1, 1, 1] : tensor<1x8x8x16xf32> to tensor<1x8x8x16xf32>
-# CHECK-NEXT:        %c0_4 = arith.constant 0 : index
-# CHECK-NEXT:        %c8 = arith.constant 8 : index
-# CHECK-NEXT:        %c1_5 = arith.constant 1 : index
-# CHECK-NEXT:        %3 = scf.for %arg5 = %c0_4 to %c8 step %c1_5 iter_args(%arg6 = %extracted_slice) -> (tensor<1x8x8x16xf32>) {
-# CHECK-NEXT:          %extracted_slice_6 = tensor.extract_slice %arg6[0, %arg5, 0, 0] [1, 1, 8, 16] [1, 1, 1, 1] : tensor<1x8x8x16xf32> to tensor<1x1x8x16xf32>
-# CHECK-NEXT:          %c0_7 = arith.constant 0 : index
-# CHECK-NEXT:          %c8_8 = arith.constant 8 : index
-# CHECK-NEXT:          %c1_9 = arith.constant 1 : index
-# CHECK-NEXT:          %4 = scf.for %arg7 = %c0_7 to %c8_8 step %c1_9 iter_args(%arg8 = %extracted_slice_6) -> (tensor<1x1x8x16xf32>) {
-# CHECK-NEXT:            %extracted_slice_11 = tensor.extract_slice %arg8[0, 0, %arg7, 0] [1, 1, 1, 16] [1, 1, 1, 1] : tensor<1x1x8x16xf32> to tensor<1x1x1x16xf32>
-# CHECK-NEXT:            %c0_12 = arith.constant 0 : index
-# CHECK-NEXT:            %c16 = arith.constant 16 : index
-# CHECK-NEXT:            %c1_13 = arith.constant 1 : index
-# CHECK-NEXT:            %5 = scf.for %arg9 = %c0_12 to %c16 step %c1_13 iter_args(%arg10 = %extracted_slice_11) -> (tensor<1x1x1x16xf32>) {
-# CHECK-NEXT:              %extracted_slice_15 = tensor.extract_slice %arg10[0, 0, 0, %arg9] [1, 1, 1, 1] [1, 1, 1, 1] : tensor<1x1x1x16xf32> to tensor<1x1x1x1xf32>
-# CHECK-NEXT:              %6 = linalg.fill {__xtc_id_O_0_} ins(%cst : f32) outs(%extracted_slice_15 : tensor<1x1x1x1xf32>) -> tensor<1x1x1x1xf32>
-# CHECK-NEXT:              %inserted_slice_16 = tensor.insert_slice %6 into %arg10[0, 0, 0, %arg9] [1, 1, 1, 1] [1, 1, 1, 1] : tensor<1x1x1x1xf32> into tensor<1x1x1x16xf32>
-# CHECK-NEXT:              scf.yield %inserted_slice_16 : tensor<1x1x1x16xf32>
-# CHECK-NEXT:            } {"./f"}
-# CHECK-NEXT:            %inserted_slice_14 = tensor.insert_slice %5 into %arg8[0, 0, %arg7, 0] [1, 1, 1, 16] [1, 1, 1, 1] : tensor<1x1x1x16xf32> into tensor<1x1x8x16xf32>
-# CHECK-NEXT:            scf.yield %inserted_slice_14 : tensor<1x1x8x16xf32>
-# CHECK-NEXT:          } {"./w"}
-# CHECK-NEXT:          %inserted_slice_10 = tensor.insert_slice %4 into %arg6[0, %arg5, 0, 0] [1, 1, 8, 16] [1, 1, 1, 1] : tensor<1x1x8x16xf32> into tensor<1x8x8x16xf32>
-# CHECK-NEXT:          scf.yield %inserted_slice_10 : tensor<1x8x8x16xf32>
-# CHECK-NEXT:        } {"./h"}
-# CHECK-NEXT:        %inserted_slice = tensor.insert_slice %3 into %arg4[%arg3, 0, 0, 0] [1, 8, 8, 16] [1, 1, 1, 1] : tensor<1x8x8x16xf32> into tensor<1x8x8x16xf32>
-# CHECK-NEXT:        scf.yield %inserted_slice : tensor<1x8x8x16xf32>
-# CHECK-NEXT:      } {"./b"}
-# CHECK-NEXT:      %c0_1 = arith.constant 0 : index
-# CHECK-NEXT:      %c1_2 = arith.constant 1 : index
-# CHECK-NEXT:      %c1_3 = arith.constant 1 : index
-# CHECK-NEXT:      %2 = scf.for %arg3 = %c0_1 to %c1_2 step %c1_3 iter_args(%arg4 = %1) -> (tensor<1x8x8x16xf32>) {
+# CHECK-NEXT:      %2 = scf.for %arg3 = %c0 to %c1 step %c1_0 iter_args(%arg4 = %1) -> (tensor<1x8x8x16xf32>) {
 # CHECK-NEXT:        %extracted_slice = tensor.extract_slice %arg0[%arg3, 0, 0, 0] [1, 10, 10, 3] [1, 1, 1, 1] : tensor<1x10x10x3xf32> to tensor<1x10x10x3xf32>
-# CHECK-NEXT:        %extracted_slice_4 = tensor.extract_slice %arg1[0, 0, 0, 0] [3, 3, 3, 16] [1, 1, 1, 1] : tensor<3x3x3x16xf32> to tensor<3x3x3x16xf32>
-# CHECK-NEXT:        %extracted_slice_5 = tensor.extract_slice %arg4[%arg3, 0, 0, 0] [1, 8, 8, 16] [1, 1, 1, 1] : tensor<1x8x8x16xf32> to tensor<1x8x8x16xf32>
-# CHECK-NEXT:        %c0_6 = arith.constant 0 : index
+# CHECK-NEXT:        %extracted_slice_1 = tensor.extract_slice %arg1[0, 0, 0, 0] [3, 3, 3, 16] [1, 1, 1, 1] : tensor<3x3x3x16xf32> to tensor<3x3x3x16xf32>
+# CHECK-NEXT:        %extracted_slice_2 = tensor.extract_slice %arg4[%arg3, 0, 0, 0] [1, 8, 8, 16] [1, 1, 1, 1] : tensor<1x8x8x16xf32> to tensor<1x8x8x16xf32>
+# CHECK-NEXT:        %c0_3 = arith.constant 0 : index
 # CHECK-NEXT:        %c8 = arith.constant 8 : index
-# CHECK-NEXT:        %c1_7 = arith.constant 1 : index
-# CHECK-NEXT:        %3 = scf.for %arg5 = %c0_6 to %c8 step %c1_7 iter_args(%arg6 = %extracted_slice_5) -> (tensor<1x8x8x16xf32>) {
-# CHECK-NEXT:          %extracted_slice_8 = tensor.extract_slice %extracted_slice[0, %arg5, 0, 0] [1, 3, 10, 3] [1, 1, 1, 1] : tensor<1x10x10x3xf32> to tensor<1x3x10x3xf32>
-# CHECK-NEXT:          %extracted_slice_9 = tensor.extract_slice %extracted_slice_4[0, 0, 0, 0] [3, 3, 3, 16] [1, 1, 1, 1] : tensor<3x3x3x16xf32> to tensor<3x3x3x16xf32>
-# CHECK-NEXT:          %extracted_slice_10 = tensor.extract_slice %arg6[0, %arg5, 0, 0] [1, 1, 8, 16] [1, 1, 1, 1] : tensor<1x8x8x16xf32> to tensor<1x1x8x16xf32>
-# CHECK-NEXT:          %c0_11 = arith.constant 0 : index
-# CHECK-NEXT:          %c8_12 = arith.constant 8 : index
-# CHECK-NEXT:          %c1_13 = arith.constant 1 : index
-# CHECK-NEXT:          %4 = scf.for %arg7 = %c0_11 to %c8_12 step %c1_13 iter_args(%arg8 = %extracted_slice_10) -> (tensor<1x1x8x16xf32>) {
-# CHECK-NEXT:            %extracted_slice_15 = tensor.extract_slice %extracted_slice_8[0, 0, %arg7, 0] [1, 3, 3, 3] [1, 1, 1, 1] : tensor<1x3x10x3xf32> to tensor<1x3x3x3xf32>
-# CHECK-NEXT:            %extracted_slice_16 = tensor.extract_slice %extracted_slice_9[0, 0, 0, 0] [3, 3, 3, 16] [1, 1, 1, 1] : tensor<3x3x3x16xf32> to tensor<3x3x3x16xf32>
-# CHECK-NEXT:            %extracted_slice_17 = tensor.extract_slice %arg8[0, 0, %arg7, 0] [1, 1, 1, 16] [1, 1, 1, 1] : tensor<1x1x8x16xf32> to tensor<1x1x1x16xf32>
-# CHECK-NEXT:            %c0_18 = arith.constant 0 : index
+# CHECK-NEXT:        %c1_4 = arith.constant 1 : index
+# CHECK-NEXT:        %3 = scf.for %arg5 = %c0_3 to %c8 step %c1_4 iter_args(%arg6 = %extracted_slice_2) -> (tensor<1x8x8x16xf32>) {
+# CHECK-NEXT:          %extracted_slice_5 = tensor.extract_slice %extracted_slice[0, %arg5, 0, 0] [1, 3, 10, 3] [1, 1, 1, 1] : tensor<1x10x10x3xf32> to tensor<1x3x10x3xf32>
+# CHECK-NEXT:          %extracted_slice_6 = tensor.extract_slice %extracted_slice_1[0, 0, 0, 0] [3, 3, 3, 16] [1, 1, 1, 1] : tensor<3x3x3x16xf32> to tensor<3x3x3x16xf32>
+# CHECK-NEXT:          %extracted_slice_7 = tensor.extract_slice %arg6[0, %arg5, 0, 0] [1, 1, 8, 16] [1, 1, 1, 1] : tensor<1x8x8x16xf32> to tensor<1x1x8x16xf32>
+# CHECK-NEXT:          %c0_8 = arith.constant 0 : index
+# CHECK-NEXT:          %c8_9 = arith.constant 8 : index
+# CHECK-NEXT:          %c1_10 = arith.constant 1 : index
+# CHECK-NEXT:          %4 = scf.for %arg7 = %c0_8 to %c8_9 step %c1_10 iter_args(%arg8 = %extracted_slice_7) -> (tensor<1x1x8x16xf32>) {
+# CHECK-NEXT:            %extracted_slice_12 = tensor.extract_slice %extracted_slice_5[0, 0, %arg7, 0] [1, 3, 3, 3] [1, 1, 1, 1] : tensor<1x3x10x3xf32> to tensor<1x3x3x3xf32>
+# CHECK-NEXT:            %extracted_slice_13 = tensor.extract_slice %extracted_slice_6[0, 0, 0, 0] [3, 3, 3, 16] [1, 1, 1, 1] : tensor<3x3x3x16xf32> to tensor<3x3x3x16xf32>
+# CHECK-NEXT:            %extracted_slice_14 = tensor.extract_slice %arg8[0, 0, %arg7, 0] [1, 1, 1, 16] [1, 1, 1, 1] : tensor<1x1x8x16xf32> to tensor<1x1x1x16xf32>
+# CHECK-NEXT:            %c0_15 = arith.constant 0 : index
 # CHECK-NEXT:            %c16 = arith.constant 16 : index
-# CHECK-NEXT:            %c1_19 = arith.constant 1 : index
-# CHECK-NEXT:            %5 = scf.for %arg9 = %c0_18 to %c16 step %c1_19 iter_args(%arg10 = %extracted_slice_17) -> (tensor<1x1x1x16xf32>) {
-# CHECK-NEXT:              %extracted_slice_21 = tensor.extract_slice %extracted_slice_15[0, 0, 0, 0] [1, 3, 3, 3] [1, 1, 1, 1] : tensor<1x3x3x3xf32> to tensor<1x3x3x3xf32>
-# CHECK-NEXT:              %extracted_slice_22 = tensor.extract_slice %extracted_slice_16[0, 0, 0, %arg9] [3, 3, 3, 1] [1, 1, 1, 1] : tensor<3x3x3x16xf32> to tensor<3x3x3x1xf32>
-# CHECK-NEXT:              %extracted_slice_23 = tensor.extract_slice %arg10[0, 0, 0, %arg9] [1, 1, 1, 1] [1, 1, 1, 1] : tensor<1x1x1x16xf32> to tensor<1x1x1x1xf32>
-# CHECK-NEXT:              %c0_24 = arith.constant 0 : index
+# CHECK-NEXT:            %c1_16 = arith.constant 1 : index
+# CHECK-NEXT:            %5 = scf.for %arg9 = %c0_15 to %c16 step %c1_16 iter_args(%arg10 = %extracted_slice_14) -> (tensor<1x1x1x16xf32>) {
+# CHECK-NEXT:              %extracted_slice_18 = tensor.extract_slice %extracted_slice_12[0, 0, 0, 0] [1, 3, 3, 3] [1, 1, 1, 1] : tensor<1x3x3x3xf32> to tensor<1x3x3x3xf32>
+# CHECK-NEXT:              %extracted_slice_19 = tensor.extract_slice %extracted_slice_13[0, 0, 0, %arg9] [3, 3, 3, 1] [1, 1, 1, 1] : tensor<3x3x3x16xf32> to tensor<3x3x3x1xf32>
+# CHECK-NEXT:              %extracted_slice_20 = tensor.extract_slice %arg10[0, 0, 0, %arg9] [1, 1, 1, 1] [1, 1, 1, 1] : tensor<1x1x1x16xf32> to tensor<1x1x1x1xf32>
+# CHECK-NEXT:              %c0_21 = arith.constant 0 : index
 # CHECK-NEXT:              %c3 = arith.constant 3 : index
-# CHECK-NEXT:              %c1_25 = arith.constant 1 : index
-# CHECK-NEXT:              %6 = scf.for %arg11 = %c0_24 to %c3 step %c1_25 iter_args(%arg12 = %extracted_slice_23) -> (tensor<1x1x1x1xf32>) {
-# CHECK-NEXT:                %extracted_slice_27 = tensor.extract_slice %extracted_slice_21[0, %arg11, 0, 0] [1, 1, 3, 3] [1, 1, 1, 1] : tensor<1x3x3x3xf32> to tensor<1x1x3x3xf32>
-# CHECK-NEXT:                %extracted_slice_28 = tensor.extract_slice %extracted_slice_22[%arg11, 0, 0, 0] [1, 3, 3, 1] [1, 1, 1, 1] : tensor<3x3x3x1xf32> to tensor<1x3x3x1xf32>
-# CHECK-NEXT:                %extracted_slice_29 = tensor.extract_slice %arg12[0, 0, 0, 0] [1, 1, 1, 1] [1, 1, 1, 1] : tensor<1x1x1x1xf32> to tensor<1x1x1x1xf32>
-# CHECK-NEXT:                %c0_30 = arith.constant 0 : index
-# CHECK-NEXT:                %c3_31 = arith.constant 3 : index
-# CHECK-NEXT:                %c1_32 = arith.constant 1 : index
-# CHECK-NEXT:                %7 = scf.for %arg13 = %c0_30 to %c3_31 step %c1_32 iter_args(%arg14 = %extracted_slice_29) -> (tensor<1x1x1x1xf32>) {
-# CHECK-NEXT:                  %extracted_slice_34 = tensor.extract_slice %extracted_slice_27[0, 0, %arg13, 0] [1, 1, 1, 3] [1, 1, 1, 1] : tensor<1x1x3x3xf32> to tensor<1x1x1x3xf32>
-# CHECK-NEXT:                  %extracted_slice_35 = tensor.extract_slice %extracted_slice_28[0, %arg13, 0, 0] [1, 1, 3, 1] [1, 1, 1, 1] : tensor<1x3x3x1xf32> to tensor<1x1x3x1xf32>
-# CHECK-NEXT:                  %extracted_slice_36 = tensor.extract_slice %arg14[0, 0, 0, 0] [1, 1, 1, 1] [1, 1, 1, 1] : tensor<1x1x1x1xf32> to tensor<1x1x1x1xf32>
-# CHECK-NEXT:                  %c0_37 = arith.constant 0 : index
-# CHECK-NEXT:                  %c3_38 = arith.constant 3 : index
-# CHECK-NEXT:                  %c1_39 = arith.constant 1 : index
-# CHECK-NEXT:                  %8 = scf.for %arg15 = %c0_37 to %c3_38 step %c1_39 iter_args(%arg16 = %extracted_slice_36) -> (tensor<1x1x1x1xf32>) {
-# CHECK-NEXT:                    %extracted_slice_41 = tensor.extract_slice %extracted_slice_34[0, 0, 0, %arg15] [1, 1, 1, 1] [1, 1, 1, 1] : tensor<1x1x1x3xf32> to tensor<1x1x1x1xf32>
-# CHECK-NEXT:                    %extracted_slice_42 = tensor.extract_slice %extracted_slice_35[0, 0, %arg15, 0] [1, 1, 1, 1] [1, 1, 1, 1] : tensor<1x1x3x1xf32> to tensor<1x1x1x1xf32>
-# CHECK-NEXT:                    %extracted_slice_43 = tensor.extract_slice %arg16[0, 0, 0, 0] [1, 1, 1, 1] [1, 1, 1, 1] : tensor<1x1x1x1xf32> to tensor<1x1x1x1xf32>
-# CHECK-NEXT:                    %9 = linalg.generic {indexing_maps = [#map, #map1, #map2], iterator_types = ["parallel", "parallel", "parallel", "parallel", "reduction", "reduction", "reduction"]} ins(%extracted_slice_41, %extracted_slice_42 : tensor<1x1x1x1xf32>, tensor<1x1x1x1xf32>) outs(%extracted_slice_43 : tensor<1x1x1x1xf32>) attrs =  {__xtc_id_O_} {
-# CHECK-NEXT:                    ^bb0(%in: f32, %in_45: f32, %out: f32):
-# CHECK-NEXT:                      %10 = arith.mulf %in, %in_45 fastmath<fast> : f32
+# CHECK-NEXT:              %c1_22 = arith.constant 1 : index
+# CHECK-NEXT:              %6 = scf.for %arg11 = %c0_21 to %c3 step %c1_22 iter_args(%arg12 = %extracted_slice_20) -> (tensor<1x1x1x1xf32>) {
+# CHECK-NEXT:                %extracted_slice_24 = tensor.extract_slice %extracted_slice_18[0, %arg11, 0, 0] [1, 1, 3, 3] [1, 1, 1, 1] : tensor<1x3x3x3xf32> to tensor<1x1x3x3xf32>
+# CHECK-NEXT:                %extracted_slice_25 = tensor.extract_slice %extracted_slice_19[%arg11, 0, 0, 0] [1, 3, 3, 1] [1, 1, 1, 1] : tensor<3x3x3x1xf32> to tensor<1x3x3x1xf32>
+# CHECK-NEXT:                %extracted_slice_26 = tensor.extract_slice %arg12[0, 0, 0, 0] [1, 1, 1, 1] [1, 1, 1, 1] : tensor<1x1x1x1xf32> to tensor<1x1x1x1xf32>
+# CHECK-NEXT:                %c0_27 = arith.constant 0 : index
+# CHECK-NEXT:                %c3_28 = arith.constant 3 : index
+# CHECK-NEXT:                %c1_29 = arith.constant 1 : index
+# CHECK-NEXT:                %7 = scf.for %arg13 = %c0_27 to %c3_28 step %c1_29 iter_args(%arg14 = %extracted_slice_26) -> (tensor<1x1x1x1xf32>) {
+# CHECK-NEXT:                  %extracted_slice_31 = tensor.extract_slice %extracted_slice_24[0, 0, %arg13, 0] [1, 1, 1, 3] [1, 1, 1, 1] : tensor<1x1x3x3xf32> to tensor<1x1x1x3xf32>
+# CHECK-NEXT:                  %extracted_slice_32 = tensor.extract_slice %extracted_slice_25[0, %arg13, 0, 0] [1, 1, 3, 1] [1, 1, 1, 1] : tensor<1x3x3x1xf32> to tensor<1x1x3x1xf32>
+# CHECK-NEXT:                  %extracted_slice_33 = tensor.extract_slice %arg14[0, 0, 0, 0] [1, 1, 1, 1] [1, 1, 1, 1] : tensor<1x1x1x1xf32> to tensor<1x1x1x1xf32>
+# CHECK-NEXT:                  %c0_34 = arith.constant 0 : index
+# CHECK-NEXT:                  %c3_35 = arith.constant 3 : index
+# CHECK-NEXT:                  %c1_36 = arith.constant 1 : index
+# CHECK-NEXT:                  %8 = scf.for %arg15 = %c0_34 to %c3_35 step %c1_36 iter_args(%arg16 = %extracted_slice_33) -> (tensor<1x1x1x1xf32>) {
+# CHECK-NEXT:                    %extracted_slice_38 = tensor.extract_slice %extracted_slice_31[0, 0, 0, %arg15] [1, 1, 1, 1] [1, 1, 1, 1] : tensor<1x1x1x3xf32> to tensor<1x1x1x1xf32>
+# CHECK-NEXT:                    %extracted_slice_39 = tensor.extract_slice %extracted_slice_32[0, 0, %arg15, 0] [1, 1, 1, 1] [1, 1, 1, 1] : tensor<1x1x3x1xf32> to tensor<1x1x1x1xf32>
+# CHECK-NEXT:                    %extracted_slice_40 = tensor.extract_slice %arg16[0, 0, 0, 0] [1, 1, 1, 1] [1, 1, 1, 1] : tensor<1x1x1x1xf32> to tensor<1x1x1x1xf32>
+# CHECK-NEXT:                    %9 = linalg.generic {indexing_maps = [#map, #map1, #map2], iterator_types = ["parallel", "parallel", "parallel", "parallel", "reduction", "reduction", "reduction"]} ins(%extracted_slice_38, %extracted_slice_39 : tensor<1x1x1x1xf32>, tensor<1x1x1x1xf32>) outs(%extracted_slice_40 : tensor<1x1x1x1xf32>) attrs =  {__xtc_id_O_} {
+# CHECK-NEXT:                    ^bb0(%in: f32, %in_42: f32, %out: f32):
+# CHECK-NEXT:                      %10 = arith.mulf %in, %in_42 fastmath<fast> : f32
 # CHECK-NEXT:                      %11 = arith.addf %out, %10 fastmath<fast> : f32
 # CHECK-NEXT:                      linalg.yield %11 : f32
 # CHECK-NEXT:                    } -> tensor<1x1x1x1xf32>
-# CHECK-NEXT:                    %inserted_slice_44 = tensor.insert_slice %9 into %arg16[0, 0, 0, 0] [1, 1, 1, 1] [1, 1, 1, 1] : tensor<1x1x1x1xf32> into tensor<1x1x1x1xf32>
-# CHECK-NEXT:                    scf.yield %inserted_slice_44 : tensor<1x1x1x1xf32>
+# CHECK-NEXT:                    %inserted_slice_41 = tensor.insert_slice %9 into %arg16[0, 0, 0, 0] [1, 1, 1, 1] [1, 1, 1, 1] : tensor<1x1x1x1xf32> into tensor<1x1x1x1xf32>
+# CHECK-NEXT:                    scf.yield %inserted_slice_41 : tensor<1x1x1x1xf32>
 # CHECK-NEXT:                  } {"./c"}
-# CHECK-NEXT:                  %inserted_slice_40 = tensor.insert_slice %8 into %arg14[0, 0, 0, 0] [1, 1, 1, 1] [1, 1, 1, 1] : tensor<1x1x1x1xf32> into tensor<1x1x1x1xf32>
-# CHECK-NEXT:                  scf.yield %inserted_slice_40 : tensor<1x1x1x1xf32>
+# CHECK-NEXT:                  %inserted_slice_37 = tensor.insert_slice %8 into %arg14[0, 0, 0, 0] [1, 1, 1, 1] [1, 1, 1, 1] : tensor<1x1x1x1xf32> into tensor<1x1x1x1xf32>
+# CHECK-NEXT:                  scf.yield %inserted_slice_37 : tensor<1x1x1x1xf32>
 # CHECK-NEXT:                } {"./s"}
-# CHECK-NEXT:                %inserted_slice_33 = tensor.insert_slice %7 into %arg12[0, 0, 0, 0] [1, 1, 1, 1] [1, 1, 1, 1] : tensor<1x1x1x1xf32> into tensor<1x1x1x1xf32>
-# CHECK-NEXT:                scf.yield %inserted_slice_33 : tensor<1x1x1x1xf32>
+# CHECK-NEXT:                %inserted_slice_30 = tensor.insert_slice %7 into %arg12[0, 0, 0, 0] [1, 1, 1, 1] [1, 1, 1, 1] : tensor<1x1x1x1xf32> into tensor<1x1x1x1xf32>
+# CHECK-NEXT:                scf.yield %inserted_slice_30 : tensor<1x1x1x1xf32>
 # CHECK-NEXT:              } {"./r"}
-# CHECK-NEXT:              %inserted_slice_26 = tensor.insert_slice %6 into %arg10[0, 0, 0, %arg9] [1, 1, 1, 1] [1, 1, 1, 1] : tensor<1x1x1x1xf32> into tensor<1x1x1x16xf32>
-# CHECK-NEXT:              scf.yield %inserted_slice_26 : tensor<1x1x1x16xf32>
+# CHECK-NEXT:              %inserted_slice_23 = tensor.insert_slice %6 into %arg10[0, 0, 0, %arg9] [1, 1, 1, 1] [1, 1, 1, 1] : tensor<1x1x1x1xf32> into tensor<1x1x1x16xf32>
+# CHECK-NEXT:              scf.yield %inserted_slice_23 : tensor<1x1x1x16xf32>
 # CHECK-NEXT:            } {"./f"}
-# CHECK-NEXT:            %inserted_slice_20 = tensor.insert_slice %5 into %arg8[0, 0, %arg7, 0] [1, 1, 1, 16] [1, 1, 1, 1] : tensor<1x1x1x16xf32> into tensor<1x1x8x16xf32>
-# CHECK-NEXT:            scf.yield %inserted_slice_20 : tensor<1x1x8x16xf32>
+# CHECK-NEXT:            %inserted_slice_17 = tensor.insert_slice %5 into %arg8[0, 0, %arg7, 0] [1, 1, 1, 16] [1, 1, 1, 1] : tensor<1x1x1x16xf32> into tensor<1x1x8x16xf32>
+# CHECK-NEXT:            scf.yield %inserted_slice_17 : tensor<1x1x8x16xf32>
 # CHECK-NEXT:          } {"./w"}
-# CHECK-NEXT:          %inserted_slice_14 = tensor.insert_slice %4 into %arg6[0, %arg5, 0, 0] [1, 1, 8, 16] [1, 1, 1, 1] : tensor<1x1x8x16xf32> into tensor<1x8x8x16xf32>
-# CHECK-NEXT:          scf.yield %inserted_slice_14 : tensor<1x8x8x16xf32>
+# CHECK-NEXT:          %inserted_slice_11 = tensor.insert_slice %4 into %arg6[0, %arg5, 0, 0] [1, 1, 8, 16] [1, 1, 1, 1] : tensor<1x1x8x16xf32> into tensor<1x8x8x16xf32>
+# CHECK-NEXT:          scf.yield %inserted_slice_11 : tensor<1x8x8x16xf32>
 # CHECK-NEXT:        } {"./h"}
 # CHECK-NEXT:        %inserted_slice = tensor.insert_slice %3 into %arg4[%arg3, 0, 0, 0] [1, 8, 8, 16] [1, 1, 1, 1] : tensor<1x8x8x16xf32> into tensor<1x8x8x16xf32>
 # CHECK-NEXT:        scf.yield %inserted_slice : tensor<1x8x8x16xf32>
@@ -227,68 +186,50 @@ print(f"CODE: {res}")
 # CHECK-NEXT:      %c1 = arith.constant 1 : index
 # CHECK-NEXT:      %c0 = arith.constant 0 : index
 # CHECK-NEXT:      %cst = arith.constant 0.000000e+00 : f32
+# CHECK-NEXT:      linalg.fill {__xtc_id_O_0_} ins(%cst : f32) outs(%arg2 : memref<1x8x8x16xf32>)
 # CHECK-NEXT:      %0 = scf.for %arg3 = %c0 to %c8 step %c1 iter_args(%arg4 = %arg2) -> (memref<1x8x8x16xf32>) {
-# CHECK-NEXT:        %subview = memref.subview %arg4[0, %arg3, 0, 0] [1, 1, 8, 16] [1, 1, 1, 1] : memref<1x8x8x16xf32> to memref<1x1x8x16xf32, strided<[1024, 128, 16, 1], offset: ?>>
-# CHECK-NEXT:        %2 = scf.for %arg5 = %c0 to %c8 step %c1 iter_args(%arg6 = %subview) -> (memref<1x1x8x16xf32, strided<[1024, 128, 16, 1], offset: ?>>) {
-# CHECK-NEXT:          %subview_1 = memref.subview %arg6[0, 0, %arg5, 0] [1, 1, 1, 16] [1, 1, 1, 1] : memref<1x1x8x16xf32, strided<[1024, 128, 16, 1], offset: ?>> to memref<1x1x1x16xf32, strided<[1024, 128, 16, 1], offset: ?>>
-# CHECK-NEXT:          %3 = scf.for %arg7 = %c0 to %c16 step %c1 iter_args(%arg8 = %subview_1) -> (memref<1x1x1x16xf32, strided<[1024, 128, 16, 1], offset: ?>>) {
-# CHECK-NEXT:            %subview_3 = memref.subview %arg8[0, 0, 0, %arg7] [1, 1, 1, 1] [1, 1, 1, 1] : memref<1x1x1x16xf32, strided<[1024, 128, 16, 1], offset: ?>> to memref<1x1x1x1xf32, strided<[1024, 128, 16, 1], offset: ?>>
-# CHECK-NEXT:            linalg.fill {__xtc_id_O_0_} ins(%cst : f32) outs(%subview_3 : memref<1x1x1x1xf32, strided<[1024, 128, 16, 1], offset: ?>>)
-# CHECK-NEXT:            %subview_4 = memref.subview %arg8[0, 0, 0, %arg7] [1, 1, 1, 1] [1, 1, 1, 1] : memref<1x1x1x16xf32, strided<[1024, 128, 16, 1], offset: ?>> to memref<1x1x1x1xf32, strided<[1024, 128, 16, 1], offset: ?>>
-# CHECK-NEXT:            memref.copy %subview_3, %subview_4 : memref<1x1x1x1xf32, strided<[1024, 128, 16, 1], offset: ?>> to memref<1x1x1x1xf32, strided<[1024, 128, 16, 1], offset: ?>>
-# CHECK-NEXT:            scf.yield %arg8 : memref<1x1x1x16xf32, strided<[1024, 128, 16, 1], offset: ?>>
-# CHECK-NEXT:          } {"./f"}
-# CHECK-NEXT:          %subview_2 = memref.subview %arg6[0, 0, %arg5, 0] [1, 1, 1, 16] [1, 1, 1, 1] : memref<1x1x8x16xf32, strided<[1024, 128, 16, 1], offset: ?>> to memref<1x1x1x16xf32, strided<[1024, 128, 16, 1], offset: ?>>
-# CHECK-NEXT:          memref.copy %3, %subview_2 : memref<1x1x1x16xf32, strided<[1024, 128, 16, 1], offset: ?>> to memref<1x1x1x16xf32, strided<[1024, 128, 16, 1], offset: ?>>
-# CHECK-NEXT:          scf.yield %arg6 : memref<1x1x8x16xf32, strided<[1024, 128, 16, 1], offset: ?>>
-# CHECK-NEXT:        } {"./w"}
-# CHECK-NEXT:        %subview_0 = memref.subview %arg4[0, %arg3, 0, 0] [1, 1, 8, 16] [1, 1, 1, 1] : memref<1x8x8x16xf32> to memref<1x1x8x16xf32, strided<[1024, 128, 16, 1], offset: ?>>
-# CHECK-NEXT:        memref.copy %2, %subview_0 : memref<1x1x8x16xf32, strided<[1024, 128, 16, 1], offset: ?>> to memref<1x1x8x16xf32, strided<[1024, 128, 16, 1], offset: ?>>
-# CHECK-NEXT:        scf.yield %arg4 : memref<1x8x8x16xf32>
-# CHECK-NEXT:      } {"./h"}
-# CHECK-NEXT:      %1 = scf.for %arg3 = %c0 to %c8 step %c1 iter_args(%arg4 = %0) -> (memref<1x8x8x16xf32>) {
 # CHECK-NEXT:        %subview = memref.subview %arg0[0, %arg3, 0, 0] [1, 3, 10, 3] [1, 1, 1, 1] : memref<1x10x10x3xf32> to memref<1x3x10x3xf32, strided<[300, 30, 3, 1], offset: ?>>
 # CHECK-NEXT:        %subview_0 = memref.subview %arg4[0, %arg3, 0, 0] [1, 1, 8, 16] [1, 1, 1, 1] : memref<1x8x8x16xf32> to memref<1x1x8x16xf32, strided<[1024, 128, 16, 1], offset: ?>>
-# CHECK-NEXT:        %2 = scf.for %arg5 = %c0 to %c8 step %c1 iter_args(%arg6 = %subview_0) -> (memref<1x1x8x16xf32, strided<[1024, 128, 16, 1], offset: ?>>) {
+# CHECK-NEXT:        %1 = scf.for %arg5 = %c0 to %c8 step %c1 iter_args(%arg6 = %subview_0) -> (memref<1x1x8x16xf32, strided<[1024, 128, 16, 1], offset: ?>>) {
 # CHECK-NEXT:          %subview_2 = memref.subview %subview[0, 0, %arg5, 0] [1, 3, 3, 3] [1, 1, 1, 1] : memref<1x3x10x3xf32, strided<[300, 30, 3, 1], offset: ?>> to memref<1x3x3x3xf32, strided<[300, 30, 3, 1], offset: ?>>
 # CHECK-NEXT:          %subview_3 = memref.subview %arg6[0, 0, %arg5, 0] [1, 1, 1, 16] [1, 1, 1, 1] : memref<1x1x8x16xf32, strided<[1024, 128, 16, 1], offset: ?>> to memref<1x1x1x16xf32, strided<[1024, 128, 16, 1], offset: ?>>
-# CHECK-NEXT:          %3 = scf.for %arg7 = %c0 to %c16 step %c1 iter_args(%arg8 = %subview_3) -> (memref<1x1x1x16xf32, strided<[1024, 128, 16, 1], offset: ?>>) {
+# CHECK-NEXT:          %2 = scf.for %arg7 = %c0 to %c16 step %c1 iter_args(%arg8 = %subview_3) -> (memref<1x1x1x16xf32, strided<[1024, 128, 16, 1], offset: ?>>) {
 # CHECK-NEXT:            %subview_5 = memref.subview %arg1[0, 0, 0, %arg7] [3, 3, 3, 1] [1, 1, 1, 1] : memref<3x3x3x16xf32> to memref<3x3x3x1xf32, strided<[144, 48, 16, 1], offset: ?>>
 # CHECK-NEXT:            %subview_6 = memref.subview %arg8[0, 0, 0, %arg7] [1, 1, 1, 1] [1, 1, 1, 1] : memref<1x1x1x16xf32, strided<[1024, 128, 16, 1], offset: ?>> to memref<1x1x1x1xf32, strided<[1024, 128, 16, 1], offset: ?>>
-# CHECK-NEXT:            %4 = scf.for %arg9 = %c0 to %c3 step %c1 iter_args(%arg10 = %subview_6) -> (memref<1x1x1x1xf32, strided<[1024, 128, 16, 1], offset: ?>>) {
+# CHECK-NEXT:            %3 = scf.for %arg9 = %c0 to %c3 step %c1 iter_args(%arg10 = %subview_6) -> (memref<1x1x1x1xf32, strided<[1024, 128, 16, 1], offset: ?>>) {
 # CHECK-NEXT:              %subview_8 = memref.subview %subview_2[0, %arg9, 0, 0] [1, 1, 3, 3] [1, 1, 1, 1] : memref<1x3x3x3xf32, strided<[300, 30, 3, 1], offset: ?>> to memref<1x1x3x3xf32, strided<[300, 30, 3, 1], offset: ?>>
 # CHECK-NEXT:              %subview_9 = memref.subview %subview_5[%arg9, 0, 0, 0] [1, 3, 3, 1] [1, 1, 1, 1] : memref<3x3x3x1xf32, strided<[144, 48, 16, 1], offset: ?>> to memref<1x3x3x1xf32, strided<[144, 48, 16, 1], offset: ?>>
-# CHECK-NEXT:              %5 = scf.for %arg11 = %c0 to %c3 step %c1 iter_args(%arg12 = %arg10) -> (memref<1x1x1x1xf32, strided<[1024, 128, 16, 1], offset: ?>>) {
+# CHECK-NEXT:              %4 = scf.for %arg11 = %c0 to %c3 step %c1 iter_args(%arg12 = %arg10) -> (memref<1x1x1x1xf32, strided<[1024, 128, 16, 1], offset: ?>>) {
 # CHECK-NEXT:                %subview_10 = memref.subview %subview_8[0, 0, %arg11, 0] [1, 1, 1, 3] [1, 1, 1, 1] : memref<1x1x3x3xf32, strided<[300, 30, 3, 1], offset: ?>> to memref<1x1x1x3xf32, strided<[300, 30, 3, 1], offset: ?>>
 # CHECK-NEXT:                %subview_11 = memref.subview %subview_9[0, %arg11, 0, 0] [1, 1, 3, 1] [1, 1, 1, 1] : memref<1x3x3x1xf32, strided<[144, 48, 16, 1], offset: ?>> to memref<1x1x3x1xf32, strided<[144, 48, 16, 1], offset: ?>>
-# CHECK-NEXT:                %6 = scf.for %arg13 = %c0 to %c3 step %c1 iter_args(%arg14 = %arg12) -> (memref<1x1x1x1xf32, strided<[1024, 128, 16, 1], offset: ?>>) {
+# CHECK-NEXT:                %5 = scf.for %arg13 = %c0 to %c3 step %c1 iter_args(%arg14 = %arg12) -> (memref<1x1x1x1xf32, strided<[1024, 128, 16, 1], offset: ?>>) {
 # CHECK-NEXT:                  %subview_12 = memref.subview %subview_10[0, 0, 0, %arg13] [1, 1, 1, 1] [1, 1, 1, 1] : memref<1x1x1x3xf32, strided<[300, 30, 3, 1], offset: ?>> to memref<1x1x1x1xf32, strided<[300, 30, 3, 1], offset: ?>>
 # CHECK-NEXT:                  %subview_13 = memref.subview %subview_11[0, 0, %arg13, 0] [1, 1, 1, 1] [1, 1, 1, 1] : memref<1x1x3x1xf32, strided<[144, 48, 16, 1], offset: ?>> to memref<1x1x1x1xf32, strided<[144, 48, 16, 1], offset: ?>>
 # CHECK-NEXT:                  linalg.generic {indexing_maps = [#map, #map1, #map2], iterator_types = ["parallel", "parallel", "parallel", "parallel", "reduction", "reduction", "reduction"]} ins(%subview_12, %subview_13 : memref<1x1x1x1xf32, strided<[300, 30, 3, 1], offset: ?>>, memref<1x1x1x1xf32, strided<[144, 48, 16, 1], offset: ?>>) outs(%arg14 : memref<1x1x1x1xf32, strided<[1024, 128, 16, 1], offset: ?>>) attrs =  {__xtc_id_O_} {
 # CHECK-NEXT:                  ^bb0(%in: f32, %in_14: f32, %out: f32):
-# CHECK-NEXT:                    %7 = arith.mulf %in, %in_14 fastmath<fast> : f32
-# CHECK-NEXT:                    %8 = arith.addf %out, %7 fastmath<fast> : f32
-# CHECK-NEXT:                    linalg.yield %8 : f32
+# CHECK-NEXT:                    %6 = arith.mulf %in, %in_14 fastmath<fast> : f32
+# CHECK-NEXT:                    %7 = arith.addf %out, %6 fastmath<fast> : f32
+# CHECK-NEXT:                    linalg.yield %7 : f32
 # CHECK-NEXT:                  }
 # CHECK-NEXT:                  scf.yield %arg14 : memref<1x1x1x1xf32, strided<[1024, 128, 16, 1], offset: ?>>
 # CHECK-NEXT:                } {"./c"}
-# CHECK-NEXT:                scf.yield %6 : memref<1x1x1x1xf32, strided<[1024, 128, 16, 1], offset: ?>>
+# CHECK-NEXT:                scf.yield %5 : memref<1x1x1x1xf32, strided<[1024, 128, 16, 1], offset: ?>>
 # CHECK-NEXT:              } {"./s"}
-# CHECK-NEXT:              scf.yield %5 : memref<1x1x1x1xf32, strided<[1024, 128, 16, 1], offset: ?>>
+# CHECK-NEXT:              scf.yield %4 : memref<1x1x1x1xf32, strided<[1024, 128, 16, 1], offset: ?>>
 # CHECK-NEXT:            } {"./r"}
 # CHECK-NEXT:            %subview_7 = memref.subview %arg8[0, 0, 0, %arg7] [1, 1, 1, 1] [1, 1, 1, 1] : memref<1x1x1x16xf32, strided<[1024, 128, 16, 1], offset: ?>> to memref<1x1x1x1xf32, strided<[1024, 128, 16, 1], offset: ?>>
-# CHECK-NEXT:            memref.copy %4, %subview_7 : memref<1x1x1x1xf32, strided<[1024, 128, 16, 1], offset: ?>> to memref<1x1x1x1xf32, strided<[1024, 128, 16, 1], offset: ?>>
+# CHECK-NEXT:            memref.copy %3, %subview_7 : memref<1x1x1x1xf32, strided<[1024, 128, 16, 1], offset: ?>> to memref<1x1x1x1xf32, strided<[1024, 128, 16, 1], offset: ?>>
 # CHECK-NEXT:            scf.yield %arg8 : memref<1x1x1x16xf32, strided<[1024, 128, 16, 1], offset: ?>>
 # CHECK-NEXT:          } {"./f"}
 # CHECK-NEXT:          %subview_4 = memref.subview %arg6[0, 0, %arg5, 0] [1, 1, 1, 16] [1, 1, 1, 1] : memref<1x1x8x16xf32, strided<[1024, 128, 16, 1], offset: ?>> to memref<1x1x1x16xf32, strided<[1024, 128, 16, 1], offset: ?>>
-# CHECK-NEXT:          memref.copy %3, %subview_4 : memref<1x1x1x16xf32, strided<[1024, 128, 16, 1], offset: ?>> to memref<1x1x1x16xf32, strided<[1024, 128, 16, 1], offset: ?>>
+# CHECK-NEXT:          memref.copy %2, %subview_4 : memref<1x1x1x16xf32, strided<[1024, 128, 16, 1], offset: ?>> to memref<1x1x1x16xf32, strided<[1024, 128, 16, 1], offset: ?>>
 # CHECK-NEXT:          scf.yield %arg6 : memref<1x1x8x16xf32, strided<[1024, 128, 16, 1], offset: ?>>
 # CHECK-NEXT:        } {"./w"}
 # CHECK-NEXT:        %subview_1 = memref.subview %arg4[0, %arg3, 0, 0] [1, 1, 8, 16] [1, 1, 1, 1] : memref<1x8x8x16xf32> to memref<1x1x8x16xf32, strided<[1024, 128, 16, 1], offset: ?>>
-# CHECK-NEXT:        memref.copy %2, %subview_1 : memref<1x1x8x16xf32, strided<[1024, 128, 16, 1], offset: ?>> to memref<1x1x8x16xf32, strided<[1024, 128, 16, 1], offset: ?>>
+# CHECK-NEXT:        memref.copy %1, %subview_1 : memref<1x1x8x16xf32, strided<[1024, 128, 16, 1], offset: ?>> to memref<1x1x8x16xf32, strided<[1024, 128, 16, 1], offset: ?>>
 # CHECK-NEXT:        scf.yield %arg4 : memref<1x8x8x16xf32>
 # CHECK-NEXT:      } {"./h"}
-# CHECK-NEXT:      memref.copy %1, %arg2 : memref<1x8x8x16xf32> to memref<1x8x8x16xf32>
+# CHECK-NEXT:      memref.copy %0, %arg2 : memref<1x8x8x16xf32> to memref<1x8x8x16xf32>
 # CHECK-NEXT:      return
 # CHECK-NEXT:    }
 # CHECK-NEXT:  }

--- a/tests/filecheck/backends/tensor_dialect/test_conv2d_r181_mlir_tensor.py
+++ b/tests/filecheck/backends/tensor_dialect/test_conv2d_r181_mlir_tensor.py
@@ -71,42 +71,33 @@ print(f"CODE: {res}")
 # CHECK-NEXT:      transform.yield 
 # CHECK-NEXT:    }
 # CHECK-NEXT:    transform.named_sequence @__transform_main(%arg0: !transform.any_op {transform.readonly}) {
-# CHECK-NEXT:      %0 = transform.structured.match attributes {__xtc_id_O_0_} in %arg0 : (!transform.any_op) -> !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op, %loops = transform.structured.tile_using_for %0 tile_sizes [1, 0, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      %0 = transform.structured.match attributes {__xtc_id_O_} in %arg0 : (!transform.any_op) -> !transform.any_op
+# CHECK-NEXT:      %tiled_linalg_op, %loops = transform.structured.tile_using_for %0 tile_sizes [1, 0, 0, 0, 0, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
 # CHECK-NEXT:      transform.annotate %loops "./b" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_0, %loops_1 = transform.structured.tile_using_for %tiled_linalg_op tile_sizes [0, 1, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      %tiled_linalg_op_0, %loops_1 = transform.structured.tile_using_for %tiled_linalg_op tile_sizes [0, 1, 0, 0, 0, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
 # CHECK-NEXT:      transform.annotate %loops_1 "./h" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_2, %loops_3 = transform.structured.tile_using_for %tiled_linalg_op_0 tile_sizes [0, 0, 1, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      %tiled_linalg_op_2, %loops_3 = transform.structured.tile_using_for %tiled_linalg_op_0 tile_sizes [0, 0, 4, 0, 0, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
 # CHECK-NEXT:      transform.annotate %loops_3 "./w" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_4, %loops_5 = transform.structured.tile_using_for %tiled_linalg_op_2 tile_sizes [0, 0, 0, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      %tiled_linalg_op_4, %loops_5 = transform.structured.tile_using_for %tiled_linalg_op_2 tile_sizes [0, 0, 0, 16, 0, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
 # CHECK-NEXT:      transform.annotate %loops_5 "./f" : !transform.any_op
-# CHECK-NEXT:      %1 = transform.structured.match attributes {__xtc_id_O_} in %arg0 : (!transform.any_op) -> !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_6, %loops_7 = transform.structured.tile_using_for %1 tile_sizes [1, 0, 0, 0, 0, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_7 "./b" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_8, %loops_9 = transform.structured.tile_using_for %tiled_linalg_op_6 tile_sizes [0, 1, 0, 0, 0, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_9 "./h" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_10, %loops_11 = transform.structured.tile_using_for %tiled_linalg_op_8 tile_sizes [0, 0, 4, 0, 0, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_11 "./w" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_12, %loops_13 = transform.structured.tile_using_for %tiled_linalg_op_10 tile_sizes [0, 0, 0, 16, 0, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_13 "./f" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_14, %loops_15 = transform.structured.tile_using_for %tiled_linalg_op_12 tile_sizes [0, 0, 0, 0, 1, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_15 "./r" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_16, %loops_17 = transform.structured.tile_using_for %tiled_linalg_op_14 tile_sizes [0, 0, 0, 0, 0, 1, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_17 "./s" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_18, %loops_19 = transform.structured.tile_using_for %tiled_linalg_op_16 tile_sizes [0, 0, 0, 0, 0, 0, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_19 "./c" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_20, %loops_21 = transform.structured.tile_using_for %tiled_linalg_op_18 tile_sizes [0, 0, 1, 0, 0, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_21 "./w1" : !transform.any_op
-# CHECK-NEXT:      %2 = transform.get_parent_op %tiled_linalg_op_20 : (!transform.any_op) -> !transform.any_op
-# CHECK-NEXT:      transform.apply_patterns to %2 {
+# CHECK-NEXT:      %tiled_linalg_op_6, %loops_7 = transform.structured.tile_using_for %tiled_linalg_op_4 tile_sizes [0, 0, 0, 0, 1, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      transform.annotate %loops_7 "./r" : !transform.any_op
+# CHECK-NEXT:      %tiled_linalg_op_8, %loops_9 = transform.structured.tile_using_for %tiled_linalg_op_6 tile_sizes [0, 0, 0, 0, 0, 1, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      transform.annotate %loops_9 "./s" : !transform.any_op
+# CHECK-NEXT:      %tiled_linalg_op_10, %loops_11 = transform.structured.tile_using_for %tiled_linalg_op_8 tile_sizes [0, 0, 0, 0, 0, 0, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      transform.annotate %loops_11 "./c" : !transform.any_op
+# CHECK-NEXT:      %tiled_linalg_op_12, %loops_13 = transform.structured.tile_using_for %tiled_linalg_op_10 tile_sizes [0, 0, 1, 0, 0, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      transform.annotate %loops_13 "./w1" : !transform.any_op
+# CHECK-NEXT:      %1 = transform.get_parent_op %tiled_linalg_op_12 : (!transform.any_op) -> !transform.any_op
+# CHECK-NEXT:      transform.apply_patterns to %1 {
 # CHECK-NEXT:        transform.apply_patterns.linalg.fold_unit_extent_dims_via_slices
 # CHECK-NEXT:      } : !transform.any_op
-# CHECK-NEXT:      %3 = transform.structured.match interface{LinalgOp} in %2 : (!transform.any_op) -> !transform.any_op
-# CHECK-NEXT:      transform.include @_vecto failures(suppress) (%3) : (!transform.any_op) -> ()
-# CHECK-NEXT:      transform.loop.unroll %loops_21 {factor = 4 : i64} : !transform.any_op
-# CHECK-NEXT:      transform.loop.unroll %loops_19 {factor = 3 : i64} : !transform.any_op
-# CHECK-NEXT:      %4 = transform.get_parent_op %loops_7 {isolated_from_above} : (!transform.any_op) -> !transform.any_op
-# CHECK-NEXT:      transform.apply_patterns to %4 {
+# CHECK-NEXT:      %2 = transform.structured.match interface{LinalgOp} in %1 : (!transform.any_op) -> !transform.any_op
+# CHECK-NEXT:      transform.include @_vecto failures(suppress) (%2) : (!transform.any_op) -> ()
+# CHECK-NEXT:      transform.loop.unroll %loops_13 {factor = 4 : i64} : !transform.any_op
+# CHECK-NEXT:      transform.loop.unroll %loops_11 {factor = 3 : i64} : !transform.any_op
+# CHECK-NEXT:      %3 = transform.get_parent_op %loops {isolated_from_above} : (!transform.any_op) -> !transform.any_op
+# CHECK-NEXT:      transform.apply_patterns to %3 {
 # CHECK-NEXT:        transform.apply_patterns.vector.reduction_to_contract
 # CHECK-NEXT:        transform.apply_patterns.vector.transfer_permutation_patterns
 # CHECK-NEXT:      } : !transform.any_op
@@ -124,34 +115,14 @@ print(f"CODE: {res}")
 # CHECK-NEXT:      %0 = ub.poison : f32
 # CHECK-NEXT:      %c7 = arith.constant 7 : index
 # CHECK-NEXT:      %c16 = arith.constant 16 : index
-# CHECK-NEXT:      %c4 = arith.constant 4 : index
 # CHECK-NEXT:      %c64 = arith.constant 64 : index
+# CHECK-NEXT:      %c4 = arith.constant 4 : index
 # CHECK-NEXT:      %c112 = arith.constant 112 : index
 # CHECK-NEXT:      %c1 = arith.constant 1 : index
 # CHECK-NEXT:      %c0 = arith.constant 0 : index
 # CHECK-NEXT:      %cst = arith.constant 0.000000e+00 : f32
 # CHECK-NEXT:      %1 = tensor.empty() : tensor<1x112x112x64xf32>
-# CHECK-NEXT:      %2 = scf.for %arg3 = %c0 to %c1 step %c1 iter_args(%arg4 = %1) -> (tensor<1x112x112x64xf32>) {
-# CHECK-NEXT:        %extracted_slice = tensor.extract_slice %arg4[%arg3, 0, 0, 0] [1, 112, 112, 64] [1, 1, 1, 1] : tensor<1x112x112x64xf32> to tensor<1x112x112x64xf32>
-# CHECK-NEXT:        %4 = scf.for %arg5 = %c0 to %c112 step %c1 iter_args(%arg6 = %extracted_slice) -> (tensor<1x112x112x64xf32>) {
-# CHECK-NEXT:          %extracted_slice_0 = tensor.extract_slice %arg6[0, %arg5, 0, 0] [1, 1, 112, 64] [1, 1, 1, 1] : tensor<1x112x112x64xf32> to tensor<1x1x112x64xf32>
-# CHECK-NEXT:          %5 = scf.for %arg7 = %c0 to %c112 step %c1 iter_args(%arg8 = %extracted_slice_0) -> (tensor<1x1x112x64xf32>) {
-# CHECK-NEXT:            %extracted_slice_2 = tensor.extract_slice %arg8[0, 0, %arg7, 0] [1, 1, 1, 64] [1, 1, 1, 1] : tensor<1x1x112x64xf32> to tensor<1x1x1x64xf32>
-# CHECK-NEXT:            %6 = scf.for %arg9 = %c0 to %c64 step %c1 iter_args(%arg10 = %extracted_slice_2) -> (tensor<1x1x1x64xf32>) {
-# CHECK-NEXT:              %extracted_slice_4 = tensor.extract_slice %arg10[0, 0, 0, %arg9] [1, 1, 1, 1] [1, 1, 1, 1] : tensor<1x1x1x64xf32> to tensor<1x1x1x1xf32>
-# CHECK-NEXT:              %7 = linalg.fill {__xtc_id_O_0_} ins(%cst : f32) outs(%extracted_slice_4 : tensor<1x1x1x1xf32>) -> tensor<1x1x1x1xf32>
-# CHECK-NEXT:              %inserted_slice_5 = tensor.insert_slice %7 into %arg10[0, 0, 0, %arg9] [1, 1, 1, 1] [1, 1, 1, 1] : tensor<1x1x1x1xf32> into tensor<1x1x1x64xf32>
-# CHECK-NEXT:              scf.yield %inserted_slice_5 : tensor<1x1x1x64xf32>
-# CHECK-NEXT:            } {"./f"}
-# CHECK-NEXT:            %inserted_slice_3 = tensor.insert_slice %6 into %arg8[0, 0, %arg7, 0] [1, 1, 1, 64] [1, 1, 1, 1] : tensor<1x1x1x64xf32> into tensor<1x1x112x64xf32>
-# CHECK-NEXT:            scf.yield %inserted_slice_3 : tensor<1x1x112x64xf32>
-# CHECK-NEXT:          } {"./w"}
-# CHECK-NEXT:          %inserted_slice_1 = tensor.insert_slice %5 into %arg6[0, %arg5, 0, 0] [1, 1, 112, 64] [1, 1, 1, 1] : tensor<1x1x112x64xf32> into tensor<1x112x112x64xf32>
-# CHECK-NEXT:          scf.yield %inserted_slice_1 : tensor<1x112x112x64xf32>
-# CHECK-NEXT:        } {"./h"}
-# CHECK-NEXT:        %inserted_slice = tensor.insert_slice %4 into %arg4[%arg3, 0, 0, 0] [1, 112, 112, 64] [1, 1, 1, 1] : tensor<1x112x112x64xf32> into tensor<1x112x112x64xf32>
-# CHECK-NEXT:        scf.yield %inserted_slice : tensor<1x112x112x64xf32>
-# CHECK-NEXT:      } {"./b"}
+# CHECK-NEXT:      %2 = linalg.fill {__xtc_id_O_0_} ins(%cst : f32) outs(%1 : tensor<1x112x112x64xf32>) -> tensor<1x112x112x64xf32>
 # CHECK-NEXT:      %3 = scf.for %arg3 = %c0 to %c1 step %c1 iter_args(%arg4 = %2) -> (tensor<1x112x112x64xf32>) {
 # CHECK-NEXT:        %extracted_slice = tensor.extract_slice %arg0[%arg3, 0, 0, 0] [1, 229, 229, 3] [1, 1, 1, 1] : tensor<1x230x230x3xf32> to tensor<1x229x229x3xf32>
 # CHECK-NEXT:        %extracted_slice_0 = tensor.extract_slice %arg4[%arg3, 0, 0, 0] [1, 112, 112, 64] [1, 1, 1, 1] : tensor<1x112x112x64xf32> to tensor<1x112x112x64xf32>
@@ -386,47 +357,29 @@ print(f"CODE: {res}")
 # CHECK-NEXT:      %0 = ub.poison : f32
 # CHECK-NEXT:      %c7 = arith.constant 7 : index
 # CHECK-NEXT:      %c16 = arith.constant 16 : index
-# CHECK-NEXT:      %c4 = arith.constant 4 : index
 # CHECK-NEXT:      %c64 = arith.constant 64 : index
+# CHECK-NEXT:      %c4 = arith.constant 4 : index
 # CHECK-NEXT:      %c112 = arith.constant 112 : index
 # CHECK-NEXT:      %c1 = arith.constant 1 : index
 # CHECK-NEXT:      %c0 = arith.constant 0 : index
 # CHECK-NEXT:      %cst = arith.constant 0.000000e+00 : f32
-# CHECK-NEXT:      %1 = scf.for %arg3 = %c0 to %c112 step %c1 iter_args(%arg4 = %arg2) -> (memref<1x112x112x64xf32>) {
-# CHECK-NEXT:        %subview_0 = memref.subview %arg4[0, %arg3, 0, 0] [1, 1, 112, 64] [1, 1, 1, 1] : memref<1x112x112x64xf32> to memref<1x1x112x64xf32, strided<[802816, 7168, 64, 1], offset: ?>>
-# CHECK-NEXT:        %3 = scf.for %arg5 = %c0 to %c112 step %c1 iter_args(%arg6 = %subview_0) -> (memref<1x1x112x64xf32, strided<[802816, 7168, 64, 1], offset: ?>>) {
-# CHECK-NEXT:          %subview_2 = memref.subview %arg6[0, 0, %arg5, 0] [1, 1, 1, 64] [1, 1, 1, 1] : memref<1x1x112x64xf32, strided<[802816, 7168, 64, 1], offset: ?>> to memref<1x1x1x64xf32, strided<[802816, 7168, 64, 1], offset: ?>>
-# CHECK-NEXT:          %4 = scf.for %arg7 = %c0 to %c64 step %c1 iter_args(%arg8 = %subview_2) -> (memref<1x1x1x64xf32, strided<[802816, 7168, 64, 1], offset: ?>>) {
-# CHECK-NEXT:            %subview_4 = memref.subview %arg8[0, 0, 0, %arg7] [1, 1, 1, 1] [1, 1, 1, 1] : memref<1x1x1x64xf32, strided<[802816, 7168, 64, 1], offset: ?>> to memref<1x1x1x1xf32, strided<[802816, 7168, 64, 1], offset: ?>>
-# CHECK-NEXT:            linalg.fill {__xtc_id_O_0_} ins(%cst : f32) outs(%subview_4 : memref<1x1x1x1xf32, strided<[802816, 7168, 64, 1], offset: ?>>)
-# CHECK-NEXT:            %subview_5 = memref.subview %arg8[0, 0, 0, %arg7] [1, 1, 1, 1] [1, 1, 1, 1] : memref<1x1x1x64xf32, strided<[802816, 7168, 64, 1], offset: ?>> to memref<1x1x1x1xf32, strided<[802816, 7168, 64, 1], offset: ?>>
-# CHECK-NEXT:            memref.copy %subview_4, %subview_5 : memref<1x1x1x1xf32, strided<[802816, 7168, 64, 1], offset: ?>> to memref<1x1x1x1xf32, strided<[802816, 7168, 64, 1], offset: ?>>
-# CHECK-NEXT:            scf.yield %arg8 : memref<1x1x1x64xf32, strided<[802816, 7168, 64, 1], offset: ?>>
-# CHECK-NEXT:          } {"./f"}
-# CHECK-NEXT:          %subview_3 = memref.subview %arg6[0, 0, %arg5, 0] [1, 1, 1, 64] [1, 1, 1, 1] : memref<1x1x112x64xf32, strided<[802816, 7168, 64, 1], offset: ?>> to memref<1x1x1x64xf32, strided<[802816, 7168, 64, 1], offset: ?>>
-# CHECK-NEXT:          memref.copy %4, %subview_3 : memref<1x1x1x64xf32, strided<[802816, 7168, 64, 1], offset: ?>> to memref<1x1x1x64xf32, strided<[802816, 7168, 64, 1], offset: ?>>
-# CHECK-NEXT:          scf.yield %arg6 : memref<1x1x112x64xf32, strided<[802816, 7168, 64, 1], offset: ?>>
-# CHECK-NEXT:        } {"./w"}
-# CHECK-NEXT:        %subview_1 = memref.subview %arg4[0, %arg3, 0, 0] [1, 1, 112, 64] [1, 1, 1, 1] : memref<1x112x112x64xf32> to memref<1x1x112x64xf32, strided<[802816, 7168, 64, 1], offset: ?>>
-# CHECK-NEXT:        memref.copy %3, %subview_1 : memref<1x1x112x64xf32, strided<[802816, 7168, 64, 1], offset: ?>> to memref<1x1x112x64xf32, strided<[802816, 7168, 64, 1], offset: ?>>
-# CHECK-NEXT:        scf.yield %arg4 : memref<1x112x112x64xf32>
-# CHECK-NEXT:      } {"./h"}
+# CHECK-NEXT:      linalg.fill {__xtc_id_O_0_} ins(%cst : f32) outs(%arg2 : memref<1x112x112x64xf32>)
 # CHECK-NEXT:      %subview = memref.subview %arg0[0, 0, 0, 0] [1, 229, 229, 3] [1, 1, 1, 1] : memref<1x230x230x3xf32> to memref<1x229x229x3xf32, strided<[158700, 690, 3, 1]>>
-# CHECK-NEXT:      %2 = scf.for %arg3 = %c0 to %c112 step %c1 iter_args(%arg4 = %1) -> (memref<1x112x112x64xf32>) {
-# CHECK-NEXT:        %3 = affine.apply #map(%arg3)
-# CHECK-NEXT:        %subview_0 = memref.subview %subview[0, %3, 0, 0] [1, 7, 229, 3] [1, 1, 1, 1] : memref<1x229x229x3xf32, strided<[158700, 690, 3, 1]>> to memref<1x7x229x3xf32, strided<[158700, 690, 3, 1], offset: ?>>
+# CHECK-NEXT:      %1 = scf.for %arg3 = %c0 to %c112 step %c1 iter_args(%arg4 = %arg2) -> (memref<1x112x112x64xf32>) {
+# CHECK-NEXT:        %2 = affine.apply #map(%arg3)
+# CHECK-NEXT:        %subview_0 = memref.subview %subview[0, %2, 0, 0] [1, 7, 229, 3] [1, 1, 1, 1] : memref<1x229x229x3xf32, strided<[158700, 690, 3, 1]>> to memref<1x7x229x3xf32, strided<[158700, 690, 3, 1], offset: ?>>
 # CHECK-NEXT:        %subview_1 = memref.subview %arg4[0, %arg3, 0, 0] [1, 1, 112, 64] [1, 1, 1, 1] : memref<1x112x112x64xf32> to memref<1x1x112x64xf32, strided<[802816, 7168, 64, 1], offset: ?>>
-# CHECK-NEXT:        %4 = scf.for %arg5 = %c0 to %c112 step %c4 iter_args(%arg6 = %subview_1) -> (memref<1x1x112x64xf32, strided<[802816, 7168, 64, 1], offset: ?>>) {
-# CHECK-NEXT:          %5 = affine.apply #map(%arg5)
-# CHECK-NEXT:          %subview_3 = memref.subview %subview_0[0, 0, %5, 0] [1, 7, 13, 3] [1, 1, 1, 1] : memref<1x7x229x3xf32, strided<[158700, 690, 3, 1], offset: ?>> to memref<1x7x13x3xf32, strided<[158700, 690, 3, 1], offset: ?>>
+# CHECK-NEXT:        %3 = scf.for %arg5 = %c0 to %c112 step %c4 iter_args(%arg6 = %subview_1) -> (memref<1x1x112x64xf32, strided<[802816, 7168, 64, 1], offset: ?>>) {
+# CHECK-NEXT:          %4 = affine.apply #map(%arg5)
+# CHECK-NEXT:          %subview_3 = memref.subview %subview_0[0, 0, %4, 0] [1, 7, 13, 3] [1, 1, 1, 1] : memref<1x7x229x3xf32, strided<[158700, 690, 3, 1], offset: ?>> to memref<1x7x13x3xf32, strided<[158700, 690, 3, 1], offset: ?>>
 # CHECK-NEXT:          %subview_4 = memref.subview %arg6[0, 0, %arg5, 0] [1, 1, 4, 64] [1, 1, 1, 1] : memref<1x1x112x64xf32, strided<[802816, 7168, 64, 1], offset: ?>> to memref<1x1x4x64xf32, strided<[802816, 7168, 64, 1], offset: ?>>
-# CHECK-NEXT:          %6 = scf.for %arg7 = %c0 to %c64 step %c16 iter_args(%arg8 = %subview_4) -> (memref<1x1x4x64xf32, strided<[802816, 7168, 64, 1], offset: ?>>) {
+# CHECK-NEXT:          %5 = scf.for %arg7 = %c0 to %c64 step %c16 iter_args(%arg8 = %subview_4) -> (memref<1x1x4x64xf32, strided<[802816, 7168, 64, 1], offset: ?>>) {
 # CHECK-NEXT:            %subview_6 = memref.subview %arg1[0, 0, 0, %arg7] [7, 7, 3, 16] [1, 1, 1, 1] : memref<7x7x3x64xf32> to memref<7x7x3x16xf32, strided<[1344, 192, 64, 1], offset: ?>>
 # CHECK-NEXT:            %subview_7 = memref.subview %arg8[0, 0, 0, %arg7] [1, 1, 4, 16] [1, 1, 1, 1] : memref<1x1x4x64xf32, strided<[802816, 7168, 64, 1], offset: ?>> to memref<1x1x4x16xf32, strided<[802816, 7168, 64, 1], offset: ?>>
-# CHECK-NEXT:            %7 = scf.for %arg9 = %c0 to %c7 step %c1 iter_args(%arg10 = %subview_7) -> (memref<1x1x4x16xf32, strided<[802816, 7168, 64, 1], offset: ?>>) {
+# CHECK-NEXT:            %6 = scf.for %arg9 = %c0 to %c7 step %c1 iter_args(%arg10 = %subview_7) -> (memref<1x1x4x16xf32, strided<[802816, 7168, 64, 1], offset: ?>>) {
 # CHECK-NEXT:              %subview_9 = memref.subview %subview_3[0, %arg9, 0, 0] [1, 1, 13, 3] [1, 1, 1, 1] : memref<1x7x13x3xf32, strided<[158700, 690, 3, 1], offset: ?>> to memref<1x1x13x3xf32, strided<[158700, 690, 3, 1], offset: ?>>
 # CHECK-NEXT:              %subview_10 = memref.subview %subview_6[%arg9, 0, 0, 0] [1, 7, 3, 16] [1, 1, 1, 1] : memref<7x7x3x16xf32, strided<[1344, 192, 64, 1], offset: ?>> to memref<1x7x3x16xf32, strided<[1344, 192, 64, 1], offset: ?>>
-# CHECK-NEXT:              %8 = scf.for %arg11 = %c0 to %c7 step %c1 iter_args(%arg12 = %arg10) -> (memref<1x1x4x16xf32, strided<[802816, 7168, 64, 1], offset: ?>>) {
+# CHECK-NEXT:              %7 = scf.for %arg11 = %c0 to %c7 step %c1 iter_args(%arg12 = %arg10) -> (memref<1x1x4x16xf32, strided<[802816, 7168, 64, 1], offset: ?>>) {
 # CHECK-NEXT:                %subview_11 = memref.subview %subview_9[0, 0, %arg11, 0] [1, 1, 7, 3] [1, 1, 1, 1] : memref<1x1x13x3xf32, strided<[158700, 690, 3, 1], offset: ?>> to memref<1x1x7x3xf32, strided<[158700, 690, 3, 1], offset: ?>>
 # CHECK-NEXT:                %subview_12 = memref.subview %subview_10[0, %arg11, 0, 0] [1, 1, 3, 16] [1, 1, 1, 1] : memref<1x7x3x16xf32, strided<[1344, 192, 64, 1], offset: ?>> to memref<1x1x3x16xf32, strided<[1344, 192, 64, 1], offset: ?>>
 # CHECK-NEXT:                %subview_13 = memref.subview %subview_11[0, 0, 0, 0] [1, 1, 7, 1] [1, 1, 1, 1] : memref<1x1x7x3xf32, strided<[158700, 690, 3, 1], offset: ?>> to memref<1x1x7x1xf32, strided<[158700, 690, 3, 1], offset: ?>>
@@ -436,13 +389,13 @@ print(f"CODE: {res}")
 # CHECK-NEXT:                %subview_17 = memref.subview %subview_15[0, 0, 0, 0] [1, 1, 1, 1] [1, 1, 1, 1] : memref<1x1x1x1xf32, strided<[158700, 690, 3, 1], offset: ?>> to memref<f32, strided<[], offset: ?>>
 # CHECK-NEXT:                %subview_18 = memref.subview %subview_14[0, 0, 0, 0] [1, 1, 1, 16] [1, 1, 1, 1] : memref<1x1x1x16xf32, strided<[1344, 192, 64, 1], offset: ?>> to memref<16xf32, strided<[1], offset: ?>>
 # CHECK-NEXT:                %subview_19 = memref.subview %subview_16[0, 0, 0, 0] [1, 1, 1, 16] [1, 1, 1, 1] : memref<1x1x1x16xf32, strided<[802816, 7168, 64, 1], offset: ?>> to memref<16xf32, strided<[1], offset: ?>>
-# CHECK-NEXT:                %9 = memref.load %subview_17[] : memref<f32, strided<[], offset: ?>>
-# CHECK-NEXT:                %10 = vector.broadcast %9 : f32 to vector<16xf32>
-# CHECK-NEXT:                %11 = vector.transfer_read %subview_18[%c0], %0 {in_bounds = [true]} : memref<16xf32, strided<[1], offset: ?>>, vector<16xf32>
-# CHECK-NEXT:                %12 = vector.transfer_read %subview_19[%c0], %0 {in_bounds = [true]} : memref<16xf32, strided<[1], offset: ?>>, vector<16xf32>
-# CHECK-NEXT:                %13 = arith.mulf %10, %11 fastmath<fast> : vector<16xf32>
-# CHECK-NEXT:                %14 = arith.addf %12, %13 fastmath<fast> : vector<16xf32>
-# CHECK-NEXT:                vector.transfer_write %14, %subview_19[%c0] {in_bounds = [true]} : vector<16xf32>, memref<16xf32, strided<[1], offset: ?>>
+# CHECK-NEXT:                %8 = memref.load %subview_17[] : memref<f32, strided<[], offset: ?>>
+# CHECK-NEXT:                %9 = vector.broadcast %8 : f32 to vector<16xf32>
+# CHECK-NEXT:                %10 = vector.transfer_read %subview_18[%c0], %0 {in_bounds = [true]} : memref<16xf32, strided<[1], offset: ?>>, vector<16xf32>
+# CHECK-NEXT:                %11 = vector.transfer_read %subview_19[%c0], %0 {in_bounds = [true]} : memref<16xf32, strided<[1], offset: ?>>, vector<16xf32>
+# CHECK-NEXT:                %12 = arith.mulf %9, %10 fastmath<fast> : vector<16xf32>
+# CHECK-NEXT:                %13 = arith.addf %11, %12 fastmath<fast> : vector<16xf32>
+# CHECK-NEXT:                vector.transfer_write %13, %subview_19[%c0] {in_bounds = [true]} : vector<16xf32>, memref<16xf32, strided<[1], offset: ?>>
 # CHECK-NEXT:                %subview_20 = memref.subview %subview_16[0, 0, 0, 0] [1, 1, 1, 16] [1, 1, 1, 1] : memref<1x1x1x16xf32, strided<[802816, 7168, 64, 1], offset: ?>> to memref<16xf32, strided<[1], offset: ?>>
 # CHECK-NEXT:                memref.copy %subview_19, %subview_20 : memref<16xf32, strided<[1], offset: ?>> to memref<16xf32, strided<[1], offset: ?>>
 # CHECK-NEXT:                %subview_21 = memref.subview %arg12[0, 0, 0, 0] [1, 1, 1, 16] [1, 1, 1, 1] : memref<1x1x4x16xf32, strided<[802816, 7168, 64, 1], offset: ?>> to memref<1x1x1x16xf32, strided<[802816, 7168, 64, 1], offset: ?>>
@@ -451,12 +404,12 @@ print(f"CODE: {res}")
 # CHECK-NEXT:                %subview_23 = memref.subview %arg12[0, 0, 1, 0] [1, 1, 1, 16] [1, 1, 1, 1] : memref<1x1x4x16xf32, strided<[802816, 7168, 64, 1], offset: ?>> to memref<1x1x1x16xf32, strided<[802816, 7168, 64, 1], offset: ?>>
 # CHECK-NEXT:                %subview_24 = memref.subview %subview_22[0, 0, 0, 0] [1, 1, 1, 1] [1, 1, 1, 1] : memref<1x1x1x1xf32, strided<[158700, 690, 3, 1], offset: ?>> to memref<f32, strided<[], offset: ?>>
 # CHECK-NEXT:                %subview_25 = memref.subview %subview_23[0, 0, 0, 0] [1, 1, 1, 16] [1, 1, 1, 1] : memref<1x1x1x16xf32, strided<[802816, 7168, 64, 1], offset: ?>> to memref<16xf32, strided<[1], offset: ?>>
-# CHECK-NEXT:                %15 = memref.load %subview_24[] : memref<f32, strided<[], offset: ?>>
-# CHECK-NEXT:                %16 = vector.broadcast %15 : f32 to vector<16xf32>
-# CHECK-NEXT:                %17 = vector.transfer_read %subview_25[%c0], %0 {in_bounds = [true]} : memref<16xf32, strided<[1], offset: ?>>, vector<16xf32>
-# CHECK-NEXT:                %18 = arith.mulf %16, %11 fastmath<fast> : vector<16xf32>
-# CHECK-NEXT:                %19 = arith.addf %17, %18 fastmath<fast> : vector<16xf32>
-# CHECK-NEXT:                vector.transfer_write %19, %subview_25[%c0] {in_bounds = [true]} : vector<16xf32>, memref<16xf32, strided<[1], offset: ?>>
+# CHECK-NEXT:                %14 = memref.load %subview_24[] : memref<f32, strided<[], offset: ?>>
+# CHECK-NEXT:                %15 = vector.broadcast %14 : f32 to vector<16xf32>
+# CHECK-NEXT:                %16 = vector.transfer_read %subview_25[%c0], %0 {in_bounds = [true]} : memref<16xf32, strided<[1], offset: ?>>, vector<16xf32>
+# CHECK-NEXT:                %17 = arith.mulf %15, %10 fastmath<fast> : vector<16xf32>
+# CHECK-NEXT:                %18 = arith.addf %16, %17 fastmath<fast> : vector<16xf32>
+# CHECK-NEXT:                vector.transfer_write %18, %subview_25[%c0] {in_bounds = [true]} : vector<16xf32>, memref<16xf32, strided<[1], offset: ?>>
 # CHECK-NEXT:                %subview_26 = memref.subview %subview_23[0, 0, 0, 0] [1, 1, 1, 16] [1, 1, 1, 1] : memref<1x1x1x16xf32, strided<[802816, 7168, 64, 1], offset: ?>> to memref<16xf32, strided<[1], offset: ?>>
 # CHECK-NEXT:                memref.copy %subview_25, %subview_26 : memref<16xf32, strided<[1], offset: ?>> to memref<16xf32, strided<[1], offset: ?>>
 # CHECK-NEXT:                %subview_27 = memref.subview %arg12[0, 0, 1, 0] [1, 1, 1, 16] [1, 1, 1, 1] : memref<1x1x4x16xf32, strided<[802816, 7168, 64, 1], offset: ?>> to memref<1x1x1x16xf32, strided<[802816, 7168, 64, 1], offset: ?>>
@@ -465,12 +418,12 @@ print(f"CODE: {res}")
 # CHECK-NEXT:                %subview_29 = memref.subview %arg12[0, 0, 2, 0] [1, 1, 1, 16] [1, 1, 1, 1] : memref<1x1x4x16xf32, strided<[802816, 7168, 64, 1], offset: ?>> to memref<1x1x1x16xf32, strided<[802816, 7168, 64, 1], offset: ?>>
 # CHECK-NEXT:                %subview_30 = memref.subview %subview_28[0, 0, 0, 0] [1, 1, 1, 1] [1, 1, 1, 1] : memref<1x1x1x1xf32, strided<[158700, 690, 3, 1], offset: ?>> to memref<f32, strided<[], offset: ?>>
 # CHECK-NEXT:                %subview_31 = memref.subview %subview_29[0, 0, 0, 0] [1, 1, 1, 16] [1, 1, 1, 1] : memref<1x1x1x16xf32, strided<[802816, 7168, 64, 1], offset: ?>> to memref<16xf32, strided<[1], offset: ?>>
-# CHECK-NEXT:                %20 = memref.load %subview_30[] : memref<f32, strided<[], offset: ?>>
-# CHECK-NEXT:                %21 = vector.broadcast %20 : f32 to vector<16xf32>
-# CHECK-NEXT:                %22 = vector.transfer_read %subview_31[%c0], %0 {in_bounds = [true]} : memref<16xf32, strided<[1], offset: ?>>, vector<16xf32>
-# CHECK-NEXT:                %23 = arith.mulf %21, %11 fastmath<fast> : vector<16xf32>
-# CHECK-NEXT:                %24 = arith.addf %22, %23 fastmath<fast> : vector<16xf32>
-# CHECK-NEXT:                vector.transfer_write %24, %subview_31[%c0] {in_bounds = [true]} : vector<16xf32>, memref<16xf32, strided<[1], offset: ?>>
+# CHECK-NEXT:                %19 = memref.load %subview_30[] : memref<f32, strided<[], offset: ?>>
+# CHECK-NEXT:                %20 = vector.broadcast %19 : f32 to vector<16xf32>
+# CHECK-NEXT:                %21 = vector.transfer_read %subview_31[%c0], %0 {in_bounds = [true]} : memref<16xf32, strided<[1], offset: ?>>, vector<16xf32>
+# CHECK-NEXT:                %22 = arith.mulf %20, %10 fastmath<fast> : vector<16xf32>
+# CHECK-NEXT:                %23 = arith.addf %21, %22 fastmath<fast> : vector<16xf32>
+# CHECK-NEXT:                vector.transfer_write %23, %subview_31[%c0] {in_bounds = [true]} : vector<16xf32>, memref<16xf32, strided<[1], offset: ?>>
 # CHECK-NEXT:                %subview_32 = memref.subview %subview_29[0, 0, 0, 0] [1, 1, 1, 16] [1, 1, 1, 1] : memref<1x1x1x16xf32, strided<[802816, 7168, 64, 1], offset: ?>> to memref<16xf32, strided<[1], offset: ?>>
 # CHECK-NEXT:                memref.copy %subview_31, %subview_32 : memref<16xf32, strided<[1], offset: ?>> to memref<16xf32, strided<[1], offset: ?>>
 # CHECK-NEXT:                %subview_33 = memref.subview %arg12[0, 0, 2, 0] [1, 1, 1, 16] [1, 1, 1, 1] : memref<1x1x4x16xf32, strided<[802816, 7168, 64, 1], offset: ?>> to memref<1x1x1x16xf32, strided<[802816, 7168, 64, 1], offset: ?>>
@@ -479,12 +432,12 @@ print(f"CODE: {res}")
 # CHECK-NEXT:                %subview_35 = memref.subview %arg12[0, 0, 3, 0] [1, 1, 1, 16] [1, 1, 1, 1] : memref<1x1x4x16xf32, strided<[802816, 7168, 64, 1], offset: ?>> to memref<1x1x1x16xf32, strided<[802816, 7168, 64, 1], offset: ?>>
 # CHECK-NEXT:                %subview_36 = memref.subview %subview_34[0, 0, 0, 0] [1, 1, 1, 1] [1, 1, 1, 1] : memref<1x1x1x1xf32, strided<[158700, 690, 3, 1], offset: ?>> to memref<f32, strided<[], offset: ?>>
 # CHECK-NEXT:                %subview_37 = memref.subview %subview_35[0, 0, 0, 0] [1, 1, 1, 16] [1, 1, 1, 1] : memref<1x1x1x16xf32, strided<[802816, 7168, 64, 1], offset: ?>> to memref<16xf32, strided<[1], offset: ?>>
-# CHECK-NEXT:                %25 = memref.load %subview_36[] : memref<f32, strided<[], offset: ?>>
-# CHECK-NEXT:                %26 = vector.broadcast %25 : f32 to vector<16xf32>
-# CHECK-NEXT:                %27 = vector.transfer_read %subview_37[%c0], %0 {in_bounds = [true]} : memref<16xf32, strided<[1], offset: ?>>, vector<16xf32>
-# CHECK-NEXT:                %28 = arith.mulf %26, %11 fastmath<fast> : vector<16xf32>
-# CHECK-NEXT:                %29 = arith.addf %27, %28 fastmath<fast> : vector<16xf32>
-# CHECK-NEXT:                vector.transfer_write %29, %subview_37[%c0] {in_bounds = [true]} : vector<16xf32>, memref<16xf32, strided<[1], offset: ?>>
+# CHECK-NEXT:                %24 = memref.load %subview_36[] : memref<f32, strided<[], offset: ?>>
+# CHECK-NEXT:                %25 = vector.broadcast %24 : f32 to vector<16xf32>
+# CHECK-NEXT:                %26 = vector.transfer_read %subview_37[%c0], %0 {in_bounds = [true]} : memref<16xf32, strided<[1], offset: ?>>, vector<16xf32>
+# CHECK-NEXT:                %27 = arith.mulf %25, %10 fastmath<fast> : vector<16xf32>
+# CHECK-NEXT:                %28 = arith.addf %26, %27 fastmath<fast> : vector<16xf32>
+# CHECK-NEXT:                vector.transfer_write %28, %subview_37[%c0] {in_bounds = [true]} : vector<16xf32>, memref<16xf32, strided<[1], offset: ?>>
 # CHECK-NEXT:                %subview_38 = memref.subview %subview_35[0, 0, 0, 0] [1, 1, 1, 16] [1, 1, 1, 1] : memref<1x1x1x16xf32, strided<[802816, 7168, 64, 1], offset: ?>> to memref<16xf32, strided<[1], offset: ?>>
 # CHECK-NEXT:                memref.copy %subview_37, %subview_38 : memref<16xf32, strided<[1], offset: ?>> to memref<16xf32, strided<[1], offset: ?>>
 # CHECK-NEXT:                %subview_39 = memref.subview %arg12[0, 0, 3, 0] [1, 1, 1, 16] [1, 1, 1, 1] : memref<1x1x4x16xf32, strided<[802816, 7168, 64, 1], offset: ?>> to memref<1x1x1x16xf32, strided<[802816, 7168, 64, 1], offset: ?>>
@@ -496,13 +449,13 @@ print(f"CODE: {res}")
 # CHECK-NEXT:                %subview_44 = memref.subview %subview_42[0, 0, 0, 0] [1, 1, 1, 1] [1, 1, 1, 1] : memref<1x1x1x1xf32, strided<[158700, 690, 3, 1], offset: ?>> to memref<f32, strided<[], offset: ?>>
 # CHECK-NEXT:                %subview_45 = memref.subview %subview_41[0, 0, 0, 0] [1, 1, 1, 16] [1, 1, 1, 1] : memref<1x1x1x16xf32, strided<[1344, 192, 64, 1], offset: ?>> to memref<16xf32, strided<[1], offset: ?>>
 # CHECK-NEXT:                %subview_46 = memref.subview %subview_43[0, 0, 0, 0] [1, 1, 1, 16] [1, 1, 1, 1] : memref<1x1x1x16xf32, strided<[802816, 7168, 64, 1], offset: ?>> to memref<16xf32, strided<[1], offset: ?>>
-# CHECK-NEXT:                %30 = memref.load %subview_44[] : memref<f32, strided<[], offset: ?>>
-# CHECK-NEXT:                %31 = vector.broadcast %30 : f32 to vector<16xf32>
-# CHECK-NEXT:                %32 = vector.transfer_read %subview_45[%c0], %0 {in_bounds = [true]} : memref<16xf32, strided<[1], offset: ?>>, vector<16xf32>
-# CHECK-NEXT:                %33 = vector.transfer_read %subview_46[%c0], %0 {in_bounds = [true]} : memref<16xf32, strided<[1], offset: ?>>, vector<16xf32>
-# CHECK-NEXT:                %34 = arith.mulf %31, %32 fastmath<fast> : vector<16xf32>
-# CHECK-NEXT:                %35 = arith.addf %33, %34 fastmath<fast> : vector<16xf32>
-# CHECK-NEXT:                vector.transfer_write %35, %subview_46[%c0] {in_bounds = [true]} : vector<16xf32>, memref<16xf32, strided<[1], offset: ?>>
+# CHECK-NEXT:                %29 = memref.load %subview_44[] : memref<f32, strided<[], offset: ?>>
+# CHECK-NEXT:                %30 = vector.broadcast %29 : f32 to vector<16xf32>
+# CHECK-NEXT:                %31 = vector.transfer_read %subview_45[%c0], %0 {in_bounds = [true]} : memref<16xf32, strided<[1], offset: ?>>, vector<16xf32>
+# CHECK-NEXT:                %32 = vector.transfer_read %subview_46[%c0], %0 {in_bounds = [true]} : memref<16xf32, strided<[1], offset: ?>>, vector<16xf32>
+# CHECK-NEXT:                %33 = arith.mulf %30, %31 fastmath<fast> : vector<16xf32>
+# CHECK-NEXT:                %34 = arith.addf %32, %33 fastmath<fast> : vector<16xf32>
+# CHECK-NEXT:                vector.transfer_write %34, %subview_46[%c0] {in_bounds = [true]} : vector<16xf32>, memref<16xf32, strided<[1], offset: ?>>
 # CHECK-NEXT:                %subview_47 = memref.subview %subview_43[0, 0, 0, 0] [1, 1, 1, 16] [1, 1, 1, 1] : memref<1x1x1x16xf32, strided<[802816, 7168, 64, 1], offset: ?>> to memref<16xf32, strided<[1], offset: ?>>
 # CHECK-NEXT:                memref.copy %subview_46, %subview_47 : memref<16xf32, strided<[1], offset: ?>> to memref<16xf32, strided<[1], offset: ?>>
 # CHECK-NEXT:                %subview_48 = memref.subview %arg12[0, 0, 0, 0] [1, 1, 1, 16] [1, 1, 1, 1] : memref<1x1x4x16xf32, strided<[802816, 7168, 64, 1], offset: ?>> to memref<1x1x1x16xf32, strided<[802816, 7168, 64, 1], offset: ?>>
@@ -511,12 +464,12 @@ print(f"CODE: {res}")
 # CHECK-NEXT:                %subview_50 = memref.subview %arg12[0, 0, 1, 0] [1, 1, 1, 16] [1, 1, 1, 1] : memref<1x1x4x16xf32, strided<[802816, 7168, 64, 1], offset: ?>> to memref<1x1x1x16xf32, strided<[802816, 7168, 64, 1], offset: ?>>
 # CHECK-NEXT:                %subview_51 = memref.subview %subview_49[0, 0, 0, 0] [1, 1, 1, 1] [1, 1, 1, 1] : memref<1x1x1x1xf32, strided<[158700, 690, 3, 1], offset: ?>> to memref<f32, strided<[], offset: ?>>
 # CHECK-NEXT:                %subview_52 = memref.subview %subview_50[0, 0, 0, 0] [1, 1, 1, 16] [1, 1, 1, 1] : memref<1x1x1x16xf32, strided<[802816, 7168, 64, 1], offset: ?>> to memref<16xf32, strided<[1], offset: ?>>
-# CHECK-NEXT:                %36 = memref.load %subview_51[] : memref<f32, strided<[], offset: ?>>
-# CHECK-NEXT:                %37 = vector.broadcast %36 : f32 to vector<16xf32>
-# CHECK-NEXT:                %38 = vector.transfer_read %subview_52[%c0], %0 {in_bounds = [true]} : memref<16xf32, strided<[1], offset: ?>>, vector<16xf32>
-# CHECK-NEXT:                %39 = arith.mulf %37, %32 fastmath<fast> : vector<16xf32>
-# CHECK-NEXT:                %40 = arith.addf %38, %39 fastmath<fast> : vector<16xf32>
-# CHECK-NEXT:                vector.transfer_write %40, %subview_52[%c0] {in_bounds = [true]} : vector<16xf32>, memref<16xf32, strided<[1], offset: ?>>
+# CHECK-NEXT:                %35 = memref.load %subview_51[] : memref<f32, strided<[], offset: ?>>
+# CHECK-NEXT:                %36 = vector.broadcast %35 : f32 to vector<16xf32>
+# CHECK-NEXT:                %37 = vector.transfer_read %subview_52[%c0], %0 {in_bounds = [true]} : memref<16xf32, strided<[1], offset: ?>>, vector<16xf32>
+# CHECK-NEXT:                %38 = arith.mulf %36, %31 fastmath<fast> : vector<16xf32>
+# CHECK-NEXT:                %39 = arith.addf %37, %38 fastmath<fast> : vector<16xf32>
+# CHECK-NEXT:                vector.transfer_write %39, %subview_52[%c0] {in_bounds = [true]} : vector<16xf32>, memref<16xf32, strided<[1], offset: ?>>
 # CHECK-NEXT:                %subview_53 = memref.subview %subview_50[0, 0, 0, 0] [1, 1, 1, 16] [1, 1, 1, 1] : memref<1x1x1x16xf32, strided<[802816, 7168, 64, 1], offset: ?>> to memref<16xf32, strided<[1], offset: ?>>
 # CHECK-NEXT:                memref.copy %subview_52, %subview_53 : memref<16xf32, strided<[1], offset: ?>> to memref<16xf32, strided<[1], offset: ?>>
 # CHECK-NEXT:                %subview_54 = memref.subview %arg12[0, 0, 1, 0] [1, 1, 1, 16] [1, 1, 1, 1] : memref<1x1x4x16xf32, strided<[802816, 7168, 64, 1], offset: ?>> to memref<1x1x1x16xf32, strided<[802816, 7168, 64, 1], offset: ?>>
@@ -525,12 +478,12 @@ print(f"CODE: {res}")
 # CHECK-NEXT:                %subview_56 = memref.subview %arg12[0, 0, 2, 0] [1, 1, 1, 16] [1, 1, 1, 1] : memref<1x1x4x16xf32, strided<[802816, 7168, 64, 1], offset: ?>> to memref<1x1x1x16xf32, strided<[802816, 7168, 64, 1], offset: ?>>
 # CHECK-NEXT:                %subview_57 = memref.subview %subview_55[0, 0, 0, 0] [1, 1, 1, 1] [1, 1, 1, 1] : memref<1x1x1x1xf32, strided<[158700, 690, 3, 1], offset: ?>> to memref<f32, strided<[], offset: ?>>
 # CHECK-NEXT:                %subview_58 = memref.subview %subview_56[0, 0, 0, 0] [1, 1, 1, 16] [1, 1, 1, 1] : memref<1x1x1x16xf32, strided<[802816, 7168, 64, 1], offset: ?>> to memref<16xf32, strided<[1], offset: ?>>
-# CHECK-NEXT:                %41 = memref.load %subview_57[] : memref<f32, strided<[], offset: ?>>
-# CHECK-NEXT:                %42 = vector.broadcast %41 : f32 to vector<16xf32>
-# CHECK-NEXT:                %43 = vector.transfer_read %subview_58[%c0], %0 {in_bounds = [true]} : memref<16xf32, strided<[1], offset: ?>>, vector<16xf32>
-# CHECK-NEXT:                %44 = arith.mulf %42, %32 fastmath<fast> : vector<16xf32>
-# CHECK-NEXT:                %45 = arith.addf %43, %44 fastmath<fast> : vector<16xf32>
-# CHECK-NEXT:                vector.transfer_write %45, %subview_58[%c0] {in_bounds = [true]} : vector<16xf32>, memref<16xf32, strided<[1], offset: ?>>
+# CHECK-NEXT:                %40 = memref.load %subview_57[] : memref<f32, strided<[], offset: ?>>
+# CHECK-NEXT:                %41 = vector.broadcast %40 : f32 to vector<16xf32>
+# CHECK-NEXT:                %42 = vector.transfer_read %subview_58[%c0], %0 {in_bounds = [true]} : memref<16xf32, strided<[1], offset: ?>>, vector<16xf32>
+# CHECK-NEXT:                %43 = arith.mulf %41, %31 fastmath<fast> : vector<16xf32>
+# CHECK-NEXT:                %44 = arith.addf %42, %43 fastmath<fast> : vector<16xf32>
+# CHECK-NEXT:                vector.transfer_write %44, %subview_58[%c0] {in_bounds = [true]} : vector<16xf32>, memref<16xf32, strided<[1], offset: ?>>
 # CHECK-NEXT:                %subview_59 = memref.subview %subview_56[0, 0, 0, 0] [1, 1, 1, 16] [1, 1, 1, 1] : memref<1x1x1x16xf32, strided<[802816, 7168, 64, 1], offset: ?>> to memref<16xf32, strided<[1], offset: ?>>
 # CHECK-NEXT:                memref.copy %subview_58, %subview_59 : memref<16xf32, strided<[1], offset: ?>> to memref<16xf32, strided<[1], offset: ?>>
 # CHECK-NEXT:                %subview_60 = memref.subview %arg12[0, 0, 2, 0] [1, 1, 1, 16] [1, 1, 1, 1] : memref<1x1x4x16xf32, strided<[802816, 7168, 64, 1], offset: ?>> to memref<1x1x1x16xf32, strided<[802816, 7168, 64, 1], offset: ?>>
@@ -539,12 +492,12 @@ print(f"CODE: {res}")
 # CHECK-NEXT:                %subview_62 = memref.subview %arg12[0, 0, 3, 0] [1, 1, 1, 16] [1, 1, 1, 1] : memref<1x1x4x16xf32, strided<[802816, 7168, 64, 1], offset: ?>> to memref<1x1x1x16xf32, strided<[802816, 7168, 64, 1], offset: ?>>
 # CHECK-NEXT:                %subview_63 = memref.subview %subview_61[0, 0, 0, 0] [1, 1, 1, 1] [1, 1, 1, 1] : memref<1x1x1x1xf32, strided<[158700, 690, 3, 1], offset: ?>> to memref<f32, strided<[], offset: ?>>
 # CHECK-NEXT:                %subview_64 = memref.subview %subview_62[0, 0, 0, 0] [1, 1, 1, 16] [1, 1, 1, 1] : memref<1x1x1x16xf32, strided<[802816, 7168, 64, 1], offset: ?>> to memref<16xf32, strided<[1], offset: ?>>
-# CHECK-NEXT:                %46 = memref.load %subview_63[] : memref<f32, strided<[], offset: ?>>
-# CHECK-NEXT:                %47 = vector.broadcast %46 : f32 to vector<16xf32>
-# CHECK-NEXT:                %48 = vector.transfer_read %subview_64[%c0], %0 {in_bounds = [true]} : memref<16xf32, strided<[1], offset: ?>>, vector<16xf32>
-# CHECK-NEXT:                %49 = arith.mulf %47, %32 fastmath<fast> : vector<16xf32>
-# CHECK-NEXT:                %50 = arith.addf %48, %49 fastmath<fast> : vector<16xf32>
-# CHECK-NEXT:                vector.transfer_write %50, %subview_64[%c0] {in_bounds = [true]} : vector<16xf32>, memref<16xf32, strided<[1], offset: ?>>
+# CHECK-NEXT:                %45 = memref.load %subview_63[] : memref<f32, strided<[], offset: ?>>
+# CHECK-NEXT:                %46 = vector.broadcast %45 : f32 to vector<16xf32>
+# CHECK-NEXT:                %47 = vector.transfer_read %subview_64[%c0], %0 {in_bounds = [true]} : memref<16xf32, strided<[1], offset: ?>>, vector<16xf32>
+# CHECK-NEXT:                %48 = arith.mulf %46, %31 fastmath<fast> : vector<16xf32>
+# CHECK-NEXT:                %49 = arith.addf %47, %48 fastmath<fast> : vector<16xf32>
+# CHECK-NEXT:                vector.transfer_write %49, %subview_64[%c0] {in_bounds = [true]} : vector<16xf32>, memref<16xf32, strided<[1], offset: ?>>
 # CHECK-NEXT:                %subview_65 = memref.subview %subview_62[0, 0, 0, 0] [1, 1, 1, 16] [1, 1, 1, 1] : memref<1x1x1x16xf32, strided<[802816, 7168, 64, 1], offset: ?>> to memref<16xf32, strided<[1], offset: ?>>
 # CHECK-NEXT:                memref.copy %subview_64, %subview_65 : memref<16xf32, strided<[1], offset: ?>> to memref<16xf32, strided<[1], offset: ?>>
 # CHECK-NEXT:                %subview_66 = memref.subview %arg12[0, 0, 3, 0] [1, 1, 1, 16] [1, 1, 1, 1] : memref<1x1x4x16xf32, strided<[802816, 7168, 64, 1], offset: ?>> to memref<1x1x1x16xf32, strided<[802816, 7168, 64, 1], offset: ?>>
@@ -556,13 +509,13 @@ print(f"CODE: {res}")
 # CHECK-NEXT:                %subview_71 = memref.subview %subview_69[0, 0, 0, 0] [1, 1, 1, 1] [1, 1, 1, 1] : memref<1x1x1x1xf32, strided<[158700, 690, 3, 1], offset: ?>> to memref<f32, strided<[], offset: ?>>
 # CHECK-NEXT:                %subview_72 = memref.subview %subview_68[0, 0, 0, 0] [1, 1, 1, 16] [1, 1, 1, 1] : memref<1x1x1x16xf32, strided<[1344, 192, 64, 1], offset: ?>> to memref<16xf32, strided<[1], offset: ?>>
 # CHECK-NEXT:                %subview_73 = memref.subview %subview_70[0, 0, 0, 0] [1, 1, 1, 16] [1, 1, 1, 1] : memref<1x1x1x16xf32, strided<[802816, 7168, 64, 1], offset: ?>> to memref<16xf32, strided<[1], offset: ?>>
-# CHECK-NEXT:                %51 = memref.load %subview_71[] : memref<f32, strided<[], offset: ?>>
-# CHECK-NEXT:                %52 = vector.broadcast %51 : f32 to vector<16xf32>
-# CHECK-NEXT:                %53 = vector.transfer_read %subview_72[%c0], %0 {in_bounds = [true]} : memref<16xf32, strided<[1], offset: ?>>, vector<16xf32>
-# CHECK-NEXT:                %54 = vector.transfer_read %subview_73[%c0], %0 {in_bounds = [true]} : memref<16xf32, strided<[1], offset: ?>>, vector<16xf32>
-# CHECK-NEXT:                %55 = arith.mulf %52, %53 fastmath<fast> : vector<16xf32>
-# CHECK-NEXT:                %56 = arith.addf %54, %55 fastmath<fast> : vector<16xf32>
-# CHECK-NEXT:                vector.transfer_write %56, %subview_73[%c0] {in_bounds = [true]} : vector<16xf32>, memref<16xf32, strided<[1], offset: ?>>
+# CHECK-NEXT:                %50 = memref.load %subview_71[] : memref<f32, strided<[], offset: ?>>
+# CHECK-NEXT:                %51 = vector.broadcast %50 : f32 to vector<16xf32>
+# CHECK-NEXT:                %52 = vector.transfer_read %subview_72[%c0], %0 {in_bounds = [true]} : memref<16xf32, strided<[1], offset: ?>>, vector<16xf32>
+# CHECK-NEXT:                %53 = vector.transfer_read %subview_73[%c0], %0 {in_bounds = [true]} : memref<16xf32, strided<[1], offset: ?>>, vector<16xf32>
+# CHECK-NEXT:                %54 = arith.mulf %51, %52 fastmath<fast> : vector<16xf32>
+# CHECK-NEXT:                %55 = arith.addf %53, %54 fastmath<fast> : vector<16xf32>
+# CHECK-NEXT:                vector.transfer_write %55, %subview_73[%c0] {in_bounds = [true]} : vector<16xf32>, memref<16xf32, strided<[1], offset: ?>>
 # CHECK-NEXT:                %subview_74 = memref.subview %subview_70[0, 0, 0, 0] [1, 1, 1, 16] [1, 1, 1, 1] : memref<1x1x1x16xf32, strided<[802816, 7168, 64, 1], offset: ?>> to memref<16xf32, strided<[1], offset: ?>>
 # CHECK-NEXT:                memref.copy %subview_73, %subview_74 : memref<16xf32, strided<[1], offset: ?>> to memref<16xf32, strided<[1], offset: ?>>
 # CHECK-NEXT:                %subview_75 = memref.subview %arg12[0, 0, 0, 0] [1, 1, 1, 16] [1, 1, 1, 1] : memref<1x1x4x16xf32, strided<[802816, 7168, 64, 1], offset: ?>> to memref<1x1x1x16xf32, strided<[802816, 7168, 64, 1], offset: ?>>
@@ -571,12 +524,12 @@ print(f"CODE: {res}")
 # CHECK-NEXT:                %subview_77 = memref.subview %arg12[0, 0, 1, 0] [1, 1, 1, 16] [1, 1, 1, 1] : memref<1x1x4x16xf32, strided<[802816, 7168, 64, 1], offset: ?>> to memref<1x1x1x16xf32, strided<[802816, 7168, 64, 1], offset: ?>>
 # CHECK-NEXT:                %subview_78 = memref.subview %subview_76[0, 0, 0, 0] [1, 1, 1, 1] [1, 1, 1, 1] : memref<1x1x1x1xf32, strided<[158700, 690, 3, 1], offset: ?>> to memref<f32, strided<[], offset: ?>>
 # CHECK-NEXT:                %subview_79 = memref.subview %subview_77[0, 0, 0, 0] [1, 1, 1, 16] [1, 1, 1, 1] : memref<1x1x1x16xf32, strided<[802816, 7168, 64, 1], offset: ?>> to memref<16xf32, strided<[1], offset: ?>>
-# CHECK-NEXT:                %57 = memref.load %subview_78[] : memref<f32, strided<[], offset: ?>>
-# CHECK-NEXT:                %58 = vector.broadcast %57 : f32 to vector<16xf32>
-# CHECK-NEXT:                %59 = vector.transfer_read %subview_79[%c0], %0 {in_bounds = [true]} : memref<16xf32, strided<[1], offset: ?>>, vector<16xf32>
-# CHECK-NEXT:                %60 = arith.mulf %58, %53 fastmath<fast> : vector<16xf32>
-# CHECK-NEXT:                %61 = arith.addf %59, %60 fastmath<fast> : vector<16xf32>
-# CHECK-NEXT:                vector.transfer_write %61, %subview_79[%c0] {in_bounds = [true]} : vector<16xf32>, memref<16xf32, strided<[1], offset: ?>>
+# CHECK-NEXT:                %56 = memref.load %subview_78[] : memref<f32, strided<[], offset: ?>>
+# CHECK-NEXT:                %57 = vector.broadcast %56 : f32 to vector<16xf32>
+# CHECK-NEXT:                %58 = vector.transfer_read %subview_79[%c0], %0 {in_bounds = [true]} : memref<16xf32, strided<[1], offset: ?>>, vector<16xf32>
+# CHECK-NEXT:                %59 = arith.mulf %57, %52 fastmath<fast> : vector<16xf32>
+# CHECK-NEXT:                %60 = arith.addf %58, %59 fastmath<fast> : vector<16xf32>
+# CHECK-NEXT:                vector.transfer_write %60, %subview_79[%c0] {in_bounds = [true]} : vector<16xf32>, memref<16xf32, strided<[1], offset: ?>>
 # CHECK-NEXT:                %subview_80 = memref.subview %subview_77[0, 0, 0, 0] [1, 1, 1, 16] [1, 1, 1, 1] : memref<1x1x1x16xf32, strided<[802816, 7168, 64, 1], offset: ?>> to memref<16xf32, strided<[1], offset: ?>>
 # CHECK-NEXT:                memref.copy %subview_79, %subview_80 : memref<16xf32, strided<[1], offset: ?>> to memref<16xf32, strided<[1], offset: ?>>
 # CHECK-NEXT:                %subview_81 = memref.subview %arg12[0, 0, 1, 0] [1, 1, 1, 16] [1, 1, 1, 1] : memref<1x1x4x16xf32, strided<[802816, 7168, 64, 1], offset: ?>> to memref<1x1x1x16xf32, strided<[802816, 7168, 64, 1], offset: ?>>
@@ -585,12 +538,12 @@ print(f"CODE: {res}")
 # CHECK-NEXT:                %subview_83 = memref.subview %arg12[0, 0, 2, 0] [1, 1, 1, 16] [1, 1, 1, 1] : memref<1x1x4x16xf32, strided<[802816, 7168, 64, 1], offset: ?>> to memref<1x1x1x16xf32, strided<[802816, 7168, 64, 1], offset: ?>>
 # CHECK-NEXT:                %subview_84 = memref.subview %subview_82[0, 0, 0, 0] [1, 1, 1, 1] [1, 1, 1, 1] : memref<1x1x1x1xf32, strided<[158700, 690, 3, 1], offset: ?>> to memref<f32, strided<[], offset: ?>>
 # CHECK-NEXT:                %subview_85 = memref.subview %subview_83[0, 0, 0, 0] [1, 1, 1, 16] [1, 1, 1, 1] : memref<1x1x1x16xf32, strided<[802816, 7168, 64, 1], offset: ?>> to memref<16xf32, strided<[1], offset: ?>>
-# CHECK-NEXT:                %62 = memref.load %subview_84[] : memref<f32, strided<[], offset: ?>>
-# CHECK-NEXT:                %63 = vector.broadcast %62 : f32 to vector<16xf32>
-# CHECK-NEXT:                %64 = vector.transfer_read %subview_85[%c0], %0 {in_bounds = [true]} : memref<16xf32, strided<[1], offset: ?>>, vector<16xf32>
-# CHECK-NEXT:                %65 = arith.mulf %63, %53 fastmath<fast> : vector<16xf32>
-# CHECK-NEXT:                %66 = arith.addf %64, %65 fastmath<fast> : vector<16xf32>
-# CHECK-NEXT:                vector.transfer_write %66, %subview_85[%c0] {in_bounds = [true]} : vector<16xf32>, memref<16xf32, strided<[1], offset: ?>>
+# CHECK-NEXT:                %61 = memref.load %subview_84[] : memref<f32, strided<[], offset: ?>>
+# CHECK-NEXT:                %62 = vector.broadcast %61 : f32 to vector<16xf32>
+# CHECK-NEXT:                %63 = vector.transfer_read %subview_85[%c0], %0 {in_bounds = [true]} : memref<16xf32, strided<[1], offset: ?>>, vector<16xf32>
+# CHECK-NEXT:                %64 = arith.mulf %62, %52 fastmath<fast> : vector<16xf32>
+# CHECK-NEXT:                %65 = arith.addf %63, %64 fastmath<fast> : vector<16xf32>
+# CHECK-NEXT:                vector.transfer_write %65, %subview_85[%c0] {in_bounds = [true]} : vector<16xf32>, memref<16xf32, strided<[1], offset: ?>>
 # CHECK-NEXT:                %subview_86 = memref.subview %subview_83[0, 0, 0, 0] [1, 1, 1, 16] [1, 1, 1, 1] : memref<1x1x1x16xf32, strided<[802816, 7168, 64, 1], offset: ?>> to memref<16xf32, strided<[1], offset: ?>>
 # CHECK-NEXT:                memref.copy %subview_85, %subview_86 : memref<16xf32, strided<[1], offset: ?>> to memref<16xf32, strided<[1], offset: ?>>
 # CHECK-NEXT:                %subview_87 = memref.subview %arg12[0, 0, 2, 0] [1, 1, 1, 16] [1, 1, 1, 1] : memref<1x1x4x16xf32, strided<[802816, 7168, 64, 1], offset: ?>> to memref<1x1x1x16xf32, strided<[802816, 7168, 64, 1], offset: ?>>
@@ -599,33 +552,33 @@ print(f"CODE: {res}")
 # CHECK-NEXT:                %subview_89 = memref.subview %arg12[0, 0, 3, 0] [1, 1, 1, 16] [1, 1, 1, 1] : memref<1x1x4x16xf32, strided<[802816, 7168, 64, 1], offset: ?>> to memref<1x1x1x16xf32, strided<[802816, 7168, 64, 1], offset: ?>>
 # CHECK-NEXT:                %subview_90 = memref.subview %subview_88[0, 0, 0, 0] [1, 1, 1, 1] [1, 1, 1, 1] : memref<1x1x1x1xf32, strided<[158700, 690, 3, 1], offset: ?>> to memref<f32, strided<[], offset: ?>>
 # CHECK-NEXT:                %subview_91 = memref.subview %subview_89[0, 0, 0, 0] [1, 1, 1, 16] [1, 1, 1, 1] : memref<1x1x1x16xf32, strided<[802816, 7168, 64, 1], offset: ?>> to memref<16xf32, strided<[1], offset: ?>>
-# CHECK-NEXT:                %67 = memref.load %subview_90[] : memref<f32, strided<[], offset: ?>>
-# CHECK-NEXT:                %68 = vector.broadcast %67 : f32 to vector<16xf32>
-# CHECK-NEXT:                %69 = vector.transfer_read %subview_91[%c0], %0 {in_bounds = [true]} : memref<16xf32, strided<[1], offset: ?>>, vector<16xf32>
-# CHECK-NEXT:                %70 = arith.mulf %68, %53 fastmath<fast> : vector<16xf32>
-# CHECK-NEXT:                %71 = arith.addf %69, %70 fastmath<fast> : vector<16xf32>
-# CHECK-NEXT:                vector.transfer_write %71, %subview_91[%c0] {in_bounds = [true]} : vector<16xf32>, memref<16xf32, strided<[1], offset: ?>>
+# CHECK-NEXT:                %66 = memref.load %subview_90[] : memref<f32, strided<[], offset: ?>>
+# CHECK-NEXT:                %67 = vector.broadcast %66 : f32 to vector<16xf32>
+# CHECK-NEXT:                %68 = vector.transfer_read %subview_91[%c0], %0 {in_bounds = [true]} : memref<16xf32, strided<[1], offset: ?>>, vector<16xf32>
+# CHECK-NEXT:                %69 = arith.mulf %67, %52 fastmath<fast> : vector<16xf32>
+# CHECK-NEXT:                %70 = arith.addf %68, %69 fastmath<fast> : vector<16xf32>
+# CHECK-NEXT:                vector.transfer_write %70, %subview_91[%c0] {in_bounds = [true]} : vector<16xf32>, memref<16xf32, strided<[1], offset: ?>>
 # CHECK-NEXT:                %subview_92 = memref.subview %subview_89[0, 0, 0, 0] [1, 1, 1, 16] [1, 1, 1, 1] : memref<1x1x1x16xf32, strided<[802816, 7168, 64, 1], offset: ?>> to memref<16xf32, strided<[1], offset: ?>>
 # CHECK-NEXT:                memref.copy %subview_91, %subview_92 : memref<16xf32, strided<[1], offset: ?>> to memref<16xf32, strided<[1], offset: ?>>
 # CHECK-NEXT:                %subview_93 = memref.subview %arg12[0, 0, 3, 0] [1, 1, 1, 16] [1, 1, 1, 1] : memref<1x1x4x16xf32, strided<[802816, 7168, 64, 1], offset: ?>> to memref<1x1x1x16xf32, strided<[802816, 7168, 64, 1], offset: ?>>
 # CHECK-NEXT:                memref.copy %subview_89, %subview_93 : memref<1x1x1x16xf32, strided<[802816, 7168, 64, 1], offset: ?>> to memref<1x1x1x16xf32, strided<[802816, 7168, 64, 1], offset: ?>>
 # CHECK-NEXT:                scf.yield %arg12 : memref<1x1x4x16xf32, strided<[802816, 7168, 64, 1], offset: ?>>
 # CHECK-NEXT:              } {"./s"}
-# CHECK-NEXT:              scf.yield %8 : memref<1x1x4x16xf32, strided<[802816, 7168, 64, 1], offset: ?>>
+# CHECK-NEXT:              scf.yield %7 : memref<1x1x4x16xf32, strided<[802816, 7168, 64, 1], offset: ?>>
 # CHECK-NEXT:            } {"./r"}
 # CHECK-NEXT:            %subview_8 = memref.subview %arg8[0, 0, 0, %arg7] [1, 1, 4, 16] [1, 1, 1, 1] : memref<1x1x4x64xf32, strided<[802816, 7168, 64, 1], offset: ?>> to memref<1x1x4x16xf32, strided<[802816, 7168, 64, 1], offset: ?>>
-# CHECK-NEXT:            memref.copy %7, %subview_8 : memref<1x1x4x16xf32, strided<[802816, 7168, 64, 1], offset: ?>> to memref<1x1x4x16xf32, strided<[802816, 7168, 64, 1], offset: ?>>
+# CHECK-NEXT:            memref.copy %6, %subview_8 : memref<1x1x4x16xf32, strided<[802816, 7168, 64, 1], offset: ?>> to memref<1x1x4x16xf32, strided<[802816, 7168, 64, 1], offset: ?>>
 # CHECK-NEXT:            scf.yield %arg8 : memref<1x1x4x64xf32, strided<[802816, 7168, 64, 1], offset: ?>>
 # CHECK-NEXT:          } {"./f"}
 # CHECK-NEXT:          %subview_5 = memref.subview %arg6[0, 0, %arg5, 0] [1, 1, 4, 64] [1, 1, 1, 1] : memref<1x1x112x64xf32, strided<[802816, 7168, 64, 1], offset: ?>> to memref<1x1x4x64xf32, strided<[802816, 7168, 64, 1], offset: ?>>
-# CHECK-NEXT:          memref.copy %6, %subview_5 : memref<1x1x4x64xf32, strided<[802816, 7168, 64, 1], offset: ?>> to memref<1x1x4x64xf32, strided<[802816, 7168, 64, 1], offset: ?>>
+# CHECK-NEXT:          memref.copy %5, %subview_5 : memref<1x1x4x64xf32, strided<[802816, 7168, 64, 1], offset: ?>> to memref<1x1x4x64xf32, strided<[802816, 7168, 64, 1], offset: ?>>
 # CHECK-NEXT:          scf.yield %arg6 : memref<1x1x112x64xf32, strided<[802816, 7168, 64, 1], offset: ?>>
 # CHECK-NEXT:        } {"./w"}
 # CHECK-NEXT:        %subview_2 = memref.subview %arg4[0, %arg3, 0, 0] [1, 1, 112, 64] [1, 1, 1, 1] : memref<1x112x112x64xf32> to memref<1x1x112x64xf32, strided<[802816, 7168, 64, 1], offset: ?>>
-# CHECK-NEXT:        memref.copy %4, %subview_2 : memref<1x1x112x64xf32, strided<[802816, 7168, 64, 1], offset: ?>> to memref<1x1x112x64xf32, strided<[802816, 7168, 64, 1], offset: ?>>
+# CHECK-NEXT:        memref.copy %3, %subview_2 : memref<1x1x112x64xf32, strided<[802816, 7168, 64, 1], offset: ?>> to memref<1x1x112x64xf32, strided<[802816, 7168, 64, 1], offset: ?>>
 # CHECK-NEXT:        scf.yield %arg4 : memref<1x112x112x64xf32>
 # CHECK-NEXT:      } {"./h"}
-# CHECK-NEXT:      memref.copy %2, %arg2 : memref<1x112x112x64xf32> to memref<1x112x112x64xf32>
+# CHECK-NEXT:      memref.copy %1, %arg2 : memref<1x112x112x64xf32> to memref<1x112x112x64xf32>
 # CHECK-NEXT:      return
 # CHECK-NEXT:    }
 # CHECK-NEXT:  }

--- a/tests/filecheck/backends/tensor_dialect/test_conv2d_relu_tensor.py
+++ b/tests/filecheck/backends/tensor_dialect/test_conv2d_relu_tensor.py
@@ -75,41 +75,32 @@ print(f"CODE: {res}")
 # CHECK-NEXT:      transform.yield 
 # CHECK-NEXT:    }
 # CHECK-NEXT:    transform.named_sequence @__transform_main(%arg0: !transform.any_op {transform.readonly}) {
-# CHECK-NEXT:      %0 = transform.structured.match attributes {__xtc_id_O_0_} in %arg0 : (!transform.any_op) -> !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op, %loops = transform.structured.tile_using_for %0 tile_sizes [1, 0, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      %0 = transform.structured.match attributes {__xtc_id_O_} in %arg0 : (!transform.any_op) -> !transform.any_op
+# CHECK-NEXT:      %tiled_linalg_op, %loops = transform.structured.tile_using_for %0 tile_sizes [1, 0, 0, 0, 0, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
 # CHECK-NEXT:      transform.annotate %loops "./b" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_0, %loops_1 = transform.structured.tile_using_for %tiled_linalg_op tile_sizes [0, 1, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      %tiled_linalg_op_0, %loops_1 = transform.structured.tile_using_for %tiled_linalg_op tile_sizes [0, 1, 0, 0, 0, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
 # CHECK-NEXT:      transform.annotate %loops_1 "./h" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_2, %loops_3 = transform.structured.tile_using_for %tiled_linalg_op_0 tile_sizes [0, 0, 1, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      %tiled_linalg_op_2, %loops_3 = transform.structured.tile_using_for %tiled_linalg_op_0 tile_sizes [0, 0, 1, 0, 0, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
 # CHECK-NEXT:      transform.annotate %loops_3 "./w" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_4, %loops_5 = transform.structured.tile_using_for %tiled_linalg_op_2 tile_sizes [0, 0, 0, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      %tiled_linalg_op_4, %loops_5 = transform.structured.tile_using_for %tiled_linalg_op_2 tile_sizes [0, 0, 0, 1, 0, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
 # CHECK-NEXT:      transform.annotate %loops_5 "./f" : !transform.any_op
-# CHECK-NEXT:      %1 = transform.structured.match attributes {__xtc_id_O_} in %arg0 : (!transform.any_op) -> !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_6, %loops_7 = transform.structured.tile_using_for %1 tile_sizes [1, 0, 0, 0, 0, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_7 "./b" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_8, %loops_9 = transform.structured.tile_using_for %tiled_linalg_op_6 tile_sizes [0, 1, 0, 0, 0, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_9 "./h" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_10, %loops_11 = transform.structured.tile_using_for %tiled_linalg_op_8 tile_sizes [0, 0, 1, 0, 0, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_11 "./w" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_12, %loops_13 = transform.structured.tile_using_for %tiled_linalg_op_10 tile_sizes [0, 0, 0, 1, 0, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_13 "./f" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_14, %loops_15 = transform.structured.tile_using_for %tiled_linalg_op_12 tile_sizes [0, 0, 0, 0, 1, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_15 "./r" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_16, %loops_17 = transform.structured.tile_using_for %tiled_linalg_op_14 tile_sizes [0, 0, 0, 0, 0, 1, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_17 "./s" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_18, %loops_19 = transform.structured.tile_using_for %tiled_linalg_op_16 tile_sizes [0, 0, 0, 0, 0, 0, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_19 "./c" : !transform.any_op
-# CHECK-NEXT:      %2 = transform.structured.match attributes {__xtc_id_relu_} in %arg0 : (!transform.any_op) -> !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_20, %loops_21 = transform.structured.tile_using_for %2 tile_sizes [16] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_21 "./i" : !transform.any_op
-# CHECK-NEXT:      %3 = transform.get_parent_op %tiled_linalg_op_20 : (!transform.any_op) -> !transform.any_op
-# CHECK-NEXT:      transform.apply_patterns to %3 {
+# CHECK-NEXT:      %tiled_linalg_op_6, %loops_7 = transform.structured.tile_using_for %tiled_linalg_op_4 tile_sizes [0, 0, 0, 0, 1, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      transform.annotate %loops_7 "./r" : !transform.any_op
+# CHECK-NEXT:      %tiled_linalg_op_8, %loops_9 = transform.structured.tile_using_for %tiled_linalg_op_6 tile_sizes [0, 0, 0, 0, 0, 1, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      transform.annotate %loops_9 "./s" : !transform.any_op
+# CHECK-NEXT:      %tiled_linalg_op_10, %loops_11 = transform.structured.tile_using_for %tiled_linalg_op_8 tile_sizes [0, 0, 0, 0, 0, 0, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      transform.annotate %loops_11 "./c" : !transform.any_op
+# CHECK-NEXT:      %1 = transform.structured.match attributes {__xtc_id_relu_} in %arg0 : (!transform.any_op) -> !transform.any_op
+# CHECK-NEXT:      %tiled_linalg_op_12, %loops_13 = transform.structured.tile_using_for %1 tile_sizes [16] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      transform.annotate %loops_13 "./i" : !transform.any_op
+# CHECK-NEXT:      %2 = transform.get_parent_op %tiled_linalg_op_12 : (!transform.any_op) -> !transform.any_op
+# CHECK-NEXT:      transform.apply_patterns to %2 {
 # CHECK-NEXT:        transform.apply_patterns.linalg.fold_unit_extent_dims_via_slices
 # CHECK-NEXT:      } : !transform.any_op
-# CHECK-NEXT:      %4 = transform.structured.match interface{LinalgOp} in %3 : (!transform.any_op) -> !transform.any_op
-# CHECK-NEXT:      transform.include @_vecto failures(suppress) (%4) : (!transform.any_op) -> ()
-# CHECK-NEXT:      %5 = transform.get_parent_op %loops_21 {isolated_from_above} : (!transform.any_op) -> !transform.any_op
-# CHECK-NEXT:      transform.apply_patterns to %5 {
+# CHECK-NEXT:      %3 = transform.structured.match interface{LinalgOp} in %2 : (!transform.any_op) -> !transform.any_op
+# CHECK-NEXT:      transform.include @_vecto failures(suppress) (%3) : (!transform.any_op) -> ()
+# CHECK-NEXT:      %4 = transform.get_parent_op %loops_13 {isolated_from_above} : (!transform.any_op) -> !transform.any_op
+# CHECK-NEXT:      transform.apply_patterns to %4 {
 # CHECK-NEXT:        transform.apply_patterns.vector.reduction_to_contract
 # CHECK-NEXT:        transform.apply_patterns.vector.transfer_permutation_patterns
 # CHECK-NEXT:      } : !transform.any_op
@@ -133,27 +124,7 @@ print(f"CODE: {res}")
 # CHECK-NEXT:      %c0 = arith.constant 0 : index
 # CHECK-NEXT:      %cst = arith.constant 0.000000e+00 : f32
 # CHECK-NEXT:      %0 = tensor.empty() : tensor<1x8x8x16xf32>
-# CHECK-NEXT:      %1 = scf.for %arg3 = %c0 to %c1 step %c1 iter_args(%arg4 = %0) -> (tensor<1x8x8x16xf32>) {
-# CHECK-NEXT:        %extracted_slice = tensor.extract_slice %arg4[%arg3, 0, 0, 0] [1, 8, 8, 16] [1, 1, 1, 1] : tensor<1x8x8x16xf32> to tensor<1x8x8x16xf32>
-# CHECK-NEXT:        %5 = scf.for %arg5 = %c0 to %c8 step %c1 iter_args(%arg6 = %extracted_slice) -> (tensor<1x8x8x16xf32>) {
-# CHECK-NEXT:          %extracted_slice_0 = tensor.extract_slice %arg6[0, %arg5, 0, 0] [1, 1, 8, 16] [1, 1, 1, 1] : tensor<1x8x8x16xf32> to tensor<1x1x8x16xf32>
-# CHECK-NEXT:          %6 = scf.for %arg7 = %c0 to %c8 step %c1 iter_args(%arg8 = %extracted_slice_0) -> (tensor<1x1x8x16xf32>) {
-# CHECK-NEXT:            %extracted_slice_2 = tensor.extract_slice %arg8[0, 0, %arg7, 0] [1, 1, 1, 16] [1, 1, 1, 1] : tensor<1x1x8x16xf32> to tensor<1x1x1x16xf32>
-# CHECK-NEXT:            %7 = scf.for %arg9 = %c0 to %c16 step %c1 iter_args(%arg10 = %extracted_slice_2) -> (tensor<1x1x1x16xf32>) {
-# CHECK-NEXT:              %extracted_slice_4 = tensor.extract_slice %arg10[0, 0, 0, %arg9] [1, 1, 1, 1] [1, 1, 1, 1] : tensor<1x1x1x16xf32> to tensor<1x1x1x1xf32>
-# CHECK-NEXT:              %8 = linalg.fill {__xtc_id_O_0_} ins(%cst : f32) outs(%extracted_slice_4 : tensor<1x1x1x1xf32>) -> tensor<1x1x1x1xf32>
-# CHECK-NEXT:              %inserted_slice_5 = tensor.insert_slice %8 into %arg10[0, 0, 0, %arg9] [1, 1, 1, 1] [1, 1, 1, 1] : tensor<1x1x1x1xf32> into tensor<1x1x1x16xf32>
-# CHECK-NEXT:              scf.yield %inserted_slice_5 : tensor<1x1x1x16xf32>
-# CHECK-NEXT:            } {"./f"}
-# CHECK-NEXT:            %inserted_slice_3 = tensor.insert_slice %7 into %arg8[0, 0, %arg7, 0] [1, 1, 1, 16] [1, 1, 1, 1] : tensor<1x1x1x16xf32> into tensor<1x1x8x16xf32>
-# CHECK-NEXT:            scf.yield %inserted_slice_3 : tensor<1x1x8x16xf32>
-# CHECK-NEXT:          } {"./w"}
-# CHECK-NEXT:          %inserted_slice_1 = tensor.insert_slice %6 into %arg6[0, %arg5, 0, 0] [1, 1, 8, 16] [1, 1, 1, 1] : tensor<1x1x8x16xf32> into tensor<1x8x8x16xf32>
-# CHECK-NEXT:          scf.yield %inserted_slice_1 : tensor<1x8x8x16xf32>
-# CHECK-NEXT:        } {"./h"}
-# CHECK-NEXT:        %inserted_slice = tensor.insert_slice %5 into %arg4[%arg3, 0, 0, 0] [1, 8, 8, 16] [1, 1, 1, 1] : tensor<1x8x8x16xf32> into tensor<1x8x8x16xf32>
-# CHECK-NEXT:        scf.yield %inserted_slice : tensor<1x8x8x16xf32>
-# CHECK-NEXT:      } {"./b"}
+# CHECK-NEXT:      %1 = linalg.fill {__xtc_id_O_0_} ins(%cst : f32) outs(%0 : tensor<1x8x8x16xf32>) -> tensor<1x8x8x16xf32>
 # CHECK-NEXT:      %2 = scf.for %arg3 = %c0 to %c1 step %c1 iter_args(%arg4 = %1) -> (tensor<1x8x8x16xf32>) {
 # CHECK-NEXT:        %extracted_slice = tensor.extract_slice %arg0[%arg3, 0, 0, 0] [1, 10, 10, 3] [1, 1, 1, 1] : tensor<1x10x10x3xf32> to tensor<1x10x10x3xf32>
 # CHECK-NEXT:        %extracted_slice_0 = tensor.extract_slice %arg4[%arg3, 0, 0, 0] [1, 8, 8, 16] [1, 1, 1, 1] : tensor<1x8x8x16xf32> to tensor<1x8x8x16xf32>
@@ -244,71 +215,53 @@ print(f"CODE: {res}")
 # CHECK-NEXT:      %c0 = arith.constant 0 : index
 # CHECK-NEXT:      %cst = arith.constant 0.000000e+00 : f32
 # CHECK-NEXT:      %alloc = memref.alloc() {alignment = 256 : i64} : memref<1x8x8x16xf32>
+# CHECK-NEXT:      linalg.fill {__xtc_id_O_0_} ins(%cst : f32) outs(%alloc : memref<1x8x8x16xf32>)
 # CHECK-NEXT:      %0 = scf.for %arg3 = %c0 to %c8 step %c1 iter_args(%arg4 = %alloc) -> (memref<1x8x8x16xf32>) {
-# CHECK-NEXT:        %subview = memref.subview %arg4[0, %arg3, 0, 0] [1, 1, 8, 16] [1, 1, 1, 1] : memref<1x8x8x16xf32> to memref<1x1x8x16xf32, strided<[1024, 128, 16, 1], offset: ?>>
-# CHECK-NEXT:        %2 = scf.for %arg5 = %c0 to %c8 step %c1 iter_args(%arg6 = %subview) -> (memref<1x1x8x16xf32, strided<[1024, 128, 16, 1], offset: ?>>) {
-# CHECK-NEXT:          %subview_1 = memref.subview %arg6[0, 0, %arg5, 0] [1, 1, 1, 16] [1, 1, 1, 1] : memref<1x1x8x16xf32, strided<[1024, 128, 16, 1], offset: ?>> to memref<1x1x1x16xf32, strided<[1024, 128, 16, 1], offset: ?>>
-# CHECK-NEXT:          %3 = scf.for %arg7 = %c0 to %c16 step %c1 iter_args(%arg8 = %subview_1) -> (memref<1x1x1x16xf32, strided<[1024, 128, 16, 1], offset: ?>>) {
-# CHECK-NEXT:            %subview_3 = memref.subview %arg8[0, 0, 0, %arg7] [1, 1, 1, 1] [1, 1, 1, 1] : memref<1x1x1x16xf32, strided<[1024, 128, 16, 1], offset: ?>> to memref<1x1x1x1xf32, strided<[1024, 128, 16, 1], offset: ?>>
-# CHECK-NEXT:            linalg.fill {__xtc_id_O_0_} ins(%cst : f32) outs(%subview_3 : memref<1x1x1x1xf32, strided<[1024, 128, 16, 1], offset: ?>>)
-# CHECK-NEXT:            %subview_4 = memref.subview %arg8[0, 0, 0, %arg7] [1, 1, 1, 1] [1, 1, 1, 1] : memref<1x1x1x16xf32, strided<[1024, 128, 16, 1], offset: ?>> to memref<1x1x1x1xf32, strided<[1024, 128, 16, 1], offset: ?>>
-# CHECK-NEXT:            memref.copy %subview_3, %subview_4 : memref<1x1x1x1xf32, strided<[1024, 128, 16, 1], offset: ?>> to memref<1x1x1x1xf32, strided<[1024, 128, 16, 1], offset: ?>>
-# CHECK-NEXT:            scf.yield %arg8 : memref<1x1x1x16xf32, strided<[1024, 128, 16, 1], offset: ?>>
-# CHECK-NEXT:          } {"./f"}
-# CHECK-NEXT:          %subview_2 = memref.subview %arg6[0, 0, %arg5, 0] [1, 1, 1, 16] [1, 1, 1, 1] : memref<1x1x8x16xf32, strided<[1024, 128, 16, 1], offset: ?>> to memref<1x1x1x16xf32, strided<[1024, 128, 16, 1], offset: ?>>
-# CHECK-NEXT:          memref.copy %3, %subview_2 : memref<1x1x1x16xf32, strided<[1024, 128, 16, 1], offset: ?>> to memref<1x1x1x16xf32, strided<[1024, 128, 16, 1], offset: ?>>
-# CHECK-NEXT:          scf.yield %arg6 : memref<1x1x8x16xf32, strided<[1024, 128, 16, 1], offset: ?>>
-# CHECK-NEXT:        } {"./w"}
-# CHECK-NEXT:        %subview_0 = memref.subview %arg4[0, %arg3, 0, 0] [1, 1, 8, 16] [1, 1, 1, 1] : memref<1x8x8x16xf32> to memref<1x1x8x16xf32, strided<[1024, 128, 16, 1], offset: ?>>
-# CHECK-NEXT:        memref.copy %2, %subview_0 : memref<1x1x8x16xf32, strided<[1024, 128, 16, 1], offset: ?>> to memref<1x1x8x16xf32, strided<[1024, 128, 16, 1], offset: ?>>
-# CHECK-NEXT:        scf.yield %arg4 : memref<1x8x8x16xf32>
-# CHECK-NEXT:      } {"./h"}
-# CHECK-NEXT:      %1 = scf.for %arg3 = %c0 to %c8 step %c1 iter_args(%arg4 = %0) -> (memref<1x8x8x16xf32>) {
 # CHECK-NEXT:        %subview = memref.subview %arg0[0, %arg3, 0, 0] [1, 3, 10, 3] [1, 1, 1, 1] : memref<1x10x10x3xf32> to memref<1x3x10x3xf32, strided<[300, 30, 3, 1], offset: ?>>
 # CHECK-NEXT:        %subview_0 = memref.subview %arg4[0, %arg3, 0, 0] [1, 1, 8, 16] [1, 1, 1, 1] : memref<1x8x8x16xf32> to memref<1x1x8x16xf32, strided<[1024, 128, 16, 1], offset: ?>>
-# CHECK-NEXT:        %2 = scf.for %arg5 = %c0 to %c8 step %c1 iter_args(%arg6 = %subview_0) -> (memref<1x1x8x16xf32, strided<[1024, 128, 16, 1], offset: ?>>) {
+# CHECK-NEXT:        %1 = scf.for %arg5 = %c0 to %c8 step %c1 iter_args(%arg6 = %subview_0) -> (memref<1x1x8x16xf32, strided<[1024, 128, 16, 1], offset: ?>>) {
 # CHECK-NEXT:          %subview_2 = memref.subview %subview[0, 0, %arg5, 0] [1, 3, 3, 3] [1, 1, 1, 1] : memref<1x3x10x3xf32, strided<[300, 30, 3, 1], offset: ?>> to memref<1x3x3x3xf32, strided<[300, 30, 3, 1], offset: ?>>
 # CHECK-NEXT:          %subview_3 = memref.subview %arg6[0, 0, %arg5, 0] [1, 1, 1, 16] [1, 1, 1, 1] : memref<1x1x8x16xf32, strided<[1024, 128, 16, 1], offset: ?>> to memref<1x1x1x16xf32, strided<[1024, 128, 16, 1], offset: ?>>
-# CHECK-NEXT:          %3 = scf.for %arg7 = %c0 to %c16 step %c1 iter_args(%arg8 = %subview_3) -> (memref<1x1x1x16xf32, strided<[1024, 128, 16, 1], offset: ?>>) {
+# CHECK-NEXT:          %2 = scf.for %arg7 = %c0 to %c16 step %c1 iter_args(%arg8 = %subview_3) -> (memref<1x1x1x16xf32, strided<[1024, 128, 16, 1], offset: ?>>) {
 # CHECK-NEXT:            %subview_5 = memref.subview %arg1[0, 0, 0, %arg7] [3, 3, 3, 1] [1, 1, 1, 1] : memref<3x3x3x16xf32> to memref<3x3x3x1xf32, strided<[144, 48, 16, 1], offset: ?>>
 # CHECK-NEXT:            %subview_6 = memref.subview %arg8[0, 0, 0, %arg7] [1, 1, 1, 1] [1, 1, 1, 1] : memref<1x1x1x16xf32, strided<[1024, 128, 16, 1], offset: ?>> to memref<1x1x1x1xf32, strided<[1024, 128, 16, 1], offset: ?>>
-# CHECK-NEXT:            %4 = scf.for %arg9 = %c0 to %c3 step %c1 iter_args(%arg10 = %subview_6) -> (memref<1x1x1x1xf32, strided<[1024, 128, 16, 1], offset: ?>>) {
+# CHECK-NEXT:            %3 = scf.for %arg9 = %c0 to %c3 step %c1 iter_args(%arg10 = %subview_6) -> (memref<1x1x1x1xf32, strided<[1024, 128, 16, 1], offset: ?>>) {
 # CHECK-NEXT:              %subview_8 = memref.subview %subview_2[0, %arg9, 0, 0] [1, 1, 3, 3] [1, 1, 1, 1] : memref<1x3x3x3xf32, strided<[300, 30, 3, 1], offset: ?>> to memref<1x1x3x3xf32, strided<[300, 30, 3, 1], offset: ?>>
 # CHECK-NEXT:              %subview_9 = memref.subview %subview_5[%arg9, 0, 0, 0] [1, 3, 3, 1] [1, 1, 1, 1] : memref<3x3x3x1xf32, strided<[144, 48, 16, 1], offset: ?>> to memref<1x3x3x1xf32, strided<[144, 48, 16, 1], offset: ?>>
-# CHECK-NEXT:              %5 = scf.for %arg11 = %c0 to %c3 step %c1 iter_args(%arg12 = %arg10) -> (memref<1x1x1x1xf32, strided<[1024, 128, 16, 1], offset: ?>>) {
+# CHECK-NEXT:              %4 = scf.for %arg11 = %c0 to %c3 step %c1 iter_args(%arg12 = %arg10) -> (memref<1x1x1x1xf32, strided<[1024, 128, 16, 1], offset: ?>>) {
 # CHECK-NEXT:                %subview_10 = memref.subview %subview_8[0, 0, %arg11, 0] [1, 1, 1, 3] [1, 1, 1, 1] : memref<1x1x3x3xf32, strided<[300, 30, 3, 1], offset: ?>> to memref<1x1x1x3xf32, strided<[300, 30, 3, 1], offset: ?>>
 # CHECK-NEXT:                %subview_11 = memref.subview %subview_9[0, %arg11, 0, 0] [1, 1, 3, 1] [1, 1, 1, 1] : memref<1x3x3x1xf32, strided<[144, 48, 16, 1], offset: ?>> to memref<1x1x3x1xf32, strided<[144, 48, 16, 1], offset: ?>>
-# CHECK-NEXT:                %6 = scf.for %arg13 = %c0 to %c3 step %c1 iter_args(%arg14 = %arg12) -> (memref<1x1x1x1xf32, strided<[1024, 128, 16, 1], offset: ?>>) {
+# CHECK-NEXT:                %5 = scf.for %arg13 = %c0 to %c3 step %c1 iter_args(%arg14 = %arg12) -> (memref<1x1x1x1xf32, strided<[1024, 128, 16, 1], offset: ?>>) {
 # CHECK-NEXT:                  %subview_12 = memref.subview %subview_10[0, 0, 0, %arg13] [1, 1, 1, 1] [1, 1, 1, 1] : memref<1x1x1x3xf32, strided<[300, 30, 3, 1], offset: ?>> to memref<1x1x1x1xf32, strided<[300, 30, 3, 1], offset: ?>>
 # CHECK-NEXT:                  %subview_13 = memref.subview %subview_11[0, 0, %arg13, 0] [1, 1, 1, 1] [1, 1, 1, 1] : memref<1x1x3x1xf32, strided<[144, 48, 16, 1], offset: ?>> to memref<1x1x1x1xf32, strided<[144, 48, 16, 1], offset: ?>>
 # CHECK-NEXT:                  linalg.generic {indexing_maps = [#map, #map1, #map2], iterator_types = ["parallel", "parallel", "parallel", "parallel", "reduction", "reduction", "reduction"]} ins(%subview_12, %subview_13 : memref<1x1x1x1xf32, strided<[300, 30, 3, 1], offset: ?>>, memref<1x1x1x1xf32, strided<[144, 48, 16, 1], offset: ?>>) outs(%arg14 : memref<1x1x1x1xf32, strided<[1024, 128, 16, 1], offset: ?>>) attrs =  {__xtc_id_O_} {
 # CHECK-NEXT:                  ^bb0(%in: f32, %in_14: f32, %out: f32):
-# CHECK-NEXT:                    %7 = arith.mulf %in, %in_14 fastmath<fast> : f32
-# CHECK-NEXT:                    %8 = arith.addf %out, %7 fastmath<fast> : f32
-# CHECK-NEXT:                    linalg.yield %8 : f32
+# CHECK-NEXT:                    %6 = arith.mulf %in, %in_14 fastmath<fast> : f32
+# CHECK-NEXT:                    %7 = arith.addf %out, %6 fastmath<fast> : f32
+# CHECK-NEXT:                    linalg.yield %7 : f32
 # CHECK-NEXT:                  }
 # CHECK-NEXT:                  scf.yield %arg14 : memref<1x1x1x1xf32, strided<[1024, 128, 16, 1], offset: ?>>
 # CHECK-NEXT:                } {"./c"}
-# CHECK-NEXT:                scf.yield %6 : memref<1x1x1x1xf32, strided<[1024, 128, 16, 1], offset: ?>>
+# CHECK-NEXT:                scf.yield %5 : memref<1x1x1x1xf32, strided<[1024, 128, 16, 1], offset: ?>>
 # CHECK-NEXT:              } {"./s"}
-# CHECK-NEXT:              scf.yield %5 : memref<1x1x1x1xf32, strided<[1024, 128, 16, 1], offset: ?>>
+# CHECK-NEXT:              scf.yield %4 : memref<1x1x1x1xf32, strided<[1024, 128, 16, 1], offset: ?>>
 # CHECK-NEXT:            } {"./r"}
 # CHECK-NEXT:            %subview_7 = memref.subview %arg8[0, 0, 0, %arg7] [1, 1, 1, 1] [1, 1, 1, 1] : memref<1x1x1x16xf32, strided<[1024, 128, 16, 1], offset: ?>> to memref<1x1x1x1xf32, strided<[1024, 128, 16, 1], offset: ?>>
-# CHECK-NEXT:            memref.copy %4, %subview_7 : memref<1x1x1x1xf32, strided<[1024, 128, 16, 1], offset: ?>> to memref<1x1x1x1xf32, strided<[1024, 128, 16, 1], offset: ?>>
+# CHECK-NEXT:            memref.copy %3, %subview_7 : memref<1x1x1x1xf32, strided<[1024, 128, 16, 1], offset: ?>> to memref<1x1x1x1xf32, strided<[1024, 128, 16, 1], offset: ?>>
 # CHECK-NEXT:            scf.yield %arg8 : memref<1x1x1x16xf32, strided<[1024, 128, 16, 1], offset: ?>>
 # CHECK-NEXT:          } {"./f"}
 # CHECK-NEXT:          %subview_4 = memref.subview %arg6[0, 0, %arg5, 0] [1, 1, 1, 16] [1, 1, 1, 1] : memref<1x1x8x16xf32, strided<[1024, 128, 16, 1], offset: ?>> to memref<1x1x1x16xf32, strided<[1024, 128, 16, 1], offset: ?>>
-# CHECK-NEXT:          memref.copy %3, %subview_4 : memref<1x1x1x16xf32, strided<[1024, 128, 16, 1], offset: ?>> to memref<1x1x1x16xf32, strided<[1024, 128, 16, 1], offset: ?>>
+# CHECK-NEXT:          memref.copy %2, %subview_4 : memref<1x1x1x16xf32, strided<[1024, 128, 16, 1], offset: ?>> to memref<1x1x1x16xf32, strided<[1024, 128, 16, 1], offset: ?>>
 # CHECK-NEXT:          scf.yield %arg6 : memref<1x1x8x16xf32, strided<[1024, 128, 16, 1], offset: ?>>
 # CHECK-NEXT:        } {"./w"}
 # CHECK-NEXT:        %subview_1 = memref.subview %arg4[0, %arg3, 0, 0] [1, 1, 8, 16] [1, 1, 1, 1] : memref<1x8x8x16xf32> to memref<1x1x8x16xf32, strided<[1024, 128, 16, 1], offset: ?>>
-# CHECK-NEXT:        memref.copy %2, %subview_1 : memref<1x1x8x16xf32, strided<[1024, 128, 16, 1], offset: ?>> to memref<1x1x8x16xf32, strided<[1024, 128, 16, 1], offset: ?>>
+# CHECK-NEXT:        memref.copy %1, %subview_1 : memref<1x1x8x16xf32, strided<[1024, 128, 16, 1], offset: ?>> to memref<1x1x8x16xf32, strided<[1024, 128, 16, 1], offset: ?>>
 # CHECK-NEXT:        scf.yield %arg4 : memref<1x8x8x16xf32>
 # CHECK-NEXT:      } {"./h"}
-# CHECK-NEXT:      linalg.generic {indexing_maps = [#map3, #map4, #map3], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%1, %cst : memref<1x8x8x16xf32>, f32) outs(%arg2 : memref<1x8x8x16xf32>) attrs =  {__xtc_id_relu_} {
+# CHECK-NEXT:      linalg.generic {indexing_maps = [#map3, #map4, #map3], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%0, %cst : memref<1x8x8x16xf32>, f32) outs(%arg2 : memref<1x8x8x16xf32>) attrs =  {__xtc_id_relu_} {
 # CHECK-NEXT:      ^bb0(%in: f32, %in_0: f32, %out: f32):
-# CHECK-NEXT:        %2 = arith.maximumf %in, %in_0 : f32
-# CHECK-NEXT:        linalg.yield %2 : f32
+# CHECK-NEXT:        %1 = arith.maximumf %in, %in_0 : f32
+# CHECK-NEXT:        linalg.yield %1 : f32
 # CHECK-NEXT:      }
 # CHECK-NEXT:      memref.copy %arg2, %arg2 : memref<1x8x8x16xf32> to memref<1x8x8x16xf32>
 # CHECK-NEXT:      return

--- a/tests/filecheck/backends/tensor_dialect/test_matmul_mlir_tensor.py
+++ b/tests/filecheck/backends/tensor_dialect/test_matmul_mlir_tensor.py
@@ -36,221 +36,194 @@ executor = module.get_executor(validate=True)
 res = executor.execute()
 print(f"CODE: {res}")
 
-# CHECK: // -----// IR Dump Before transform //----- //
-# CHECK-NEXT: module attributes {transform.with_named_sequence} {
-# CHECK-NEXT:   func.func @matmul(%arg0: tensor<4x512xf32> {llvm.noalias}, %arg1: tensor<512x32xf32> {llvm.noalias}, %arg2: memref<4x32xf32> {llvm.noalias}) {
-# CHECK-NEXT:     %0 = tensor.empty() : tensor<4x32xf32>
-# CHECK-NEXT:     %cst = arith.constant 0.000000e+00 : f32
-# CHECK-NEXT:     %1 = linalg.fill {__xtc_id_C_0_} ins(%cst : f32) outs(%0 : tensor<4x32xf32>) -> tensor<4x32xf32>
-# CHECK-NEXT:     %2 = linalg.matmul {__xtc_id_C_} ins(%arg0, %arg1 : tensor<4x512xf32>, tensor<512x32xf32>) outs(%1 : tensor<4x32xf32>) -> tensor<4x32xf32>
-# CHECK-NEXT:     bufferization.materialize_in_destination %2 in restrict writable %arg2 : (tensor<4x32xf32>, memref<4x32xf32>) -> ()
-# CHECK-NEXT:     return
-# CHECK-NEXT:   }
-# CHECK-NEXT:   transform.named_sequence @_vecto(%arg0: !transform.any_op {transform.consumed}) {
-# CHECK-NEXT:     transform.structured.vectorize %arg0 : !transform.any_op
-# CHECK-NEXT:     transform.yield 
-# CHECK-NEXT:   }
-# CHECK-NEXT:   transform.named_sequence @_post_bufferize(%arg0: !transform.any_op {transform.readonly}) {
-# CHECK-NEXT:     %0 = transform.structured.match attributes {sym_name = "matmul"} in %arg0 : (!transform.any_op) -> !transform.any_op
-# CHECK-NEXT:     transform.apply_patterns to %0 {
-# CHECK-NEXT:       transform.apply_patterns.vector.lower_outerproduct
-# CHECK-NEXT:       transform.apply_patterns.vector.lower_contraction
-# CHECK-NEXT:     } : !transform.any_op
-# CHECK-NEXT:     transform.yield 
-# CHECK-NEXT:   }
-# CHECK-NEXT:   transform.named_sequence @__transform_main(%arg0: !transform.any_op {transform.readonly}) {
-# CHECK-NEXT:     %0 = transform.structured.match attributes {__xtc_id_C_0_} in %arg0 : (!transform.any_op) -> !transform.any_op
-# CHECK-NEXT:     %tiled_linalg_op, %loops = transform.structured.tile_using_for %0 tile_sizes [1, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:     transform.annotate %loops "./i" : !transform.any_op
-# CHECK-NEXT:     %tiled_linalg_op_0, %loops_1 = transform.structured.tile_using_for %tiled_linalg_op tile_sizes [0, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:     transform.annotate %loops_1 "./j" : !transform.any_op
-# CHECK-NEXT:     %1 = transform.structured.match attributes {__xtc_id_C_} in %arg0 : (!transform.any_op) -> !transform.any_op
-# CHECK-NEXT:     %tiled_linalg_op_2, %loops_3 = transform.structured.tile_using_for %1 tile_sizes [0, 0, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:     transform.annotate %loops_3 "./k" : !transform.any_op
-# CHECK-NEXT:     %tiled_linalg_op_4, %loops_5 = transform.structured.tile_using_for %tiled_linalg_op_2 tile_sizes [2, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:     transform.annotate %loops_5 "./i" : !transform.any_op
-# CHECK-NEXT:     %tiled_linalg_op_6, %loops_7 = transform.structured.tile_using_for %tiled_linalg_op_4 tile_sizes [0, 16, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:     transform.annotate %loops_7 "./j" : !transform.any_op
-# CHECK-NEXT:     %tiled_linalg_op_8, %loops_9 = transform.structured.tile_using_for %tiled_linalg_op_6 tile_sizes [1, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:     transform.annotate %loops_9 "./i1" : !transform.any_op
-# CHECK-NEXT:     %2 = transform.get_parent_op %tiled_linalg_op_8 : (!transform.any_op) -> !transform.any_op
-# CHECK-NEXT:     transform.apply_patterns to %2 {
-# CHECK-NEXT:       transform.apply_patterns.linalg.fold_unit_extent_dims_via_slices
-# CHECK-NEXT:     } : !transform.any_op
-# CHECK-NEXT:     %3 = transform.structured.match interface{LinalgOp} in %2 : (!transform.any_op) -> !transform.any_op
-# CHECK-NEXT:     transform.include @_vecto failures(suppress) (%3) : (!transform.any_op) -> ()
-# CHECK-NEXT:     transform.loop.unroll %loops_9 {factor = 2 : i64} : !transform.any_op
-# CHECK-NEXT:     %4 = transform.get_parent_op %loops_3 {isolated_from_above} : (!transform.any_op) -> !transform.any_op
-# CHECK-NEXT:     transform.apply_patterns to %4 {
-# CHECK-NEXT:       transform.apply_patterns.vector.reduction_to_contract
-# CHECK-NEXT:       transform.apply_patterns.vector.transfer_permutation_patterns
-# CHECK-NEXT:     } : !transform.any_op
-# CHECK-NEXT:     transform.yield 
-# CHECK-NEXT:   }
-# CHECK-NEXT: }
+# CHECK:       // -----// IR Dump Before transform //----- //
+# CHECK-NEXT:  module attributes {transform.with_named_sequence} {
+# CHECK-NEXT:    func.func @matmul(%arg0: tensor<4x512xf32> {llvm.noalias}, %arg1: tensor<512x32xf32> {llvm.noalias}, %arg2: memref<4x32xf32> {llvm.noalias}) {
+# CHECK-NEXT:      %0 = tensor.empty() : tensor<4x32xf32>
+# CHECK-NEXT:      %cst = arith.constant 0.000000e+00 : f32
+# CHECK-NEXT:      %1 = linalg.fill {__xtc_id_C_0_} ins(%cst : f32) outs(%0 : tensor<4x32xf32>) -> tensor<4x32xf32>
+# CHECK-NEXT:      %2 = linalg.matmul {__xtc_id_C_} ins(%arg0, %arg1 : tensor<4x512xf32>, tensor<512x32xf32>) outs(%1 : tensor<4x32xf32>) -> tensor<4x32xf32>
+# CHECK-NEXT:      bufferization.materialize_in_destination %2 in restrict writable %arg2 : (tensor<4x32xf32>, memref<4x32xf32>) -> ()
+# CHECK-NEXT:      return
+# CHECK-NEXT:    }
+# CHECK-NEXT:    transform.named_sequence @_vecto(%arg0: !transform.any_op {transform.consumed}) {
+# CHECK-NEXT:      transform.structured.vectorize %arg0 : !transform.any_op
+# CHECK-NEXT:      transform.yield 
+# CHECK-NEXT:    }
+# CHECK-NEXT:    transform.named_sequence @_post_bufferize(%arg0: !transform.any_op {transform.readonly}) {
+# CHECK-NEXT:      %0 = transform.structured.match attributes {sym_name = "matmul"} in %arg0 : (!transform.any_op) -> !transform.any_op
+# CHECK-NEXT:      transform.apply_patterns to %0 {
+# CHECK-NEXT:        transform.apply_patterns.vector.lower_outerproduct
+# CHECK-NEXT:        transform.apply_patterns.vector.lower_contraction
+# CHECK-NEXT:      } : !transform.any_op
+# CHECK-NEXT:      transform.yield 
+# CHECK-NEXT:    }
+# CHECK-NEXT:    transform.named_sequence @__transform_main(%arg0: !transform.any_op {transform.readonly}) {
+# CHECK-NEXT:      %0 = transform.structured.match attributes {__xtc_id_C_} in %arg0 : (!transform.any_op) -> !transform.any_op
+# CHECK-NEXT:      %tiled_linalg_op, %loops = transform.structured.tile_using_for %0 tile_sizes [0, 0, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      transform.annotate %loops "./k" : !transform.any_op
+# CHECK-NEXT:      %tiled_linalg_op_0, %loops_1 = transform.structured.tile_using_for %tiled_linalg_op tile_sizes [2, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      transform.annotate %loops_1 "./i" : !transform.any_op
+# CHECK-NEXT:      %tiled_linalg_op_2, %loops_3 = transform.structured.tile_using_for %tiled_linalg_op_0 tile_sizes [0, 16, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      transform.annotate %loops_3 "./j" : !transform.any_op
+# CHECK-NEXT:      %tiled_linalg_op_4, %loops_5 = transform.structured.tile_using_for %tiled_linalg_op_2 tile_sizes [1, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      transform.annotate %loops_5 "./i1" : !transform.any_op
+# CHECK-NEXT:      %1 = transform.get_parent_op %tiled_linalg_op_4 : (!transform.any_op) -> !transform.any_op
+# CHECK-NEXT:      transform.apply_patterns to %1 {
+# CHECK-NEXT:        transform.apply_patterns.linalg.fold_unit_extent_dims_via_slices
+# CHECK-NEXT:      } : !transform.any_op
+# CHECK-NEXT:      %2 = transform.structured.match interface{LinalgOp} in %1 : (!transform.any_op) -> !transform.any_op
+# CHECK-NEXT:      transform.include @_vecto failures(suppress) (%2) : (!transform.any_op) -> ()
+# CHECK-NEXT:      transform.loop.unroll %loops_5 {factor = 2 : i64} : !transform.any_op
+# CHECK-NEXT:      %3 = transform.get_parent_op %loops {isolated_from_above} : (!transform.any_op) -> !transform.any_op
+# CHECK-NEXT:      transform.apply_patterns to %3 {
+# CHECK-NEXT:        transform.apply_patterns.vector.reduction_to_contract
+# CHECK-NEXT:        transform.apply_patterns.vector.transfer_permutation_patterns
+# CHECK-NEXT:      } : !transform.any_op
+# CHECK-NEXT:      transform.yield 
+# CHECK-NEXT:    }
+# CHECK-NEXT:  }
 # CHECK-NEXT:  
-# CHECK-NEXT: // -----// IR Dump After transform //----- //
-# CHECK-NEXT: #map = affine_map<(d0, d1, d2) -> (d0, d2)>
-# CHECK-NEXT: #map1 = affine_map<(d0, d1, d2) -> (d2, d1)>
-# CHECK-NEXT: #map2 = affine_map<(d0, d1, d2) -> (d0, d1)>
-# CHECK-NEXT: module attributes {transform.with_named_sequence} {
-# CHECK-NEXT:   func.func @matmul(%arg0: tensor<4x512xf32> {llvm.noalias}, %arg1: tensor<512x32xf32> {llvm.noalias}, %arg2: memref<4x32xf32> {llvm.noalias}) {
-# CHECK-NEXT:     %0 = ub.poison : f32
-# CHECK-NEXT:     %c16 = arith.constant 16 : index
-# CHECK-NEXT:     %c2 = arith.constant 2 : index
-# CHECK-NEXT:     %c512 = arith.constant 512 : index
-# CHECK-NEXT:     %c32 = arith.constant 32 : index
-# CHECK-NEXT:     %c1 = arith.constant 1 : index
-# CHECK-NEXT:     %c4 = arith.constant 4 : index
-# CHECK-NEXT:     %c0 = arith.constant 0 : index
-# CHECK-NEXT:     %cst = arith.constant 0.000000e+00 : f32
-# CHECK-NEXT:     %1 = tensor.empty() : tensor<4x32xf32>
-# CHECK-NEXT:     %2 = scf.for %arg3 = %c0 to %c4 step %c1 iter_args(%arg4 = %1) -> (tensor<4x32xf32>) {
-# CHECK-NEXT:       %extracted_slice = tensor.extract_slice %arg4[%arg3, 0] [1, 32] [1, 1] : tensor<4x32xf32> to tensor<1x32xf32>
-# CHECK-NEXT:       %4 = scf.for %arg5 = %c0 to %c32 step %c1 iter_args(%arg6 = %extracted_slice) -> (tensor<1x32xf32>) {
-# CHECK-NEXT:         %extracted_slice_0 = tensor.extract_slice %arg6[0, %arg5] [1, 1] [1, 1] : tensor<1x32xf32> to tensor<1x1xf32>
-# CHECK-NEXT:         %5 = linalg.fill {__xtc_id_C_0_} ins(%cst : f32) outs(%extracted_slice_0 : tensor<1x1xf32>) -> tensor<1x1xf32>
-# CHECK-NEXT:         %inserted_slice_1 = tensor.insert_slice %5 into %arg6[0, %arg5] [1, 1] [1, 1] : tensor<1x1xf32> into tensor<1x32xf32>
-# CHECK-NEXT:         scf.yield %inserted_slice_1 : tensor<1x32xf32>
-# CHECK-NEXT:       } {"./j"}
-# CHECK-NEXT:       %inserted_slice = tensor.insert_slice %4 into %arg4[%arg3, 0] [1, 32] [1, 1] : tensor<1x32xf32> into tensor<4x32xf32>
-# CHECK-NEXT:       scf.yield %inserted_slice : tensor<4x32xf32>
-# CHECK-NEXT:     } {"./i"}
-# CHECK-NEXT:     %3 = scf.for %arg3 = %c0 to %c512 step %c1 iter_args(%arg4 = %2) -> (tensor<4x32xf32>) {
-# CHECK-NEXT:       %extracted_slice = tensor.extract_slice %arg0[0, %arg3] [4, 1] [1, 1] : tensor<4x512xf32> to tensor<4x1xf32>
-# CHECK-NEXT:       %extracted_slice_0 = tensor.extract_slice %arg1[%arg3, 0] [1, 32] [1, 1] : tensor<512x32xf32> to tensor<1x32xf32>
-# CHECK-NEXT:       %4 = scf.for %arg5 = %c0 to %c4 step %c2 iter_args(%arg6 = %arg4) -> (tensor<4x32xf32>) {
-# CHECK-NEXT:         %extracted_slice_1 = tensor.extract_slice %extracted_slice[%arg5, 0] [2, 1] [1, 1] : tensor<4x1xf32> to tensor<2x1xf32>
-# CHECK-NEXT:         %extracted_slice_2 = tensor.extract_slice %arg6[%arg5, 0] [2, 32] [1, 1] : tensor<4x32xf32> to tensor<2x32xf32>
-# CHECK-NEXT:         %5 = scf.for %arg7 = %c0 to %c32 step %c16 iter_args(%arg8 = %extracted_slice_2) -> (tensor<2x32xf32>) {
-# CHECK-NEXT:           %extracted_slice_3 = tensor.extract_slice %extracted_slice_0[0, %arg7] [1, 16] [1, 1] : tensor<1x32xf32> to tensor<1x16xf32>
-# CHECK-NEXT:           %extracted_slice_4 = tensor.extract_slice %arg8[0, %arg7] [2, 16] [1, 1] : tensor<2x32xf32> to tensor<2x16xf32>
-# CHECK-NEXT:           %extracted_slice_5 = tensor.extract_slice %extracted_slice_1[%c0, 0] [1, 1] [1, 1] : tensor<2x1xf32> to tensor<1x1xf32>
-# CHECK-NEXT:           %extracted_slice_6 = tensor.extract_slice %extracted_slice_4[%c0, 0] [1, 16] [1, 1] : tensor<2x16xf32> to tensor<1x16xf32>
-# CHECK-NEXT:           %6 = vector.transfer_read %extracted_slice_5[%c0, %c0], %0 {in_bounds = [true, true]} : tensor<1x1xf32>, vector<1x1xf32>
-# CHECK-NEXT:           %7 = vector.transfer_read %extracted_slice_3[%c0, %c0], %0 {in_bounds = [true, true]} : tensor<1x16xf32>, vector<1x16xf32>
-# CHECK-NEXT:           %8 = vector.transfer_read %extracted_slice_6[%c0, %c0], %0 {in_bounds = [true, true]} : tensor<1x16xf32>, vector<1x16xf32>
-# CHECK-NEXT:           %9 = vector.contract {indexing_maps = [#map, #map1, #map2], iterator_types = ["parallel", "parallel", "reduction"], kind = #vector.kind<add>} %6, %7, %8 : vector<1x1xf32>, vector<1x16xf32> into vector<1x16xf32>
-# CHECK-NEXT:           %10 = vector.transfer_write %9, %extracted_slice_6[%c0, %c0] {in_bounds = [true, true]} : vector<1x16xf32>, tensor<1x16xf32>
-# CHECK-NEXT:           %inserted_slice_7 = tensor.insert_slice %10 into %extracted_slice_4[%c0, 0] [1, 16] [1, 1] : tensor<1x16xf32> into tensor<2x16xf32>
-# CHECK-NEXT:           %extracted_slice_8 = tensor.extract_slice %extracted_slice_1[%c1, 0] [1, 1] [1, 1] : tensor<2x1xf32> to tensor<1x1xf32>
-# CHECK-NEXT:           %extracted_slice_9 = tensor.extract_slice %inserted_slice_7[%c1, 0] [1, 16] [1, 1] : tensor<2x16xf32> to tensor<1x16xf32>
-# CHECK-NEXT:           %11 = vector.transfer_read %extracted_slice_8[%c0, %c0], %0 {in_bounds = [true, true]} : tensor<1x1xf32>, vector<1x1xf32>
-# CHECK-NEXT:           %12 = vector.transfer_read %extracted_slice_3[%c0, %c0], %0 {in_bounds = [true, true]} : tensor<1x16xf32>, vector<1x16xf32>
-# CHECK-NEXT:           %13 = vector.transfer_read %extracted_slice_9[%c0, %c0], %0 {in_bounds = [true, true]} : tensor<1x16xf32>, vector<1x16xf32>
-# CHECK-NEXT:           %14 = vector.contract {indexing_maps = [#map, #map1, #map2], iterator_types = ["parallel", "parallel", "reduction"], kind = #vector.kind<add>} %11, %12, %13 : vector<1x1xf32>, vector<1x16xf32> into vector<1x16xf32>
-# CHECK-NEXT:           %15 = vector.transfer_write %14, %extracted_slice_9[%c0, %c0] {in_bounds = [true, true]} : vector<1x16xf32>, tensor<1x16xf32>
-# CHECK-NEXT:           %inserted_slice_10 = tensor.insert_slice %15 into %inserted_slice_7[%c1, 0] [1, 16] [1, 1] : tensor<1x16xf32> into tensor<2x16xf32>
-# CHECK-NEXT:           %inserted_slice_11 = tensor.insert_slice %inserted_slice_10 into %arg8[0, %arg7] [2, 16] [1, 1] : tensor<2x16xf32> into tensor<2x32xf32>
-# CHECK-NEXT:           scf.yield %inserted_slice_11 : tensor<2x32xf32>
-# CHECK-NEXT:         } {"./j"}
-# CHECK-NEXT:         %inserted_slice = tensor.insert_slice %5 into %arg6[%arg5, 0] [2, 32] [1, 1] : tensor<2x32xf32> into tensor<4x32xf32>
-# CHECK-NEXT:         scf.yield %inserted_slice : tensor<4x32xf32>
-# CHECK-NEXT:       } {"./i"}
-# CHECK-NEXT:       scf.yield %4 : tensor<4x32xf32>
-# CHECK-NEXT:     } {"./k"}
-# CHECK-NEXT:     bufferization.materialize_in_destination %3 in restrict writable %arg2 : (tensor<4x32xf32>, memref<4x32xf32>) -> ()
-# CHECK-NEXT:     return
-# CHECK-NEXT:   }
-# CHECK-NEXT:   transform.named_sequence @_vecto(%arg0: !transform.any_op {transform.consumed}) {
-# CHECK-NEXT:     transform.structured.vectorize %arg0 : !transform.any_op
-# CHECK-NEXT:     transform.yield 
-# CHECK-NEXT:   }
-# CHECK-NEXT:   transform.named_sequence @_post_bufferize(%arg0: !transform.any_op {transform.readonly}) {
-# CHECK-NEXT:     %0 = transform.structured.match attributes {sym_name = "matmul"} in %arg0 : (!transform.any_op) -> !transform.any_op
-# CHECK-NEXT:     transform.apply_patterns to %0 {
-# CHECK-NEXT:       transform.apply_patterns.vector.lower_outerproduct
-# CHECK-NEXT:       transform.apply_patterns.vector.lower_contraction
-# CHECK-NEXT:     } : !transform.any_op
-# CHECK-NEXT:     transform.yield 
-# CHECK-NEXT:   }
-# CHECK-NEXT: }
+# CHECK-NEXT:  // -----// IR Dump After transform //----- //
+# CHECK-NEXT:  #map = affine_map<(d0, d1, d2) -> (d0, d2)>
+# CHECK-NEXT:  #map1 = affine_map<(d0, d1, d2) -> (d2, d1)>
+# CHECK-NEXT:  #map2 = affine_map<(d0, d1, d2) -> (d0, d1)>
+# CHECK-NEXT:  module attributes {transform.with_named_sequence} {
+# CHECK-NEXT:    func.func @matmul(%arg0: tensor<4x512xf32> {llvm.noalias}, %arg1: tensor<512x32xf32> {llvm.noalias}, %arg2: memref<4x32xf32> {llvm.noalias}) {
+# CHECK-NEXT:      %0 = ub.poison : f32
+# CHECK-NEXT:      %c16 = arith.constant 16 : index
+# CHECK-NEXT:      %c32 = arith.constant 32 : index
+# CHECK-NEXT:      %c2 = arith.constant 2 : index
+# CHECK-NEXT:      %c4 = arith.constant 4 : index
+# CHECK-NEXT:      %c1 = arith.constant 1 : index
+# CHECK-NEXT:      %c512 = arith.constant 512 : index
+# CHECK-NEXT:      %c0 = arith.constant 0 : index
+# CHECK-NEXT:      %cst = arith.constant 0.000000e+00 : f32
+# CHECK-NEXT:      %1 = tensor.empty() : tensor<4x32xf32>
+# CHECK-NEXT:      %2 = linalg.fill {__xtc_id_C_0_} ins(%cst : f32) outs(%1 : tensor<4x32xf32>) -> tensor<4x32xf32>
+# CHECK-NEXT:      %3 = scf.for %arg3 = %c0 to %c512 step %c1 iter_args(%arg4 = %2) -> (tensor<4x32xf32>) {
+# CHECK-NEXT:        %extracted_slice = tensor.extract_slice %arg0[0, %arg3] [4, 1] [1, 1] : tensor<4x512xf32> to tensor<4x1xf32>
+# CHECK-NEXT:        %extracted_slice_0 = tensor.extract_slice %arg1[%arg3, 0] [1, 32] [1, 1] : tensor<512x32xf32> to tensor<1x32xf32>
+# CHECK-NEXT:        %4 = scf.for %arg5 = %c0 to %c4 step %c2 iter_args(%arg6 = %arg4) -> (tensor<4x32xf32>) {
+# CHECK-NEXT:          %extracted_slice_1 = tensor.extract_slice %extracted_slice[%arg5, 0] [2, 1] [1, 1] : tensor<4x1xf32> to tensor<2x1xf32>
+# CHECK-NEXT:          %extracted_slice_2 = tensor.extract_slice %arg6[%arg5, 0] [2, 32] [1, 1] : tensor<4x32xf32> to tensor<2x32xf32>
+# CHECK-NEXT:          %5 = scf.for %arg7 = %c0 to %c32 step %c16 iter_args(%arg8 = %extracted_slice_2) -> (tensor<2x32xf32>) {
+# CHECK-NEXT:            %extracted_slice_3 = tensor.extract_slice %extracted_slice_0[0, %arg7] [1, 16] [1, 1] : tensor<1x32xf32> to tensor<1x16xf32>
+# CHECK-NEXT:            %extracted_slice_4 = tensor.extract_slice %arg8[0, %arg7] [2, 16] [1, 1] : tensor<2x32xf32> to tensor<2x16xf32>
+# CHECK-NEXT:            %extracted_slice_5 = tensor.extract_slice %extracted_slice_1[%c0, 0] [1, 1] [1, 1] : tensor<2x1xf32> to tensor<1x1xf32>
+# CHECK-NEXT:            %extracted_slice_6 = tensor.extract_slice %extracted_slice_4[%c0, 0] [1, 16] [1, 1] : tensor<2x16xf32> to tensor<1x16xf32>
+# CHECK-NEXT:            %6 = vector.transfer_read %extracted_slice_5[%c0, %c0], %0 {in_bounds = [true, true]} : tensor<1x1xf32>, vector<1x1xf32>
+# CHECK-NEXT:            %7 = vector.transfer_read %extracted_slice_3[%c0, %c0], %0 {in_bounds = [true, true]} : tensor<1x16xf32>, vector<1x16xf32>
+# CHECK-NEXT:            %8 = vector.transfer_read %extracted_slice_6[%c0, %c0], %0 {in_bounds = [true, true]} : tensor<1x16xf32>, vector<1x16xf32>
+# CHECK-NEXT:            %9 = vector.contract {indexing_maps = [#map, #map1, #map2], iterator_types = ["parallel", "parallel", "reduction"], kind = #vector.kind<add>} %6, %7, %8 : vector<1x1xf32>, vector<1x16xf32> into vector<1x16xf32>
+# CHECK-NEXT:            %10 = vector.transfer_write %9, %extracted_slice_6[%c0, %c0] {in_bounds = [true, true]} : vector<1x16xf32>, tensor<1x16xf32>
+# CHECK-NEXT:            %inserted_slice_7 = tensor.insert_slice %10 into %extracted_slice_4[%c0, 0] [1, 16] [1, 1] : tensor<1x16xf32> into tensor<2x16xf32>
+# CHECK-NEXT:            %extracted_slice_8 = tensor.extract_slice %extracted_slice_1[%c1, 0] [1, 1] [1, 1] : tensor<2x1xf32> to tensor<1x1xf32>
+# CHECK-NEXT:            %extracted_slice_9 = tensor.extract_slice %inserted_slice_7[%c1, 0] [1, 16] [1, 1] : tensor<2x16xf32> to tensor<1x16xf32>
+# CHECK-NEXT:            %11 = vector.transfer_read %extracted_slice_8[%c0, %c0], %0 {in_bounds = [true, true]} : tensor<1x1xf32>, vector<1x1xf32>
+# CHECK-NEXT:            %12 = vector.transfer_read %extracted_slice_3[%c0, %c0], %0 {in_bounds = [true, true]} : tensor<1x16xf32>, vector<1x16xf32>
+# CHECK-NEXT:            %13 = vector.transfer_read %extracted_slice_9[%c0, %c0], %0 {in_bounds = [true, true]} : tensor<1x16xf32>, vector<1x16xf32>
+# CHECK-NEXT:            %14 = vector.contract {indexing_maps = [#map, #map1, #map2], iterator_types = ["parallel", "parallel", "reduction"], kind = #vector.kind<add>} %11, %12, %13 : vector<1x1xf32>, vector<1x16xf32> into vector<1x16xf32>
+# CHECK-NEXT:            %15 = vector.transfer_write %14, %extracted_slice_9[%c0, %c0] {in_bounds = [true, true]} : vector<1x16xf32>, tensor<1x16xf32>
+# CHECK-NEXT:            %inserted_slice_10 = tensor.insert_slice %15 into %inserted_slice_7[%c1, 0] [1, 16] [1, 1] : tensor<1x16xf32> into tensor<2x16xf32>
+# CHECK-NEXT:            %inserted_slice_11 = tensor.insert_slice %inserted_slice_10 into %arg8[0, %arg7] [2, 16] [1, 1] : tensor<2x16xf32> into tensor<2x32xf32>
+# CHECK-NEXT:            scf.yield %inserted_slice_11 : tensor<2x32xf32>
+# CHECK-NEXT:          } {"./j"}
+# CHECK-NEXT:          %inserted_slice = tensor.insert_slice %5 into %arg6[%arg5, 0] [2, 32] [1, 1] : tensor<2x32xf32> into tensor<4x32xf32>
+# CHECK-NEXT:          scf.yield %inserted_slice : tensor<4x32xf32>
+# CHECK-NEXT:        } {"./i"}
+# CHECK-NEXT:        scf.yield %4 : tensor<4x32xf32>
+# CHECK-NEXT:      } {"./k"}
+# CHECK-NEXT:      bufferization.materialize_in_destination %3 in restrict writable %arg2 : (tensor<4x32xf32>, memref<4x32xf32>) -> ()
+# CHECK-NEXT:      return
+# CHECK-NEXT:    }
+# CHECK-NEXT:    transform.named_sequence @_vecto(%arg0: !transform.any_op {transform.consumed}) {
+# CHECK-NEXT:      transform.structured.vectorize %arg0 : !transform.any_op
+# CHECK-NEXT:      transform.yield 
+# CHECK-NEXT:    }
+# CHECK-NEXT:    transform.named_sequence @_post_bufferize(%arg0: !transform.any_op {transform.readonly}) {
+# CHECK-NEXT:      %0 = transform.structured.match attributes {sym_name = "matmul"} in %arg0 : (!transform.any_op) -> !transform.any_op
+# CHECK-NEXT:      transform.apply_patterns to %0 {
+# CHECK-NEXT:        transform.apply_patterns.vector.lower_outerproduct
+# CHECK-NEXT:        transform.apply_patterns.vector.lower_contraction
+# CHECK-NEXT:      } : !transform.any_op
+# CHECK-NEXT:      transform.yield 
+# CHECK-NEXT:    }
+# CHECK-NEXT:  }
 # CHECK-NEXT:  
-# CHECK-NEXT: // -----// IR Dump After Tensor Lowering //----- //
-# CHECK-NEXT: module attributes {transform.with_named_sequence} {
-# CHECK-NEXT:   func.func @matmul(%arg0: memref<4x512xf32> {llvm.noalias}, %arg1: memref<512x32xf32> {llvm.noalias}, %arg2: memref<4x32xf32> {llvm.noalias}) {
-# CHECK-NEXT:     %cst = arith.constant dense<0.000000e+00> : vector<1x16xf32>
-# CHECK-NEXT:     %0 = ub.poison : f32
-# CHECK-NEXT:     %c16 = arith.constant 16 : index
-# CHECK-NEXT:     %c2 = arith.constant 2 : index
-# CHECK-NEXT:     %c512 = arith.constant 512 : index
-# CHECK-NEXT:     %c32 = arith.constant 32 : index
-# CHECK-NEXT:     %c1 = arith.constant 1 : index
-# CHECK-NEXT:     %c4 = arith.constant 4 : index
-# CHECK-NEXT:     %c0 = arith.constant 0 : index
-# CHECK-NEXT:     %cst_0 = arith.constant 0.000000e+00 : f32
-# CHECK-NEXT:     %1 = scf.for %arg3 = %c0 to %c4 step %c1 iter_args(%arg4 = %arg2) -> (memref<4x32xf32>) {
-# CHECK-NEXT:       %subview = memref.subview %arg4[%arg3, 0] [1, 32] [1, 1] : memref<4x32xf32> to memref<1x32xf32, strided<[32, 1], offset: ?>>
-# CHECK-NEXT:       %3 = scf.for %arg5 = %c0 to %c32 step %c1 iter_args(%arg6 = %subview) -> (memref<1x32xf32, strided<[32, 1], offset: ?>>) {
-# CHECK-NEXT:         %subview_2 = memref.subview %arg6[0, %arg5] [1, 1] [1, 1] : memref<1x32xf32, strided<[32, 1], offset: ?>> to memref<1x1xf32, strided<[32, 1], offset: ?>>
-# CHECK-NEXT:         linalg.fill {__xtc_id_C_0_} ins(%cst_0 : f32) outs(%subview_2 : memref<1x1xf32, strided<[32, 1], offset: ?>>)
-# CHECK-NEXT:         %subview_3 = memref.subview %arg6[0, %arg5] [1, 1] [1, 1] : memref<1x32xf32, strided<[32, 1], offset: ?>> to memref<1x1xf32, strided<[32, 1], offset: ?>>
-# CHECK-NEXT:         memref.copy %subview_2, %subview_3 : memref<1x1xf32, strided<[32, 1], offset: ?>> to memref<1x1xf32, strided<[32, 1], offset: ?>>
-# CHECK-NEXT:         scf.yield %arg6 : memref<1x32xf32, strided<[32, 1], offset: ?>>
-# CHECK-NEXT:       } {"./j"}
-# CHECK-NEXT:       %subview_1 = memref.subview %arg4[%arg3, 0] [1, 32] [1, 1] : memref<4x32xf32> to memref<1x32xf32, strided<[32, 1], offset: ?>>
-# CHECK-NEXT:       memref.copy %3, %subview_1 : memref<1x32xf32, strided<[32, 1], offset: ?>> to memref<1x32xf32, strided<[32, 1], offset: ?>>
-# CHECK-NEXT:       scf.yield %arg4 : memref<4x32xf32>
-# CHECK-NEXT:     } {"./i"}
-# CHECK-NEXT:     %2 = scf.for %arg3 = %c0 to %c512 step %c1 iter_args(%arg4 = %1) -> (memref<4x32xf32>) {
-# CHECK-NEXT:       %subview = memref.subview %arg0[0, %arg3] [4, 1] [1, 1] : memref<4x512xf32> to memref<4x1xf32, strided<[512, 1], offset: ?>>
-# CHECK-NEXT:       %subview_1 = memref.subview %arg1[%arg3, 0] [1, 32] [1, 1] : memref<512x32xf32> to memref<1x32xf32, strided<[32, 1], offset: ?>>
-# CHECK-NEXT:       %3 = scf.for %arg5 = %c0 to %c4 step %c2 iter_args(%arg6 = %arg4) -> (memref<4x32xf32>) {
-# CHECK-NEXT:         %subview_2 = memref.subview %subview[%arg5, 0] [2, 1] [1, 1] : memref<4x1xf32, strided<[512, 1], offset: ?>> to memref<2x1xf32, strided<[512, 1], offset: ?>>
-# CHECK-NEXT:         %subview_3 = memref.subview %arg6[%arg5, 0] [2, 32] [1, 1] : memref<4x32xf32> to memref<2x32xf32, strided<[32, 1], offset: ?>>
-# CHECK-NEXT:         %4 = scf.for %arg7 = %c0 to %c32 step %c16 iter_args(%arg8 = %subview_3) -> (memref<2x32xf32, strided<[32, 1], offset: ?>>) {
-# CHECK-NEXT:           %subview_5 = memref.subview %subview_1[0, %arg7] [1, 16] [1, 1] : memref<1x32xf32, strided<[32, 1], offset: ?>> to memref<1x16xf32, strided<[32, 1], offset: ?>>
-# CHECK-NEXT:           %subview_6 = memref.subview %arg8[0, %arg7] [2, 16] [1, 1] : memref<2x32xf32, strided<[32, 1], offset: ?>> to memref<2x16xf32, strided<[32, 1], offset: ?>>
-# CHECK-NEXT:           %subview_7 = memref.subview %subview_2[0, 0] [1, 1] [1, 1] : memref<2x1xf32, strided<[512, 1], offset: ?>> to memref<1x1xf32, strided<[512, 1], offset: ?>>
-# CHECK-NEXT:           %subview_8 = memref.subview %subview_6[0, 0] [1, 16] [1, 1] : memref<2x16xf32, strided<[32, 1], offset: ?>> to memref<1x16xf32, strided<[32, 1], offset: ?>>
-# CHECK-NEXT:           %5 = vector.transfer_read %subview_7[%c0, %c0], %0 {in_bounds = [true, true]} : memref<1x1xf32, strided<[512, 1], offset: ?>>, vector<1x1xf32>
-# CHECK-NEXT:           %6 = vector.transfer_read %subview_5[%c0, %c0], %0 {in_bounds = [true, true]} : memref<1x16xf32, strided<[32, 1], offset: ?>>, vector<1x16xf32>
-# CHECK-NEXT:           %7 = vector.transfer_read %subview_8[%c0, %c0], %0 {in_bounds = [true, true]} : memref<1x16xf32, strided<[32, 1], offset: ?>>, vector<1x16xf32>
-# CHECK-NEXT:           %8 = vector.extract %6[0] : vector<16xf32> from vector<1x16xf32>
-# CHECK-NEXT:           %9 = vector.extract %5[0, 0] : f32 from vector<1x1xf32>
-# CHECK-NEXT:           %10 = vector.broadcast %9 : f32 to vector<16xf32>
-# CHECK-NEXT:           %11 = vector.extract %7[0] : vector<16xf32> from vector<1x16xf32>
-# CHECK-NEXT:           %12 = vector.fma %10, %8, %11 : vector<16xf32>
-# CHECK-NEXT:           %13 = vector.insert %12, %cst [0] : vector<16xf32> into vector<1x16xf32>
-# CHECK-NEXT:           vector.transfer_write %13, %subview_8[%c0, %c0] {in_bounds = [true, true]} : vector<1x16xf32>, memref<1x16xf32, strided<[32, 1], offset: ?>>
-# CHECK-NEXT:           %subview_9 = memref.subview %subview_6[0, 0] [1, 16] [1, 1] : memref<2x16xf32, strided<[32, 1], offset: ?>> to memref<1x16xf32, strided<[32, 1], offset: ?>>
-# CHECK-NEXT:           memref.copy %subview_8, %subview_9 : memref<1x16xf32, strided<[32, 1], offset: ?>> to memref<1x16xf32, strided<[32, 1], offset: ?>>
-# CHECK-NEXT:           %subview_10 = memref.subview %subview_2[1, 0] [1, 1] [1, 1] : memref<2x1xf32, strided<[512, 1], offset: ?>> to memref<1x1xf32, strided<[512, 1], offset: ?>>
-# CHECK-NEXT:           %subview_11 = memref.subview %subview_6[1, 0] [1, 16] [1, 1] : memref<2x16xf32, strided<[32, 1], offset: ?>> to memref<1x16xf32, strided<[32, 1], offset: ?>>
-# CHECK-NEXT:           %14 = vector.transfer_read %subview_10[%c0, %c0], %0 {in_bounds = [true, true]} : memref<1x1xf32, strided<[512, 1], offset: ?>>, vector<1x1xf32>
-# CHECK-NEXT:           %15 = vector.transfer_read %subview_11[%c0, %c0], %0 {in_bounds = [true, true]} : memref<1x16xf32, strided<[32, 1], offset: ?>>, vector<1x16xf32>
-# CHECK-NEXT:           %16 = vector.extract %6[0] : vector<16xf32> from vector<1x16xf32>
-# CHECK-NEXT:           %17 = vector.extract %14[0, 0] : f32 from vector<1x1xf32>
-# CHECK-NEXT:           %18 = vector.broadcast %17 : f32 to vector<16xf32>
-# CHECK-NEXT:           %19 = vector.extract %15[0] : vector<16xf32> from vector<1x16xf32>
-# CHECK-NEXT:           %20 = vector.fma %18, %16, %19 : vector<16xf32>
-# CHECK-NEXT:           %21 = vector.insert %20, %cst [0] : vector<16xf32> into vector<1x16xf32>
-# CHECK-NEXT:           vector.transfer_write %21, %subview_11[%c0, %c0] {in_bounds = [true, true]} : vector<1x16xf32>, memref<1x16xf32, strided<[32, 1], offset: ?>>
-# CHECK-NEXT:           %subview_12 = memref.subview %subview_6[1, 0] [1, 16] [1, 1] : memref<2x16xf32, strided<[32, 1], offset: ?>> to memref<1x16xf32, strided<[32, 1], offset: ?>>
-# CHECK-NEXT:           memref.copy %subview_11, %subview_12 : memref<1x16xf32, strided<[32, 1], offset: ?>> to memref<1x16xf32, strided<[32, 1], offset: ?>>
-# CHECK-NEXT:           %subview_13 = memref.subview %arg8[0, %arg7] [2, 16] [1, 1] : memref<2x32xf32, strided<[32, 1], offset: ?>> to memref<2x16xf32, strided<[32, 1], offset: ?>>
-# CHECK-NEXT:           memref.copy %subview_6, %subview_13 : memref<2x16xf32, strided<[32, 1], offset: ?>> to memref<2x16xf32, strided<[32, 1], offset: ?>>
-# CHECK-NEXT:           scf.yield %arg8 : memref<2x32xf32, strided<[32, 1], offset: ?>>
-# CHECK-NEXT:         } {"./j"}
-# CHECK-NEXT:         %subview_4 = memref.subview %arg6[%arg5, 0] [2, 32] [1, 1] : memref<4x32xf32> to memref<2x32xf32, strided<[32, 1], offset: ?>>
-# CHECK-NEXT:         memref.copy %4, %subview_4 : memref<2x32xf32, strided<[32, 1], offset: ?>> to memref<2x32xf32, strided<[32, 1], offset: ?>>
-# CHECK-NEXT:         scf.yield %arg6 : memref<4x32xf32>
-# CHECK-NEXT:       } {"./i"}
-# CHECK-NEXT:       scf.yield %3 : memref<4x32xf32>
-# CHECK-NEXT:     } {"./k"}
-# CHECK-NEXT:     memref.copy %2, %arg2 : memref<4x32xf32> to memref<4x32xf32>
-# CHECK-NEXT:     return
-# CHECK-NEXT:   }
-# CHECK-NEXT: }
+# CHECK-NEXT:  // -----// IR Dump After Tensor Lowering //----- //
+# CHECK-NEXT:  module attributes {transform.with_named_sequence} {
+# CHECK-NEXT:    func.func @matmul(%arg0: memref<4x512xf32> {llvm.noalias}, %arg1: memref<512x32xf32> {llvm.noalias}, %arg2: memref<4x32xf32> {llvm.noalias}) {
+# CHECK-NEXT:      %cst = arith.constant dense<0.000000e+00> : vector<1x16xf32>
+# CHECK-NEXT:      %0 = ub.poison : f32
+# CHECK-NEXT:      %c16 = arith.constant 16 : index
+# CHECK-NEXT:      %c32 = arith.constant 32 : index
+# CHECK-NEXT:      %c2 = arith.constant 2 : index
+# CHECK-NEXT:      %c4 = arith.constant 4 : index
+# CHECK-NEXT:      %c1 = arith.constant 1 : index
+# CHECK-NEXT:      %c512 = arith.constant 512 : index
+# CHECK-NEXT:      %c0 = arith.constant 0 : index
+# CHECK-NEXT:      %cst_0 = arith.constant 0.000000e+00 : f32
+# CHECK-NEXT:      linalg.fill {__xtc_id_C_0_} ins(%cst_0 : f32) outs(%arg2 : memref<4x32xf32>)
+# CHECK-NEXT:      %1 = scf.for %arg3 = %c0 to %c512 step %c1 iter_args(%arg4 = %arg2) -> (memref<4x32xf32>) {
+# CHECK-NEXT:        %subview = memref.subview %arg0[0, %arg3] [4, 1] [1, 1] : memref<4x512xf32> to memref<4x1xf32, strided<[512, 1], offset: ?>>
+# CHECK-NEXT:        %subview_1 = memref.subview %arg1[%arg3, 0] [1, 32] [1, 1] : memref<512x32xf32> to memref<1x32xf32, strided<[32, 1], offset: ?>>
+# CHECK-NEXT:        %2 = scf.for %arg5 = %c0 to %c4 step %c2 iter_args(%arg6 = %arg4) -> (memref<4x32xf32>) {
+# CHECK-NEXT:          %subview_2 = memref.subview %subview[%arg5, 0] [2, 1] [1, 1] : memref<4x1xf32, strided<[512, 1], offset: ?>> to memref<2x1xf32, strided<[512, 1], offset: ?>>
+# CHECK-NEXT:          %subview_3 = memref.subview %arg6[%arg5, 0] [2, 32] [1, 1] : memref<4x32xf32> to memref<2x32xf32, strided<[32, 1], offset: ?>>
+# CHECK-NEXT:          %3 = scf.for %arg7 = %c0 to %c32 step %c16 iter_args(%arg8 = %subview_3) -> (memref<2x32xf32, strided<[32, 1], offset: ?>>) {
+# CHECK-NEXT:            %subview_5 = memref.subview %subview_1[0, %arg7] [1, 16] [1, 1] : memref<1x32xf32, strided<[32, 1], offset: ?>> to memref<1x16xf32, strided<[32, 1], offset: ?>>
+# CHECK-NEXT:            %subview_6 = memref.subview %arg8[0, %arg7] [2, 16] [1, 1] : memref<2x32xf32, strided<[32, 1], offset: ?>> to memref<2x16xf32, strided<[32, 1], offset: ?>>
+# CHECK-NEXT:            %subview_7 = memref.subview %subview_2[0, 0] [1, 1] [1, 1] : memref<2x1xf32, strided<[512, 1], offset: ?>> to memref<1x1xf32, strided<[512, 1], offset: ?>>
+# CHECK-NEXT:            %subview_8 = memref.subview %subview_6[0, 0] [1, 16] [1, 1] : memref<2x16xf32, strided<[32, 1], offset: ?>> to memref<1x16xf32, strided<[32, 1], offset: ?>>
+# CHECK-NEXT:            %4 = vector.transfer_read %subview_7[%c0, %c0], %0 {in_bounds = [true, true]} : memref<1x1xf32, strided<[512, 1], offset: ?>>, vector<1x1xf32>
+# CHECK-NEXT:            %5 = vector.transfer_read %subview_5[%c0, %c0], %0 {in_bounds = [true, true]} : memref<1x16xf32, strided<[32, 1], offset: ?>>, vector<1x16xf32>
+# CHECK-NEXT:            %6 = vector.transfer_read %subview_8[%c0, %c0], %0 {in_bounds = [true, true]} : memref<1x16xf32, strided<[32, 1], offset: ?>>, vector<1x16xf32>
+# CHECK-NEXT:            %7 = vector.extract %5[0] : vector<16xf32> from vector<1x16xf32>
+# CHECK-NEXT:            %8 = vector.extract %4[0, 0] : f32 from vector<1x1xf32>
+# CHECK-NEXT:            %9 = vector.broadcast %8 : f32 to vector<16xf32>
+# CHECK-NEXT:            %10 = vector.extract %6[0] : vector<16xf32> from vector<1x16xf32>
+# CHECK-NEXT:            %11 = vector.fma %9, %7, %10 : vector<16xf32>
+# CHECK-NEXT:            %12 = vector.insert %11, %cst [0] : vector<16xf32> into vector<1x16xf32>
+# CHECK-NEXT:            vector.transfer_write %12, %subview_8[%c0, %c0] {in_bounds = [true, true]} : vector<1x16xf32>, memref<1x16xf32, strided<[32, 1], offset: ?>>
+# CHECK-NEXT:            %subview_9 = memref.subview %subview_6[0, 0] [1, 16] [1, 1] : memref<2x16xf32, strided<[32, 1], offset: ?>> to memref<1x16xf32, strided<[32, 1], offset: ?>>
+# CHECK-NEXT:            memref.copy %subview_8, %subview_9 : memref<1x16xf32, strided<[32, 1], offset: ?>> to memref<1x16xf32, strided<[32, 1], offset: ?>>
+# CHECK-NEXT:            %subview_10 = memref.subview %subview_2[1, 0] [1, 1] [1, 1] : memref<2x1xf32, strided<[512, 1], offset: ?>> to memref<1x1xf32, strided<[512, 1], offset: ?>>
+# CHECK-NEXT:            %subview_11 = memref.subview %subview_6[1, 0] [1, 16] [1, 1] : memref<2x16xf32, strided<[32, 1], offset: ?>> to memref<1x16xf32, strided<[32, 1], offset: ?>>
+# CHECK-NEXT:            %13 = vector.transfer_read %subview_10[%c0, %c0], %0 {in_bounds = [true, true]} : memref<1x1xf32, strided<[512, 1], offset: ?>>, vector<1x1xf32>
+# CHECK-NEXT:            %14 = vector.transfer_read %subview_11[%c0, %c0], %0 {in_bounds = [true, true]} : memref<1x16xf32, strided<[32, 1], offset: ?>>, vector<1x16xf32>
+# CHECK-NEXT:            %15 = vector.extract %5[0] : vector<16xf32> from vector<1x16xf32>
+# CHECK-NEXT:            %16 = vector.extract %13[0, 0] : f32 from vector<1x1xf32>
+# CHECK-NEXT:            %17 = vector.broadcast %16 : f32 to vector<16xf32>
+# CHECK-NEXT:            %18 = vector.extract %14[0] : vector<16xf32> from vector<1x16xf32>
+# CHECK-NEXT:            %19 = vector.fma %17, %15, %18 : vector<16xf32>
+# CHECK-NEXT:            %20 = vector.insert %19, %cst [0] : vector<16xf32> into vector<1x16xf32>
+# CHECK-NEXT:            vector.transfer_write %20, %subview_11[%c0, %c0] {in_bounds = [true, true]} : vector<1x16xf32>, memref<1x16xf32, strided<[32, 1], offset: ?>>
+# CHECK-NEXT:            %subview_12 = memref.subview %subview_6[1, 0] [1, 16] [1, 1] : memref<2x16xf32, strided<[32, 1], offset: ?>> to memref<1x16xf32, strided<[32, 1], offset: ?>>
+# CHECK-NEXT:            memref.copy %subview_11, %subview_12 : memref<1x16xf32, strided<[32, 1], offset: ?>> to memref<1x16xf32, strided<[32, 1], offset: ?>>
+# CHECK-NEXT:            %subview_13 = memref.subview %arg8[0, %arg7] [2, 16] [1, 1] : memref<2x32xf32, strided<[32, 1], offset: ?>> to memref<2x16xf32, strided<[32, 1], offset: ?>>
+# CHECK-NEXT:            memref.copy %subview_6, %subview_13 : memref<2x16xf32, strided<[32, 1], offset: ?>> to memref<2x16xf32, strided<[32, 1], offset: ?>>
+# CHECK-NEXT:            scf.yield %arg8 : memref<2x32xf32, strided<[32, 1], offset: ?>>
+# CHECK-NEXT:          } {"./j"}
+# CHECK-NEXT:          %subview_4 = memref.subview %arg6[%arg5, 0] [2, 32] [1, 1] : memref<4x32xf32> to memref<2x32xf32, strided<[32, 1], offset: ?>>
+# CHECK-NEXT:          memref.copy %3, %subview_4 : memref<2x32xf32, strided<[32, 1], offset: ?>> to memref<2x32xf32, strided<[32, 1], offset: ?>>
+# CHECK-NEXT:          scf.yield %arg6 : memref<4x32xf32>
+# CHECK-NEXT:        } {"./i"}
+# CHECK-NEXT:        scf.yield %2 : memref<4x32xf32>
+# CHECK-NEXT:      } {"./k"}
+# CHECK-NEXT:      memref.copy %1, %arg2 : memref<4x32xf32> to memref<4x32xf32>
+# CHECK-NEXT:      return
+# CHECK-NEXT:    }
+# CHECK-NEXT:  }
 # CHECK-NEXT:  
-# CHECK-NEXT: graph:
-# CHECK-NEXT:   name: matmul
-# CHECK-NEXT:   inputs:
-# CHECK-NEXT:   - %0 : 4x512xfloat32
-# CHECK-NEXT:   - %1 : 512x32xfloat32
-# CHECK-NEXT:   outputs:
-# CHECK-NEXT:   - %2 : 4x32xfloat32
-# CHECK-NEXT:   nodes:
-# CHECK-NEXT:   - %2: matmul(%0, %1) {name = 'C'} : [4x512xfloat32, 512x32xfloat32] -> [4x32xfloat32]
+# CHECK-NEXT:  graph:
+# CHECK-NEXT:    name: matmul
+# CHECK-NEXT:    inputs:
+# CHECK-NEXT:    - %0 : 4x512xfloat32
+# CHECK-NEXT:    - %1 : 512x32xfloat32
+# CHECK-NEXT:    outputs:
+# CHECK-NEXT:    - %2 : 4x32xfloat32
+# CHECK-NEXT:    nodes:
+# CHECK-NEXT:    - %2: matmul(%0, %1) {name = 'C'} : [4x512xfloat32, 512x32xfloat32] -> [4x32xfloat32]
 # CHECK-NEXT:  
-# CHECK-NEXT: CODE: 0
+# CHECK-NEXT:  CODE: 0

--- a/tests/filecheck/backends/tensor_dialect/test_matmul_mlir_tensor_layout.py
+++ b/tests/filecheck/backends/tensor_dialect/test_matmul_mlir_tensor_layout.py
@@ -28,56 +28,51 @@ module = comp.compile(sched)
 executor = module.get_executor(validate=True)
 res = executor.execute()
 print(f"CODE: {res}")
-# CHECK: // -----// IR Dump Before transform //----- //
-# CHECK-NEXT: #map = affine_map<(d0, d1, d2) -> (d2, d0)>
-# CHECK-NEXT: #map1 = affine_map<(d0, d1, d2) -> (d2, d1)>
-# CHECK-NEXT: #map2 = affine_map<(d0, d1, d2) -> (d0, d1)>
-# CHECK-NEXT: module attributes {transform.with_named_sequence} {
-# CHECK-NEXT:   func.func @matmul_layout(%arg0: tensor<512x4xf32> {llvm.noalias}, %arg1: tensor<512x32xf32> {llvm.noalias}, %arg2: memref<4x32xf32> {llvm.noalias}) {
-# CHECK-NEXT:     %0 = tensor.empty() : tensor<4x32xf32>
-# CHECK-NEXT:     %cst = arith.constant 0.000000e+00 : f32
-# CHECK-NEXT:     %1 = linalg.fill {__xtc_id_C_0_} ins(%cst : f32) outs(%0 : tensor<4x32xf32>) -> tensor<4x32xf32>
-# CHECK-NEXT:     %2 = linalg.generic {indexing_maps = [#map, #map1, #map2], iterator_types = ["parallel", "parallel", "reduction"]} ins(%arg0, %arg1 : tensor<512x4xf32>, tensor<512x32xf32>) outs(%1 : tensor<4x32xf32>) attrs =  {__xtc_id_C_} {
-# CHECK-NEXT:     ^bb0(%in: f32, %in_0: f32, %out: f32):
-# CHECK-NEXT:       %3 = arith.mulf %in, %in_0 : f32
-# CHECK-NEXT:       %4 = arith.addf %out, %3 : f32
-# CHECK-NEXT:       linalg.yield %4 : f32
-# CHECK-NEXT:     } -> tensor<4x32xf32>
-# CHECK-NEXT:     bufferization.materialize_in_destination %2 in restrict writable %arg2 : (tensor<4x32xf32>, memref<4x32xf32>) -> ()
-# CHECK-NEXT:     return
-# CHECK-NEXT:   }
-# CHECK-NEXT:   transform.named_sequence @_vecto(%arg0: !transform.any_op {transform.consumed}) {
-# CHECK-NEXT:     transform.structured.vectorize %arg0 : !transform.any_op
-# CHECK-NEXT:     transform.yield 
-# CHECK-NEXT:   }
-# CHECK-NEXT:   transform.named_sequence @_post_bufferize(%arg0: !transform.any_op {transform.readonly}) {
-# CHECK-NEXT:     transform.yield 
-# CHECK-NEXT:   }
-# CHECK-NEXT:   transform.named_sequence @__transform_main(%arg0: !transform.any_op {transform.readonly}) {
-# CHECK-NEXT:     %0 = transform.structured.match attributes {__xtc_id_C_0_} in %arg0 : (!transform.any_op) -> !transform.any_op
-# CHECK-NEXT:     %tiled_linalg_op, %loops = transform.structured.tile_using_for %0 tile_sizes [1, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:     transform.annotate %loops "./i" : !transform.any_op
-# CHECK-NEXT:     %tiled_linalg_op_0, %loops_1 = transform.structured.tile_using_for %tiled_linalg_op tile_sizes [0, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:     transform.annotate %loops_1 "./j" : !transform.any_op
-# CHECK-NEXT:     %1 = transform.structured.match attributes {__xtc_id_C_} in %arg0 : (!transform.any_op) -> !transform.any_op
-# CHECK-NEXT:     %tiled_linalg_op_2, %loops_3 = transform.structured.tile_using_for %1 tile_sizes [1, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:     transform.annotate %loops_3 "./i" : !transform.any_op
-# CHECK-NEXT:     %tiled_linalg_op_4, %loops_5 = transform.structured.tile_using_for %tiled_linalg_op_2 tile_sizes [0, 1, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:     transform.annotate %loops_5 "./j" : !transform.any_op
-# CHECK-NEXT:     %tiled_linalg_op_6, %loops_7 = transform.structured.tile_using_for %tiled_linalg_op_4 tile_sizes [0, 0, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:     transform.annotate %loops_7 "./k" : !transform.any_op
-# CHECK-NEXT:     transform.yield 
-# CHECK-NEXT:   }
-# CHECK-NEXT: }
+# CHECK:       // -----// IR Dump Before transform //----- //
+# CHECK-NEXT:  #map = affine_map<(d0, d1, d2) -> (d2, d0)>
+# CHECK-NEXT:  #map1 = affine_map<(d0, d1, d2) -> (d2, d1)>
+# CHECK-NEXT:  #map2 = affine_map<(d0, d1, d2) -> (d0, d1)>
+# CHECK-NEXT:  module attributes {transform.with_named_sequence} {
+# CHECK-NEXT:    func.func @matmul_layout(%arg0: tensor<512x4xf32> {llvm.noalias}, %arg1: tensor<512x32xf32> {llvm.noalias}, %arg2: memref<4x32xf32> {llvm.noalias}) {
+# CHECK-NEXT:      %0 = tensor.empty() : tensor<4x32xf32>
+# CHECK-NEXT:      %cst = arith.constant 0.000000e+00 : f32
+# CHECK-NEXT:      %1 = linalg.fill {__xtc_id_C_0_} ins(%cst : f32) outs(%0 : tensor<4x32xf32>) -> tensor<4x32xf32>
+# CHECK-NEXT:      %2 = linalg.generic {indexing_maps = [#map, #map1, #map2], iterator_types = ["parallel", "parallel", "reduction"]} ins(%arg0, %arg1 : tensor<512x4xf32>, tensor<512x32xf32>) outs(%1 : tensor<4x32xf32>) attrs =  {__xtc_id_C_} {
+# CHECK-NEXT:      ^bb0(%in: f32, %in_0: f32, %out: f32):
+# CHECK-NEXT:        %3 = arith.mulf %in, %in_0 : f32
+# CHECK-NEXT:        %4 = arith.addf %out, %3 : f32
+# CHECK-NEXT:        linalg.yield %4 : f32
+# CHECK-NEXT:      } -> tensor<4x32xf32>
+# CHECK-NEXT:      bufferization.materialize_in_destination %2 in restrict writable %arg2 : (tensor<4x32xf32>, memref<4x32xf32>) -> ()
+# CHECK-NEXT:      return
+# CHECK-NEXT:    }
+# CHECK-NEXT:    transform.named_sequence @_vecto(%arg0: !transform.any_op {transform.consumed}) {
+# CHECK-NEXT:      transform.structured.vectorize %arg0 : !transform.any_op
+# CHECK-NEXT:      transform.yield 
+# CHECK-NEXT:    }
+# CHECK-NEXT:    transform.named_sequence @_post_bufferize(%arg0: !transform.any_op {transform.readonly}) {
+# CHECK-NEXT:      transform.yield 
+# CHECK-NEXT:    }
+# CHECK-NEXT:    transform.named_sequence @__transform_main(%arg0: !transform.any_op {transform.readonly}) {
+# CHECK-NEXT:      %0 = transform.structured.match attributes {__xtc_id_C_} in %arg0 : (!transform.any_op) -> !transform.any_op
+# CHECK-NEXT:      %tiled_linalg_op, %loops = transform.structured.tile_using_for %0 tile_sizes [1, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      transform.annotate %loops "./i" : !transform.any_op
+# CHECK-NEXT:      %tiled_linalg_op_0, %loops_1 = transform.structured.tile_using_for %tiled_linalg_op tile_sizes [0, 1, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      transform.annotate %loops_1 "./j" : !transform.any_op
+# CHECK-NEXT:      %tiled_linalg_op_2, %loops_3 = transform.structured.tile_using_for %tiled_linalg_op_0 tile_sizes [0, 0, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      transform.annotate %loops_3 "./k" : !transform.any_op
+# CHECK-NEXT:      transform.yield 
+# CHECK-NEXT:    }
+# CHECK-NEXT:  }
 # CHECK-NEXT:  
-# CHECK-NEXT: graph:
-# CHECK-NEXT:   name: matmul_layout
-# CHECK-NEXT:   inputs:
-# CHECK-NEXT:   - %0 : 4x512xfloat32, <(0,1)->(1,0)>
-# CHECK-NEXT:   - %1 : 512x32xfloat32
-# CHECK-NEXT:   outputs:
-# CHECK-NEXT:   - %2 : 4x32xfloat32
-# CHECK-NEXT:   nodes:
-# CHECK-NEXT:   - %2: matmul(%0, %1) {name = 'C'} : [4x512xfloat32, <(0,1)->(1,0)>, 512x32xfloat32] -> [4x32xfloat32]
+# CHECK-NEXT:  graph:
+# CHECK-NEXT:    name: matmul_layout
+# CHECK-NEXT:    inputs:
+# CHECK-NEXT:    - %0 : 4x512xfloat32, <(0,1)->(1,0)>
+# CHECK-NEXT:    - %1 : 512x32xfloat32
+# CHECK-NEXT:    outputs:
+# CHECK-NEXT:    - %2 : 4x32xfloat32
+# CHECK-NEXT:    nodes:
+# CHECK-NEXT:    - %2: matmul(%0, %1) {name = 'C'} : [4x512xfloat32, <(0,1)->(1,0)>, 512x32xfloat32] -> [4x32xfloat32]
 # CHECK-NEXT:  
-# CHECK-NEXT: CODE: 0
+# CHECK-NEXT:  CODE: 0

--- a/tests/filecheck/backends/tensor_dialect/test_matmul_relu_mlir_tensor.py
+++ b/tests/filecheck/backends/tensor_dialect/test_matmul_relu_mlir_tensor.py
@@ -37,266 +37,239 @@ executor = module.get_executor(validate=True)
 res = executor.execute()
 print(f"CODE: {res}")
 
-# CHECK: // -----// IR Dump Before transform //----- //
-# CHECK-NEXT: #map = affine_map<(d0, d1) -> (d0, d1)>
-# CHECK-NEXT: #map1 = affine_map<(d0, d1) -> ()>
-# CHECK-NEXT: module attributes {transform.with_named_sequence} {
-# CHECK-NEXT:   func.func @matmul_relu(%arg0: tensor<4x512xf32> {llvm.noalias}, %arg1: tensor<512x32xf32> {llvm.noalias}, %arg2: memref<4x32xf32> {llvm.noalias}) {
-# CHECK-NEXT:     %0 = tensor.empty() : tensor<4x32xf32>
-# CHECK-NEXT:     %cst = arith.constant 0.000000e+00 : f32
-# CHECK-NEXT:     %1 = linalg.fill {__xtc_id_matmul_0_} ins(%cst : f32) outs(%0 : tensor<4x32xf32>) -> tensor<4x32xf32>
-# CHECK-NEXT:     %2 = linalg.matmul {__xtc_id_matmul_} ins(%arg0, %arg1 : tensor<4x512xf32>, tensor<512x32xf32>) outs(%1 : tensor<4x32xf32>) -> tensor<4x32xf32>
-# CHECK-NEXT:     %3 = tensor.empty() : tensor<4x32xf32>
-# CHECK-NEXT:     %cst_0 = arith.constant 0.000000e+00 : f32
-# CHECK-NEXT:     %4 = linalg.generic {indexing_maps = [#map, #map1, #map], iterator_types = ["parallel", "parallel"]} ins(%2, %cst_0 : tensor<4x32xf32>, f32) outs(%3 : tensor<4x32xf32>) attrs =  {__xtc_id_relu_} {
-# CHECK-NEXT:     ^bb0(%in: f32, %in_1: f32, %out: f32):
-# CHECK-NEXT:       %5 = arith.maximumf %in, %in_1 : f32
-# CHECK-NEXT:       linalg.yield %5 : f32
-# CHECK-NEXT:     } -> tensor<4x32xf32>
-# CHECK-NEXT:     bufferization.materialize_in_destination %4 in restrict writable %arg2 : (tensor<4x32xf32>, memref<4x32xf32>) -> ()
-# CHECK-NEXT:     return
-# CHECK-NEXT:   }
-# CHECK-NEXT:   transform.named_sequence @_vecto(%arg0: !transform.any_op {transform.consumed}) {
-# CHECK-NEXT:     transform.structured.vectorize %arg0 : !transform.any_op
-# CHECK-NEXT:     transform.yield 
-# CHECK-NEXT:   }
-# CHECK-NEXT:   transform.named_sequence @_post_bufferize(%arg0: !transform.any_op {transform.readonly}) {
-# CHECK-NEXT:     %0 = transform.structured.match attributes {sym_name = "matmul_relu"} in %arg0 : (!transform.any_op) -> !transform.any_op
-# CHECK-NEXT:     transform.apply_patterns to %0 {
-# CHECK-NEXT:       transform.apply_patterns.vector.lower_outerproduct
-# CHECK-NEXT:       transform.apply_patterns.vector.lower_contraction
-# CHECK-NEXT:     } : !transform.any_op
-# CHECK-NEXT:     transform.yield 
-# CHECK-NEXT:   }
-# CHECK-NEXT:   transform.named_sequence @__transform_main(%arg0: !transform.any_op {transform.readonly}) {
-# CHECK-NEXT:     %0 = transform.structured.match attributes {__xtc_id_matmul_0_} in %arg0 : (!transform.any_op) -> !transform.any_op
-# CHECK-NEXT:     %tiled_linalg_op, %loops = transform.structured.tile_using_for %0 tile_sizes [1, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:     transform.annotate %loops "./i" : !transform.any_op
-# CHECK-NEXT:     %tiled_linalg_op_0, %loops_1 = transform.structured.tile_using_for %tiled_linalg_op tile_sizes [0, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:     transform.annotate %loops_1 "./j" : !transform.any_op
-# CHECK-NEXT:     %1 = transform.structured.match attributes {__xtc_id_matmul_} in %arg0 : (!transform.any_op) -> !transform.any_op
-# CHECK-NEXT:     %tiled_linalg_op_2, %loops_3 = transform.structured.tile_using_for %1 tile_sizes [0, 0, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:     transform.annotate %loops_3 "./k" : !transform.any_op
-# CHECK-NEXT:     %tiled_linalg_op_4, %loops_5 = transform.structured.tile_using_for %tiled_linalg_op_2 tile_sizes [2, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:     transform.annotate %loops_5 "./i" : !transform.any_op
-# CHECK-NEXT:     %tiled_linalg_op_6, %loops_7 = transform.structured.tile_using_for %tiled_linalg_op_4 tile_sizes [0, 16, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:     transform.annotate %loops_7 "./j" : !transform.any_op
-# CHECK-NEXT:     %tiled_linalg_op_8, %loops_9 = transform.structured.tile_using_for %tiled_linalg_op_6 tile_sizes [1, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:     transform.annotate %loops_9 "./i1" : !transform.any_op
-# CHECK-NEXT:     %2 = transform.get_parent_op %tiled_linalg_op_8 : (!transform.any_op) -> !transform.any_op
-# CHECK-NEXT:     transform.apply_patterns to %2 {
-# CHECK-NEXT:       transform.apply_patterns.linalg.fold_unit_extent_dims_via_slices
-# CHECK-NEXT:     } : !transform.any_op
-# CHECK-NEXT:     %3 = transform.structured.match interface{LinalgOp} in %2 : (!transform.any_op) -> !transform.any_op
-# CHECK-NEXT:     transform.include @_vecto failures(suppress) (%3) : (!transform.any_op) -> ()
-# CHECK-NEXT:     transform.loop.unroll %loops_9 {factor = 2 : i64} : !transform.any_op
-# CHECK-NEXT:     %4 = transform.get_parent_op %loops_3 {isolated_from_above} : (!transform.any_op) -> !transform.any_op
-# CHECK-NEXT:     transform.apply_patterns to %4 {
-# CHECK-NEXT:       transform.apply_patterns.vector.reduction_to_contract
-# CHECK-NEXT:       transform.apply_patterns.vector.transfer_permutation_patterns
-# CHECK-NEXT:     } : !transform.any_op
-# CHECK-NEXT:     %5 = transform.structured.match attributes {__xtc_id_relu_} in %arg0 : (!transform.any_op) -> !transform.any_op
-# CHECK-NEXT:     %tiled_linalg_op_10, %loops_11 = transform.structured.tile_using_for %5 tile_sizes [1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:     transform.annotate %loops_11 "./i" : !transform.any_op
-# CHECK-NEXT:     transform.yield 
-# CHECK-NEXT:   }
-# CHECK-NEXT: }
+# CHECK:       // -----// IR Dump Before transform //----- //
+# CHECK-NEXT:  #map = affine_map<(d0, d1) -> (d0, d1)>
+# CHECK-NEXT:  #map1 = affine_map<(d0, d1) -> ()>
+# CHECK-NEXT:  module attributes {transform.with_named_sequence} {
+# CHECK-NEXT:    func.func @matmul_relu(%arg0: tensor<4x512xf32> {llvm.noalias}, %arg1: tensor<512x32xf32> {llvm.noalias}, %arg2: memref<4x32xf32> {llvm.noalias}) {
+# CHECK-NEXT:      %0 = tensor.empty() : tensor<4x32xf32>
+# CHECK-NEXT:      %cst = arith.constant 0.000000e+00 : f32
+# CHECK-NEXT:      %1 = linalg.fill {__xtc_id_matmul_0_} ins(%cst : f32) outs(%0 : tensor<4x32xf32>) -> tensor<4x32xf32>
+# CHECK-NEXT:      %2 = linalg.matmul {__xtc_id_matmul_} ins(%arg0, %arg1 : tensor<4x512xf32>, tensor<512x32xf32>) outs(%1 : tensor<4x32xf32>) -> tensor<4x32xf32>
+# CHECK-NEXT:      %3 = tensor.empty() : tensor<4x32xf32>
+# CHECK-NEXT:      %cst_0 = arith.constant 0.000000e+00 : f32
+# CHECK-NEXT:      %4 = linalg.generic {indexing_maps = [#map, #map1, #map], iterator_types = ["parallel", "parallel"]} ins(%2, %cst_0 : tensor<4x32xf32>, f32) outs(%3 : tensor<4x32xf32>) attrs =  {__xtc_id_relu_} {
+# CHECK-NEXT:      ^bb0(%in: f32, %in_1: f32, %out: f32):
+# CHECK-NEXT:        %5 = arith.maximumf %in, %in_1 : f32
+# CHECK-NEXT:        linalg.yield %5 : f32
+# CHECK-NEXT:      } -> tensor<4x32xf32>
+# CHECK-NEXT:      bufferization.materialize_in_destination %4 in restrict writable %arg2 : (tensor<4x32xf32>, memref<4x32xf32>) -> ()
+# CHECK-NEXT:      return
+# CHECK-NEXT:    }
+# CHECK-NEXT:    transform.named_sequence @_vecto(%arg0: !transform.any_op {transform.consumed}) {
+# CHECK-NEXT:      transform.structured.vectorize %arg0 : !transform.any_op
+# CHECK-NEXT:      transform.yield 
+# CHECK-NEXT:    }
+# CHECK-NEXT:    transform.named_sequence @_post_bufferize(%arg0: !transform.any_op {transform.readonly}) {
+# CHECK-NEXT:      %0 = transform.structured.match attributes {sym_name = "matmul_relu"} in %arg0 : (!transform.any_op) -> !transform.any_op
+# CHECK-NEXT:      transform.apply_patterns to %0 {
+# CHECK-NEXT:        transform.apply_patterns.vector.lower_outerproduct
+# CHECK-NEXT:        transform.apply_patterns.vector.lower_contraction
+# CHECK-NEXT:      } : !transform.any_op
+# CHECK-NEXT:      transform.yield 
+# CHECK-NEXT:    }
+# CHECK-NEXT:    transform.named_sequence @__transform_main(%arg0: !transform.any_op {transform.readonly}) {
+# CHECK-NEXT:      %0 = transform.structured.match attributes {__xtc_id_matmul_} in %arg0 : (!transform.any_op) -> !transform.any_op
+# CHECK-NEXT:      %tiled_linalg_op, %loops = transform.structured.tile_using_for %0 tile_sizes [0, 0, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      transform.annotate %loops "./k" : !transform.any_op
+# CHECK-NEXT:      %tiled_linalg_op_0, %loops_1 = transform.structured.tile_using_for %tiled_linalg_op tile_sizes [2, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      transform.annotate %loops_1 "./i" : !transform.any_op
+# CHECK-NEXT:      %tiled_linalg_op_2, %loops_3 = transform.structured.tile_using_for %tiled_linalg_op_0 tile_sizes [0, 16, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      transform.annotate %loops_3 "./j" : !transform.any_op
+# CHECK-NEXT:      %tiled_linalg_op_4, %loops_5 = transform.structured.tile_using_for %tiled_linalg_op_2 tile_sizes [1, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      transform.annotate %loops_5 "./i1" : !transform.any_op
+# CHECK-NEXT:      %1 = transform.get_parent_op %tiled_linalg_op_4 : (!transform.any_op) -> !transform.any_op
+# CHECK-NEXT:      transform.apply_patterns to %1 {
+# CHECK-NEXT:        transform.apply_patterns.linalg.fold_unit_extent_dims_via_slices
+# CHECK-NEXT:      } : !transform.any_op
+# CHECK-NEXT:      %2 = transform.structured.match interface{LinalgOp} in %1 : (!transform.any_op) -> !transform.any_op
+# CHECK-NEXT:      transform.include @_vecto failures(suppress) (%2) : (!transform.any_op) -> ()
+# CHECK-NEXT:      transform.loop.unroll %loops_5 {factor = 2 : i64} : !transform.any_op
+# CHECK-NEXT:      %3 = transform.get_parent_op %loops {isolated_from_above} : (!transform.any_op) -> !transform.any_op
+# CHECK-NEXT:      transform.apply_patterns to %3 {
+# CHECK-NEXT:        transform.apply_patterns.vector.reduction_to_contract
+# CHECK-NEXT:        transform.apply_patterns.vector.transfer_permutation_patterns
+# CHECK-NEXT:      } : !transform.any_op
+# CHECK-NEXT:      %4 = transform.structured.match attributes {__xtc_id_relu_} in %arg0 : (!transform.any_op) -> !transform.any_op
+# CHECK-NEXT:      %tiled_linalg_op_6, %loops_7 = transform.structured.tile_using_for %4 tile_sizes [1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      transform.annotate %loops_7 "./i" : !transform.any_op
+# CHECK-NEXT:      transform.yield 
+# CHECK-NEXT:    }
+# CHECK-NEXT:  }
 # CHECK-NEXT:  
-# CHECK-NEXT: // -----// IR Dump After transform //----- //
-# CHECK-NEXT: #map = affine_map<(d0, d1, d2) -> (d0, d2)>
-# CHECK-NEXT: #map1 = affine_map<(d0, d1, d2) -> (d2, d1)>
-# CHECK-NEXT: #map2 = affine_map<(d0, d1, d2) -> (d0, d1)>
-# CHECK-NEXT: #map3 = affine_map<(d0, d1) -> (d0, d1)>
-# CHECK-NEXT: #map4 = affine_map<(d0, d1) -> ()>
-# CHECK-NEXT: module attributes {transform.with_named_sequence} {
-# CHECK-NEXT:   func.func @matmul_relu(%arg0: tensor<4x512xf32> {llvm.noalias}, %arg1: tensor<512x32xf32> {llvm.noalias}, %arg2: memref<4x32xf32> {llvm.noalias}) {
-# CHECK-NEXT:     %0 = ub.poison : f32
-# CHECK-NEXT:     %c16 = arith.constant 16 : index
-# CHECK-NEXT:     %c2 = arith.constant 2 : index
-# CHECK-NEXT:     %c512 = arith.constant 512 : index
-# CHECK-NEXT:     %c32 = arith.constant 32 : index
-# CHECK-NEXT:     %c1 = arith.constant 1 : index
-# CHECK-NEXT:     %c4 = arith.constant 4 : index
-# CHECK-NEXT:     %c0 = arith.constant 0 : index
-# CHECK-NEXT:     %cst = arith.constant 0.000000e+00 : f32
-# CHECK-NEXT:     %1 = tensor.empty() : tensor<4x32xf32>
-# CHECK-NEXT:     %2 = scf.for %arg3 = %c0 to %c4 step %c1 iter_args(%arg4 = %1) -> (tensor<4x32xf32>) {
-# CHECK-NEXT:       %extracted_slice = tensor.extract_slice %arg4[%arg3, 0] [1, 32] [1, 1] : tensor<4x32xf32> to tensor<1x32xf32>
-# CHECK-NEXT:       %6 = scf.for %arg5 = %c0 to %c32 step %c1 iter_args(%arg6 = %extracted_slice) -> (tensor<1x32xf32>) {
-# CHECK-NEXT:         %extracted_slice_3 = tensor.extract_slice %arg6[0, %arg5] [1, 1] [1, 1] : tensor<1x32xf32> to tensor<1x1xf32>
-# CHECK-NEXT:         %7 = linalg.fill {__xtc_id_matmul_0_} ins(%cst : f32) outs(%extracted_slice_3 : tensor<1x1xf32>) -> tensor<1x1xf32>
-# CHECK-NEXT:         %inserted_slice_4 = tensor.insert_slice %7 into %arg6[0, %arg5] [1, 1] [1, 1] : tensor<1x1xf32> into tensor<1x32xf32>
-# CHECK-NEXT:         scf.yield %inserted_slice_4 : tensor<1x32xf32>
-# CHECK-NEXT:       } {"./j"}
-# CHECK-NEXT:       %inserted_slice = tensor.insert_slice %6 into %arg4[%arg3, 0] [1, 32] [1, 1] : tensor<1x32xf32> into tensor<4x32xf32>
-# CHECK-NEXT:       scf.yield %inserted_slice : tensor<4x32xf32>
-# CHECK-NEXT:     } {"./i"}
-# CHECK-NEXT:     %3 = scf.for %arg3 = %c0 to %c512 step %c1 iter_args(%arg4 = %2) -> (tensor<4x32xf32>) {
-# CHECK-NEXT:       %extracted_slice = tensor.extract_slice %arg0[0, %arg3] [4, 1] [1, 1] : tensor<4x512xf32> to tensor<4x1xf32>
-# CHECK-NEXT:       %extracted_slice_3 = tensor.extract_slice %arg1[%arg3, 0] [1, 32] [1, 1] : tensor<512x32xf32> to tensor<1x32xf32>
-# CHECK-NEXT:       %6 = scf.for %arg5 = %c0 to %c4 step %c2 iter_args(%arg6 = %arg4) -> (tensor<4x32xf32>) {
-# CHECK-NEXT:         %extracted_slice_4 = tensor.extract_slice %extracted_slice[%arg5, 0] [2, 1] [1, 1] : tensor<4x1xf32> to tensor<2x1xf32>
-# CHECK-NEXT:         %extracted_slice_5 = tensor.extract_slice %arg6[%arg5, 0] [2, 32] [1, 1] : tensor<4x32xf32> to tensor<2x32xf32>
-# CHECK-NEXT:         %7 = scf.for %arg7 = %c0 to %c32 step %c16 iter_args(%arg8 = %extracted_slice_5) -> (tensor<2x32xf32>) {
-# CHECK-NEXT:           %extracted_slice_6 = tensor.extract_slice %extracted_slice_3[0, %arg7] [1, 16] [1, 1] : tensor<1x32xf32> to tensor<1x16xf32>
-# CHECK-NEXT:           %extracted_slice_7 = tensor.extract_slice %arg8[0, %arg7] [2, 16] [1, 1] : tensor<2x32xf32> to tensor<2x16xf32>
-# CHECK-NEXT:           %extracted_slice_8 = tensor.extract_slice %extracted_slice_4[%c0, 0] [1, 1] [1, 1] : tensor<2x1xf32> to tensor<1x1xf32>
-# CHECK-NEXT:           %extracted_slice_9 = tensor.extract_slice %extracted_slice_7[%c0, 0] [1, 16] [1, 1] : tensor<2x16xf32> to tensor<1x16xf32>
-# CHECK-NEXT:           %8 = vector.transfer_read %extracted_slice_8[%c0, %c0], %0 {in_bounds = [true, true]} : tensor<1x1xf32>, vector<1x1xf32>
-# CHECK-NEXT:           %9 = vector.transfer_read %extracted_slice_6[%c0, %c0], %0 {in_bounds = [true, true]} : tensor<1x16xf32>, vector<1x16xf32>
-# CHECK-NEXT:           %10 = vector.transfer_read %extracted_slice_9[%c0, %c0], %0 {in_bounds = [true, true]} : tensor<1x16xf32>, vector<1x16xf32>
-# CHECK-NEXT:           %11 = vector.contract {indexing_maps = [#map, #map1, #map2], iterator_types = ["parallel", "parallel", "reduction"], kind = #vector.kind<add>} %8, %9, %10 : vector<1x1xf32>, vector<1x16xf32> into vector<1x16xf32>
-# CHECK-NEXT:           %12 = vector.transfer_write %11, %extracted_slice_9[%c0, %c0] {in_bounds = [true, true]} : vector<1x16xf32>, tensor<1x16xf32>
-# CHECK-NEXT:           %inserted_slice_10 = tensor.insert_slice %12 into %extracted_slice_7[%c0, 0] [1, 16] [1, 1] : tensor<1x16xf32> into tensor<2x16xf32>
-# CHECK-NEXT:           %extracted_slice_11 = tensor.extract_slice %extracted_slice_4[%c1, 0] [1, 1] [1, 1] : tensor<2x1xf32> to tensor<1x1xf32>
-# CHECK-NEXT:           %extracted_slice_12 = tensor.extract_slice %inserted_slice_10[%c1, 0] [1, 16] [1, 1] : tensor<2x16xf32> to tensor<1x16xf32>
-# CHECK-NEXT:           %13 = vector.transfer_read %extracted_slice_11[%c0, %c0], %0 {in_bounds = [true, true]} : tensor<1x1xf32>, vector<1x1xf32>
-# CHECK-NEXT:           %14 = vector.transfer_read %extracted_slice_6[%c0, %c0], %0 {in_bounds = [true, true]} : tensor<1x16xf32>, vector<1x16xf32>
-# CHECK-NEXT:           %15 = vector.transfer_read %extracted_slice_12[%c0, %c0], %0 {in_bounds = [true, true]} : tensor<1x16xf32>, vector<1x16xf32>
-# CHECK-NEXT:           %16 = vector.contract {indexing_maps = [#map, #map1, #map2], iterator_types = ["parallel", "parallel", "reduction"], kind = #vector.kind<add>} %13, %14, %15 : vector<1x1xf32>, vector<1x16xf32> into vector<1x16xf32>
-# CHECK-NEXT:           %17 = vector.transfer_write %16, %extracted_slice_12[%c0, %c0] {in_bounds = [true, true]} : vector<1x16xf32>, tensor<1x16xf32>
-# CHECK-NEXT:           %inserted_slice_13 = tensor.insert_slice %17 into %inserted_slice_10[%c1, 0] [1, 16] [1, 1] : tensor<1x16xf32> into tensor<2x16xf32>
-# CHECK-NEXT:           %inserted_slice_14 = tensor.insert_slice %inserted_slice_13 into %arg8[0, %arg7] [2, 16] [1, 1] : tensor<2x16xf32> into tensor<2x32xf32>
-# CHECK-NEXT:           scf.yield %inserted_slice_14 : tensor<2x32xf32>
-# CHECK-NEXT:         } {"./j"}
-# CHECK-NEXT:         %inserted_slice = tensor.insert_slice %7 into %arg6[%arg5, 0] [2, 32] [1, 1] : tensor<2x32xf32> into tensor<4x32xf32>
-# CHECK-NEXT:         scf.yield %inserted_slice : tensor<4x32xf32>
-# CHECK-NEXT:       } {"./i"}
-# CHECK-NEXT:       scf.yield %6 : tensor<4x32xf32>
-# CHECK-NEXT:     } {"./k"}
-# CHECK-NEXT:     %4 = tensor.empty() : tensor<4x32xf32>
-# CHECK-NEXT:     %c0_0 = arith.constant 0 : index
-# CHECK-NEXT:     %c4_1 = arith.constant 4 : index
-# CHECK-NEXT:     %c1_2 = arith.constant 1 : index
-# CHECK-NEXT:     %5 = scf.for %arg3 = %c0_0 to %c4_1 step %c1_2 iter_args(%arg4 = %4) -> (tensor<4x32xf32>) {
-# CHECK-NEXT:       %extracted_slice = tensor.extract_slice %3[%arg3, 0] [1, 32] [1, 1] : tensor<4x32xf32> to tensor<1x32xf32>
-# CHECK-NEXT:       %extracted_slice_3 = tensor.extract_slice %arg4[%arg3, 0] [1, 32] [1, 1] : tensor<4x32xf32> to tensor<1x32xf32>
-# CHECK-NEXT:       %6 = linalg.generic {indexing_maps = [#map3, #map4, #map3], iterator_types = ["parallel", "parallel"]} ins(%extracted_slice, %cst : tensor<1x32xf32>, f32) outs(%extracted_slice_3 : tensor<1x32xf32>) attrs =  {__xtc_id_relu_} {
-# CHECK-NEXT:       ^bb0(%in: f32, %in_4: f32, %out: f32):
-# CHECK-NEXT:         %7 = arith.maximumf %in, %in_4 : f32
-# CHECK-NEXT:         linalg.yield %7 : f32
-# CHECK-NEXT:       } -> tensor<1x32xf32>
-# CHECK-NEXT:       %inserted_slice = tensor.insert_slice %6 into %arg4[%arg3, 0] [1, 32] [1, 1] : tensor<1x32xf32> into tensor<4x32xf32>
-# CHECK-NEXT:       scf.yield %inserted_slice : tensor<4x32xf32>
-# CHECK-NEXT:     } {"./i"}
-# CHECK-NEXT:     bufferization.materialize_in_destination %5 in restrict writable %arg2 : (tensor<4x32xf32>, memref<4x32xf32>) -> ()
-# CHECK-NEXT:     return
-# CHECK-NEXT:   }
-# CHECK-NEXT:   transform.named_sequence @_vecto(%arg0: !transform.any_op {transform.consumed}) {
-# CHECK-NEXT:     transform.structured.vectorize %arg0 : !transform.any_op
-# CHECK-NEXT:     transform.yield 
-# CHECK-NEXT:   }
-# CHECK-NEXT:   transform.named_sequence @_post_bufferize(%arg0: !transform.any_op {transform.readonly}) {
-# CHECK-NEXT:     %0 = transform.structured.match attributes {sym_name = "matmul_relu"} in %arg0 : (!transform.any_op) -> !transform.any_op
-# CHECK-NEXT:     transform.apply_patterns to %0 {
-# CHECK-NEXT:       transform.apply_patterns.vector.lower_outerproduct
-# CHECK-NEXT:       transform.apply_patterns.vector.lower_contraction
-# CHECK-NEXT:     } : !transform.any_op
-# CHECK-NEXT:     transform.yield 
-# CHECK-NEXT:   }
-# CHECK-NEXT: }
+# CHECK-NEXT:  // -----// IR Dump After transform //----- //
+# CHECK-NEXT:  #map = affine_map<(d0, d1, d2) -> (d0, d2)>
+# CHECK-NEXT:  #map1 = affine_map<(d0, d1, d2) -> (d2, d1)>
+# CHECK-NEXT:  #map2 = affine_map<(d0, d1, d2) -> (d0, d1)>
+# CHECK-NEXT:  #map3 = affine_map<(d0, d1) -> (d0, d1)>
+# CHECK-NEXT:  #map4 = affine_map<(d0, d1) -> ()>
+# CHECK-NEXT:  module attributes {transform.with_named_sequence} {
+# CHECK-NEXT:    func.func @matmul_relu(%arg0: tensor<4x512xf32> {llvm.noalias}, %arg1: tensor<512x32xf32> {llvm.noalias}, %arg2: memref<4x32xf32> {llvm.noalias}) {
+# CHECK-NEXT:      %0 = ub.poison : f32
+# CHECK-NEXT:      %c16 = arith.constant 16 : index
+# CHECK-NEXT:      %c32 = arith.constant 32 : index
+# CHECK-NEXT:      %c2 = arith.constant 2 : index
+# CHECK-NEXT:      %c4 = arith.constant 4 : index
+# CHECK-NEXT:      %c1 = arith.constant 1 : index
+# CHECK-NEXT:      %c512 = arith.constant 512 : index
+# CHECK-NEXT:      %c0 = arith.constant 0 : index
+# CHECK-NEXT:      %cst = arith.constant 0.000000e+00 : f32
+# CHECK-NEXT:      %1 = tensor.empty() : tensor<4x32xf32>
+# CHECK-NEXT:      %2 = linalg.fill {__xtc_id_matmul_0_} ins(%cst : f32) outs(%1 : tensor<4x32xf32>) -> tensor<4x32xf32>
+# CHECK-NEXT:      %3 = scf.for %arg3 = %c0 to %c512 step %c1 iter_args(%arg4 = %2) -> (tensor<4x32xf32>) {
+# CHECK-NEXT:        %extracted_slice = tensor.extract_slice %arg0[0, %arg3] [4, 1] [1, 1] : tensor<4x512xf32> to tensor<4x1xf32>
+# CHECK-NEXT:        %extracted_slice_3 = tensor.extract_slice %arg1[%arg3, 0] [1, 32] [1, 1] : tensor<512x32xf32> to tensor<1x32xf32>
+# CHECK-NEXT:        %6 = scf.for %arg5 = %c0 to %c4 step %c2 iter_args(%arg6 = %arg4) -> (tensor<4x32xf32>) {
+# CHECK-NEXT:          %extracted_slice_4 = tensor.extract_slice %extracted_slice[%arg5, 0] [2, 1] [1, 1] : tensor<4x1xf32> to tensor<2x1xf32>
+# CHECK-NEXT:          %extracted_slice_5 = tensor.extract_slice %arg6[%arg5, 0] [2, 32] [1, 1] : tensor<4x32xf32> to tensor<2x32xf32>
+# CHECK-NEXT:          %7 = scf.for %arg7 = %c0 to %c32 step %c16 iter_args(%arg8 = %extracted_slice_5) -> (tensor<2x32xf32>) {
+# CHECK-NEXT:            %extracted_slice_6 = tensor.extract_slice %extracted_slice_3[0, %arg7] [1, 16] [1, 1] : tensor<1x32xf32> to tensor<1x16xf32>
+# CHECK-NEXT:            %extracted_slice_7 = tensor.extract_slice %arg8[0, %arg7] [2, 16] [1, 1] : tensor<2x32xf32> to tensor<2x16xf32>
+# CHECK-NEXT:            %extracted_slice_8 = tensor.extract_slice %extracted_slice_4[%c0, 0] [1, 1] [1, 1] : tensor<2x1xf32> to tensor<1x1xf32>
+# CHECK-NEXT:            %extracted_slice_9 = tensor.extract_slice %extracted_slice_7[%c0, 0] [1, 16] [1, 1] : tensor<2x16xf32> to tensor<1x16xf32>
+# CHECK-NEXT:            %8 = vector.transfer_read %extracted_slice_8[%c0, %c0], %0 {in_bounds = [true, true]} : tensor<1x1xf32>, vector<1x1xf32>
+# CHECK-NEXT:            %9 = vector.transfer_read %extracted_slice_6[%c0, %c0], %0 {in_bounds = [true, true]} : tensor<1x16xf32>, vector<1x16xf32>
+# CHECK-NEXT:            %10 = vector.transfer_read %extracted_slice_9[%c0, %c0], %0 {in_bounds = [true, true]} : tensor<1x16xf32>, vector<1x16xf32>
+# CHECK-NEXT:            %11 = vector.contract {indexing_maps = [#map, #map1, #map2], iterator_types = ["parallel", "parallel", "reduction"], kind = #vector.kind<add>} %8, %9, %10 : vector<1x1xf32>, vector<1x16xf32> into vector<1x16xf32>
+# CHECK-NEXT:            %12 = vector.transfer_write %11, %extracted_slice_9[%c0, %c0] {in_bounds = [true, true]} : vector<1x16xf32>, tensor<1x16xf32>
+# CHECK-NEXT:            %inserted_slice_10 = tensor.insert_slice %12 into %extracted_slice_7[%c0, 0] [1, 16] [1, 1] : tensor<1x16xf32> into tensor<2x16xf32>
+# CHECK-NEXT:            %extracted_slice_11 = tensor.extract_slice %extracted_slice_4[%c1, 0] [1, 1] [1, 1] : tensor<2x1xf32> to tensor<1x1xf32>
+# CHECK-NEXT:            %extracted_slice_12 = tensor.extract_slice %inserted_slice_10[%c1, 0] [1, 16] [1, 1] : tensor<2x16xf32> to tensor<1x16xf32>
+# CHECK-NEXT:            %13 = vector.transfer_read %extracted_slice_11[%c0, %c0], %0 {in_bounds = [true, true]} : tensor<1x1xf32>, vector<1x1xf32>
+# CHECK-NEXT:            %14 = vector.transfer_read %extracted_slice_6[%c0, %c0], %0 {in_bounds = [true, true]} : tensor<1x16xf32>, vector<1x16xf32>
+# CHECK-NEXT:            %15 = vector.transfer_read %extracted_slice_12[%c0, %c0], %0 {in_bounds = [true, true]} : tensor<1x16xf32>, vector<1x16xf32>
+# CHECK-NEXT:            %16 = vector.contract {indexing_maps = [#map, #map1, #map2], iterator_types = ["parallel", "parallel", "reduction"], kind = #vector.kind<add>} %13, %14, %15 : vector<1x1xf32>, vector<1x16xf32> into vector<1x16xf32>
+# CHECK-NEXT:            %17 = vector.transfer_write %16, %extracted_slice_12[%c0, %c0] {in_bounds = [true, true]} : vector<1x16xf32>, tensor<1x16xf32>
+# CHECK-NEXT:            %inserted_slice_13 = tensor.insert_slice %17 into %inserted_slice_10[%c1, 0] [1, 16] [1, 1] : tensor<1x16xf32> into tensor<2x16xf32>
+# CHECK-NEXT:            %inserted_slice_14 = tensor.insert_slice %inserted_slice_13 into %arg8[0, %arg7] [2, 16] [1, 1] : tensor<2x16xf32> into tensor<2x32xf32>
+# CHECK-NEXT:            scf.yield %inserted_slice_14 : tensor<2x32xf32>
+# CHECK-NEXT:          } {"./j"}
+# CHECK-NEXT:          %inserted_slice = tensor.insert_slice %7 into %arg6[%arg5, 0] [2, 32] [1, 1] : tensor<2x32xf32> into tensor<4x32xf32>
+# CHECK-NEXT:          scf.yield %inserted_slice : tensor<4x32xf32>
+# CHECK-NEXT:        } {"./i"}
+# CHECK-NEXT:        scf.yield %6 : tensor<4x32xf32>
+# CHECK-NEXT:      } {"./k"}
+# CHECK-NEXT:      %4 = tensor.empty() : tensor<4x32xf32>
+# CHECK-NEXT:      %c0_0 = arith.constant 0 : index
+# CHECK-NEXT:      %c4_1 = arith.constant 4 : index
+# CHECK-NEXT:      %c1_2 = arith.constant 1 : index
+# CHECK-NEXT:      %5 = scf.for %arg3 = %c0_0 to %c4_1 step %c1_2 iter_args(%arg4 = %4) -> (tensor<4x32xf32>) {
+# CHECK-NEXT:        %extracted_slice = tensor.extract_slice %3[%arg3, 0] [1, 32] [1, 1] : tensor<4x32xf32> to tensor<1x32xf32>
+# CHECK-NEXT:        %extracted_slice_3 = tensor.extract_slice %arg4[%arg3, 0] [1, 32] [1, 1] : tensor<4x32xf32> to tensor<1x32xf32>
+# CHECK-NEXT:        %6 = linalg.generic {indexing_maps = [#map3, #map4, #map3], iterator_types = ["parallel", "parallel"]} ins(%extracted_slice, %cst : tensor<1x32xf32>, f32) outs(%extracted_slice_3 : tensor<1x32xf32>) attrs =  {__xtc_id_relu_} {
+# CHECK-NEXT:        ^bb0(%in: f32, %in_4: f32, %out: f32):
+# CHECK-NEXT:          %7 = arith.maximumf %in, %in_4 : f32
+# CHECK-NEXT:          linalg.yield %7 : f32
+# CHECK-NEXT:        } -> tensor<1x32xf32>
+# CHECK-NEXT:        %inserted_slice = tensor.insert_slice %6 into %arg4[%arg3, 0] [1, 32] [1, 1] : tensor<1x32xf32> into tensor<4x32xf32>
+# CHECK-NEXT:        scf.yield %inserted_slice : tensor<4x32xf32>
+# CHECK-NEXT:      } {"./i"}
+# CHECK-NEXT:      bufferization.materialize_in_destination %5 in restrict writable %arg2 : (tensor<4x32xf32>, memref<4x32xf32>) -> ()
+# CHECK-NEXT:      return
+# CHECK-NEXT:    }
+# CHECK-NEXT:    transform.named_sequence @_vecto(%arg0: !transform.any_op {transform.consumed}) {
+# CHECK-NEXT:      transform.structured.vectorize %arg0 : !transform.any_op
+# CHECK-NEXT:      transform.yield 
+# CHECK-NEXT:    }
+# CHECK-NEXT:    transform.named_sequence @_post_bufferize(%arg0: !transform.any_op {transform.readonly}) {
+# CHECK-NEXT:      %0 = transform.structured.match attributes {sym_name = "matmul_relu"} in %arg0 : (!transform.any_op) -> !transform.any_op
+# CHECK-NEXT:      transform.apply_patterns to %0 {
+# CHECK-NEXT:        transform.apply_patterns.vector.lower_outerproduct
+# CHECK-NEXT:        transform.apply_patterns.vector.lower_contraction
+# CHECK-NEXT:      } : !transform.any_op
+# CHECK-NEXT:      transform.yield 
+# CHECK-NEXT:    }
+# CHECK-NEXT:  }
 # CHECK-NEXT:  
-# CHECK-NEXT: // -----// IR Dump After Tensor Lowering //----- //
-# CHECK-NEXT: #map = affine_map<(d0, d1) -> (d0, d1)>
-# CHECK-NEXT: #map1 = affine_map<(d0, d1) -> ()>
-# CHECK-NEXT: module attributes {transform.with_named_sequence} {
-# CHECK-NEXT:   func.func @matmul_relu(%arg0: memref<4x512xf32> {llvm.noalias}, %arg1: memref<512x32xf32> {llvm.noalias}, %arg2: memref<4x32xf32> {llvm.noalias}) {
-# CHECK-NEXT:     %cst = arith.constant dense<0.000000e+00> : vector<1x16xf32>
-# CHECK-NEXT:     %0 = ub.poison : f32
-# CHECK-NEXT:     %c16 = arith.constant 16 : index
-# CHECK-NEXT:     %c2 = arith.constant 2 : index
-# CHECK-NEXT:     %c512 = arith.constant 512 : index
-# CHECK-NEXT:     %c32 = arith.constant 32 : index
-# CHECK-NEXT:     %c1 = arith.constant 1 : index
-# CHECK-NEXT:     %c4 = arith.constant 4 : index
-# CHECK-NEXT:     %c0 = arith.constant 0 : index
-# CHECK-NEXT:     %cst_0 = arith.constant 0.000000e+00 : f32
-# CHECK-NEXT:     %alloca = memref.alloca() {alignment = 256 : i64} : memref<4x32xf32>
-# CHECK-NEXT:     %1 = scf.for %arg3 = %c0 to %c4 step %c1 iter_args(%arg4 = %alloca) -> (memref<4x32xf32>) {
-# CHECK-NEXT:       %subview = memref.subview %arg4[%arg3, 0] [1, 32] [1, 1] : memref<4x32xf32> to memref<1x32xf32, strided<[32, 1], offset: ?>>
-# CHECK-NEXT:       %4 = scf.for %arg5 = %c0 to %c32 step %c1 iter_args(%arg6 = %subview) -> (memref<1x32xf32, strided<[32, 1], offset: ?>>) {
-# CHECK-NEXT:         %subview_2 = memref.subview %arg6[0, %arg5] [1, 1] [1, 1] : memref<1x32xf32, strided<[32, 1], offset: ?>> to memref<1x1xf32, strided<[32, 1], offset: ?>>
-# CHECK-NEXT:         linalg.fill {__xtc_id_matmul_0_} ins(%cst_0 : f32) outs(%subview_2 : memref<1x1xf32, strided<[32, 1], offset: ?>>)
-# CHECK-NEXT:         %subview_3 = memref.subview %arg6[0, %arg5] [1, 1] [1, 1] : memref<1x32xf32, strided<[32, 1], offset: ?>> to memref<1x1xf32, strided<[32, 1], offset: ?>>
-# CHECK-NEXT:         memref.copy %subview_2, %subview_3 : memref<1x1xf32, strided<[32, 1], offset: ?>> to memref<1x1xf32, strided<[32, 1], offset: ?>>
-# CHECK-NEXT:         scf.yield %arg6 : memref<1x32xf32, strided<[32, 1], offset: ?>>
-# CHECK-NEXT:       } {"./j"}
-# CHECK-NEXT:       %subview_1 = memref.subview %arg4[%arg3, 0] [1, 32] [1, 1] : memref<4x32xf32> to memref<1x32xf32, strided<[32, 1], offset: ?>>
-# CHECK-NEXT:       memref.copy %4, %subview_1 : memref<1x32xf32, strided<[32, 1], offset: ?>> to memref<1x32xf32, strided<[32, 1], offset: ?>>
-# CHECK-NEXT:       scf.yield %arg4 : memref<4x32xf32>
-# CHECK-NEXT:     } {"./i"}
-# CHECK-NEXT:     %2 = scf.for %arg3 = %c0 to %c512 step %c1 iter_args(%arg4 = %1) -> (memref<4x32xf32>) {
-# CHECK-NEXT:       %subview = memref.subview %arg0[0, %arg3] [4, 1] [1, 1] : memref<4x512xf32> to memref<4x1xf32, strided<[512, 1], offset: ?>>
-# CHECK-NEXT:       %subview_1 = memref.subview %arg1[%arg3, 0] [1, 32] [1, 1] : memref<512x32xf32> to memref<1x32xf32, strided<[32, 1], offset: ?>>
-# CHECK-NEXT:       %4 = scf.for %arg5 = %c0 to %c4 step %c2 iter_args(%arg6 = %arg4) -> (memref<4x32xf32>) {
-# CHECK-NEXT:         %subview_2 = memref.subview %subview[%arg5, 0] [2, 1] [1, 1] : memref<4x1xf32, strided<[512, 1], offset: ?>> to memref<2x1xf32, strided<[512, 1], offset: ?>>
-# CHECK-NEXT:         %subview_3 = memref.subview %arg6[%arg5, 0] [2, 32] [1, 1] : memref<4x32xf32> to memref<2x32xf32, strided<[32, 1], offset: ?>>
-# CHECK-NEXT:         %5 = scf.for %arg7 = %c0 to %c32 step %c16 iter_args(%arg8 = %subview_3) -> (memref<2x32xf32, strided<[32, 1], offset: ?>>) {
-# CHECK-NEXT:           %subview_5 = memref.subview %subview_1[0, %arg7] [1, 16] [1, 1] : memref<1x32xf32, strided<[32, 1], offset: ?>> to memref<1x16xf32, strided<[32, 1], offset: ?>>
-# CHECK-NEXT:           %subview_6 = memref.subview %arg8[0, %arg7] [2, 16] [1, 1] : memref<2x32xf32, strided<[32, 1], offset: ?>> to memref<2x16xf32, strided<[32, 1], offset: ?>>
-# CHECK-NEXT:           %subview_7 = memref.subview %subview_2[0, 0] [1, 1] [1, 1] : memref<2x1xf32, strided<[512, 1], offset: ?>> to memref<1x1xf32, strided<[512, 1], offset: ?>>
-# CHECK-NEXT:           %subview_8 = memref.subview %subview_6[0, 0] [1, 16] [1, 1] : memref<2x16xf32, strided<[32, 1], offset: ?>> to memref<1x16xf32, strided<[32, 1], offset: ?>>
-# CHECK-NEXT:           %6 = vector.transfer_read %subview_7[%c0, %c0], %0 {in_bounds = [true, true]} : memref<1x1xf32, strided<[512, 1], offset: ?>>, vector<1x1xf32>
-# CHECK-NEXT:           %7 = vector.transfer_read %subview_5[%c0, %c0], %0 {in_bounds = [true, true]} : memref<1x16xf32, strided<[32, 1], offset: ?>>, vector<1x16xf32>
-# CHECK-NEXT:           %8 = vector.transfer_read %subview_8[%c0, %c0], %0 {in_bounds = [true, true]} : memref<1x16xf32, strided<[32, 1], offset: ?>>, vector<1x16xf32>
-# CHECK-NEXT:           %9 = vector.extract %7[0] : vector<16xf32> from vector<1x16xf32>
-# CHECK-NEXT:           %10 = vector.extract %6[0, 0] : f32 from vector<1x1xf32>
-# CHECK-NEXT:           %11 = vector.broadcast %10 : f32 to vector<16xf32>
-# CHECK-NEXT:           %12 = vector.extract %8[0] : vector<16xf32> from vector<1x16xf32>
-# CHECK-NEXT:           %13 = vector.fma %11, %9, %12 : vector<16xf32>
-# CHECK-NEXT:           %14 = vector.insert %13, %cst [0] : vector<16xf32> into vector<1x16xf32>
-# CHECK-NEXT:           vector.transfer_write %14, %subview_8[%c0, %c0] {in_bounds = [true, true]} : vector<1x16xf32>, memref<1x16xf32, strided<[32, 1], offset: ?>>
-# CHECK-NEXT:           %subview_9 = memref.subview %subview_6[0, 0] [1, 16] [1, 1] : memref<2x16xf32, strided<[32, 1], offset: ?>> to memref<1x16xf32, strided<[32, 1], offset: ?>>
-# CHECK-NEXT:           memref.copy %subview_8, %subview_9 : memref<1x16xf32, strided<[32, 1], offset: ?>> to memref<1x16xf32, strided<[32, 1], offset: ?>>
-# CHECK-NEXT:           %subview_10 = memref.subview %subview_2[1, 0] [1, 1] [1, 1] : memref<2x1xf32, strided<[512, 1], offset: ?>> to memref<1x1xf32, strided<[512, 1], offset: ?>>
-# CHECK-NEXT:           %subview_11 = memref.subview %subview_6[1, 0] [1, 16] [1, 1] : memref<2x16xf32, strided<[32, 1], offset: ?>> to memref<1x16xf32, strided<[32, 1], offset: ?>>
-# CHECK-NEXT:           %15 = vector.transfer_read %subview_10[%c0, %c0], %0 {in_bounds = [true, true]} : memref<1x1xf32, strided<[512, 1], offset: ?>>, vector<1x1xf32>
-# CHECK-NEXT:           %16 = vector.transfer_read %subview_11[%c0, %c0], %0 {in_bounds = [true, true]} : memref<1x16xf32, strided<[32, 1], offset: ?>>, vector<1x16xf32>
-# CHECK-NEXT:           %17 = vector.extract %7[0] : vector<16xf32> from vector<1x16xf32>
-# CHECK-NEXT:           %18 = vector.extract %15[0, 0] : f32 from vector<1x1xf32>
-# CHECK-NEXT:           %19 = vector.broadcast %18 : f32 to vector<16xf32>
-# CHECK-NEXT:           %20 = vector.extract %16[0] : vector<16xf32> from vector<1x16xf32>
-# CHECK-NEXT:           %21 = vector.fma %19, %17, %20 : vector<16xf32>
-# CHECK-NEXT:           %22 = vector.insert %21, %cst [0] : vector<16xf32> into vector<1x16xf32>
-# CHECK-NEXT:           vector.transfer_write %22, %subview_11[%c0, %c0] {in_bounds = [true, true]} : vector<1x16xf32>, memref<1x16xf32, strided<[32, 1], offset: ?>>
-# CHECK-NEXT:           %subview_12 = memref.subview %subview_6[1, 0] [1, 16] [1, 1] : memref<2x16xf32, strided<[32, 1], offset: ?>> to memref<1x16xf32, strided<[32, 1], offset: ?>>
-# CHECK-NEXT:           memref.copy %subview_11, %subview_12 : memref<1x16xf32, strided<[32, 1], offset: ?>> to memref<1x16xf32, strided<[32, 1], offset: ?>>
-# CHECK-NEXT:           %subview_13 = memref.subview %arg8[0, %arg7] [2, 16] [1, 1] : memref<2x32xf32, strided<[32, 1], offset: ?>> to memref<2x16xf32, strided<[32, 1], offset: ?>>
-# CHECK-NEXT:           memref.copy %subview_6, %subview_13 : memref<2x16xf32, strided<[32, 1], offset: ?>> to memref<2x16xf32, strided<[32, 1], offset: ?>>
-# CHECK-NEXT:           scf.yield %arg8 : memref<2x32xf32, strided<[32, 1], offset: ?>>
-# CHECK-NEXT:         } {"./j"}
-# CHECK-NEXT:         %subview_4 = memref.subview %arg6[%arg5, 0] [2, 32] [1, 1] : memref<4x32xf32> to memref<2x32xf32, strided<[32, 1], offset: ?>>
-# CHECK-NEXT:         memref.copy %5, %subview_4 : memref<2x32xf32, strided<[32, 1], offset: ?>> to memref<2x32xf32, strided<[32, 1], offset: ?>>
-# CHECK-NEXT:         scf.yield %arg6 : memref<4x32xf32>
-# CHECK-NEXT:       } {"./i"}
-# CHECK-NEXT:       scf.yield %4 : memref<4x32xf32>
-# CHECK-NEXT:     } {"./k"}
-# CHECK-NEXT:     %3 = scf.for %arg3 = %c0 to %c4 step %c1 iter_args(%arg4 = %arg2) -> (memref<4x32xf32>) {
-# CHECK-NEXT:       %subview = memref.subview %2[%arg3, 0] [1, 32] [1, 1] : memref<4x32xf32> to memref<1x32xf32, strided<[32, 1], offset: ?>>
-# CHECK-NEXT:       %subview_1 = memref.subview %arg4[%arg3, 0] [1, 32] [1, 1] : memref<4x32xf32> to memref<1x32xf32, strided<[32, 1], offset: ?>>
-# CHECK-NEXT:       linalg.generic {indexing_maps = [#map, #map1, #map], iterator_types = ["parallel", "parallel"]} ins(%subview, %cst_0 : memref<1x32xf32, strided<[32, 1], offset: ?>>, f32) outs(%subview_1 : memref<1x32xf32, strided<[32, 1], offset: ?>>) attrs =  {__xtc_id_relu_} {
-# CHECK-NEXT:       ^bb0(%in: f32, %in_3: f32, %out: f32):
-# CHECK-NEXT:         %4 = arith.maximumf %in, %in_3 : f32
-# CHECK-NEXT:         linalg.yield %4 : f32
-# CHECK-NEXT:       }
-# CHECK-NEXT:       %subview_2 = memref.subview %arg4[%arg3, 0] [1, 32] [1, 1] : memref<4x32xf32> to memref<1x32xf32, strided<[32, 1], offset: ?>>
-# CHECK-NEXT:       memref.copy %subview_1, %subview_2 : memref<1x32xf32, strided<[32, 1], offset: ?>> to memref<1x32xf32, strided<[32, 1], offset: ?>>
-# CHECK-NEXT:       scf.yield %arg4 : memref<4x32xf32>
-# CHECK-NEXT:     } {"./i"}
-# CHECK-NEXT:     memref.copy %3, %arg2 : memref<4x32xf32> to memref<4x32xf32>
-# CHECK-NEXT:     return
-# CHECK-NEXT:   }
-# CHECK-NEXT: }
+# CHECK-NEXT:  // -----// IR Dump After Tensor Lowering //----- //
+# CHECK-NEXT:  #map = affine_map<(d0, d1) -> (d0, d1)>
+# CHECK-NEXT:  #map1 = affine_map<(d0, d1) -> ()>
+# CHECK-NEXT:  module attributes {transform.with_named_sequence} {
+# CHECK-NEXT:    func.func @matmul_relu(%arg0: memref<4x512xf32> {llvm.noalias}, %arg1: memref<512x32xf32> {llvm.noalias}, %arg2: memref<4x32xf32> {llvm.noalias}) {
+# CHECK-NEXT:      %cst = arith.constant dense<0.000000e+00> : vector<1x16xf32>
+# CHECK-NEXT:      %0 = ub.poison : f32
+# CHECK-NEXT:      %c16 = arith.constant 16 : index
+# CHECK-NEXT:      %c32 = arith.constant 32 : index
+# CHECK-NEXT:      %c2 = arith.constant 2 : index
+# CHECK-NEXT:      %c4 = arith.constant 4 : index
+# CHECK-NEXT:      %c1 = arith.constant 1 : index
+# CHECK-NEXT:      %c512 = arith.constant 512 : index
+# CHECK-NEXT:      %c0 = arith.constant 0 : index
+# CHECK-NEXT:      %cst_0 = arith.constant 0.000000e+00 : f32
+# CHECK-NEXT:      %alloca = memref.alloca() {alignment = 256 : i64} : memref<4x32xf32>
+# CHECK-NEXT:      linalg.fill {__xtc_id_matmul_0_} ins(%cst_0 : f32) outs(%alloca : memref<4x32xf32>)
+# CHECK-NEXT:      %1 = scf.for %arg3 = %c0 to %c512 step %c1 iter_args(%arg4 = %alloca) -> (memref<4x32xf32>) {
+# CHECK-NEXT:        %subview = memref.subview %arg0[0, %arg3] [4, 1] [1, 1] : memref<4x512xf32> to memref<4x1xf32, strided<[512, 1], offset: ?>>
+# CHECK-NEXT:        %subview_1 = memref.subview %arg1[%arg3, 0] [1, 32] [1, 1] : memref<512x32xf32> to memref<1x32xf32, strided<[32, 1], offset: ?>>
+# CHECK-NEXT:        %3 = scf.for %arg5 = %c0 to %c4 step %c2 iter_args(%arg6 = %arg4) -> (memref<4x32xf32>) {
+# CHECK-NEXT:          %subview_2 = memref.subview %subview[%arg5, 0] [2, 1] [1, 1] : memref<4x1xf32, strided<[512, 1], offset: ?>> to memref<2x1xf32, strided<[512, 1], offset: ?>>
+# CHECK-NEXT:          %subview_3 = memref.subview %arg6[%arg5, 0] [2, 32] [1, 1] : memref<4x32xf32> to memref<2x32xf32, strided<[32, 1], offset: ?>>
+# CHECK-NEXT:          %4 = scf.for %arg7 = %c0 to %c32 step %c16 iter_args(%arg8 = %subview_3) -> (memref<2x32xf32, strided<[32, 1], offset: ?>>) {
+# CHECK-NEXT:            %subview_5 = memref.subview %subview_1[0, %arg7] [1, 16] [1, 1] : memref<1x32xf32, strided<[32, 1], offset: ?>> to memref<1x16xf32, strided<[32, 1], offset: ?>>
+# CHECK-NEXT:            %subview_6 = memref.subview %arg8[0, %arg7] [2, 16] [1, 1] : memref<2x32xf32, strided<[32, 1], offset: ?>> to memref<2x16xf32, strided<[32, 1], offset: ?>>
+# CHECK-NEXT:            %subview_7 = memref.subview %subview_2[0, 0] [1, 1] [1, 1] : memref<2x1xf32, strided<[512, 1], offset: ?>> to memref<1x1xf32, strided<[512, 1], offset: ?>>
+# CHECK-NEXT:            %subview_8 = memref.subview %subview_6[0, 0] [1, 16] [1, 1] : memref<2x16xf32, strided<[32, 1], offset: ?>> to memref<1x16xf32, strided<[32, 1], offset: ?>>
+# CHECK-NEXT:            %5 = vector.transfer_read %subview_7[%c0, %c0], %0 {in_bounds = [true, true]} : memref<1x1xf32, strided<[512, 1], offset: ?>>, vector<1x1xf32>
+# CHECK-NEXT:            %6 = vector.transfer_read %subview_5[%c0, %c0], %0 {in_bounds = [true, true]} : memref<1x16xf32, strided<[32, 1], offset: ?>>, vector<1x16xf32>
+# CHECK-NEXT:            %7 = vector.transfer_read %subview_8[%c0, %c0], %0 {in_bounds = [true, true]} : memref<1x16xf32, strided<[32, 1], offset: ?>>, vector<1x16xf32>
+# CHECK-NEXT:            %8 = vector.extract %6[0] : vector<16xf32> from vector<1x16xf32>
+# CHECK-NEXT:            %9 = vector.extract %5[0, 0] : f32 from vector<1x1xf32>
+# CHECK-NEXT:            %10 = vector.broadcast %9 : f32 to vector<16xf32>
+# CHECK-NEXT:            %11 = vector.extract %7[0] : vector<16xf32> from vector<1x16xf32>
+# CHECK-NEXT:            %12 = vector.fma %10, %8, %11 : vector<16xf32>
+# CHECK-NEXT:            %13 = vector.insert %12, %cst [0] : vector<16xf32> into vector<1x16xf32>
+# CHECK-NEXT:            vector.transfer_write %13, %subview_8[%c0, %c0] {in_bounds = [true, true]} : vector<1x16xf32>, memref<1x16xf32, strided<[32, 1], offset: ?>>
+# CHECK-NEXT:            %subview_9 = memref.subview %subview_6[0, 0] [1, 16] [1, 1] : memref<2x16xf32, strided<[32, 1], offset: ?>> to memref<1x16xf32, strided<[32, 1], offset: ?>>
+# CHECK-NEXT:            memref.copy %subview_8, %subview_9 : memref<1x16xf32, strided<[32, 1], offset: ?>> to memref<1x16xf32, strided<[32, 1], offset: ?>>
+# CHECK-NEXT:            %subview_10 = memref.subview %subview_2[1, 0] [1, 1] [1, 1] : memref<2x1xf32, strided<[512, 1], offset: ?>> to memref<1x1xf32, strided<[512, 1], offset: ?>>
+# CHECK-NEXT:            %subview_11 = memref.subview %subview_6[1, 0] [1, 16] [1, 1] : memref<2x16xf32, strided<[32, 1], offset: ?>> to memref<1x16xf32, strided<[32, 1], offset: ?>>
+# CHECK-NEXT:            %14 = vector.transfer_read %subview_10[%c0, %c0], %0 {in_bounds = [true, true]} : memref<1x1xf32, strided<[512, 1], offset: ?>>, vector<1x1xf32>
+# CHECK-NEXT:            %15 = vector.transfer_read %subview_11[%c0, %c0], %0 {in_bounds = [true, true]} : memref<1x16xf32, strided<[32, 1], offset: ?>>, vector<1x16xf32>
+# CHECK-NEXT:            %16 = vector.extract %6[0] : vector<16xf32> from vector<1x16xf32>
+# CHECK-NEXT:            %17 = vector.extract %14[0, 0] : f32 from vector<1x1xf32>
+# CHECK-NEXT:            %18 = vector.broadcast %17 : f32 to vector<16xf32>
+# CHECK-NEXT:            %19 = vector.extract %15[0] : vector<16xf32> from vector<1x16xf32>
+# CHECK-NEXT:            %20 = vector.fma %18, %16, %19 : vector<16xf32>
+# CHECK-NEXT:            %21 = vector.insert %20, %cst [0] : vector<16xf32> into vector<1x16xf32>
+# CHECK-NEXT:            vector.transfer_write %21, %subview_11[%c0, %c0] {in_bounds = [true, true]} : vector<1x16xf32>, memref<1x16xf32, strided<[32, 1], offset: ?>>
+# CHECK-NEXT:            %subview_12 = memref.subview %subview_6[1, 0] [1, 16] [1, 1] : memref<2x16xf32, strided<[32, 1], offset: ?>> to memref<1x16xf32, strided<[32, 1], offset: ?>>
+# CHECK-NEXT:            memref.copy %subview_11, %subview_12 : memref<1x16xf32, strided<[32, 1], offset: ?>> to memref<1x16xf32, strided<[32, 1], offset: ?>>
+# CHECK-NEXT:            %subview_13 = memref.subview %arg8[0, %arg7] [2, 16] [1, 1] : memref<2x32xf32, strided<[32, 1], offset: ?>> to memref<2x16xf32, strided<[32, 1], offset: ?>>
+# CHECK-NEXT:            memref.copy %subview_6, %subview_13 : memref<2x16xf32, strided<[32, 1], offset: ?>> to memref<2x16xf32, strided<[32, 1], offset: ?>>
+# CHECK-NEXT:            scf.yield %arg8 : memref<2x32xf32, strided<[32, 1], offset: ?>>
+# CHECK-NEXT:          } {"./j"}
+# CHECK-NEXT:          %subview_4 = memref.subview %arg6[%arg5, 0] [2, 32] [1, 1] : memref<4x32xf32> to memref<2x32xf32, strided<[32, 1], offset: ?>>
+# CHECK-NEXT:          memref.copy %4, %subview_4 : memref<2x32xf32, strided<[32, 1], offset: ?>> to memref<2x32xf32, strided<[32, 1], offset: ?>>
+# CHECK-NEXT:          scf.yield %arg6 : memref<4x32xf32>
+# CHECK-NEXT:        } {"./i"}
+# CHECK-NEXT:        scf.yield %3 : memref<4x32xf32>
+# CHECK-NEXT:      } {"./k"}
+# CHECK-NEXT:      %2 = scf.for %arg3 = %c0 to %c4 step %c1 iter_args(%arg4 = %arg2) -> (memref<4x32xf32>) {
+# CHECK-NEXT:        %subview = memref.subview %1[%arg3, 0] [1, 32] [1, 1] : memref<4x32xf32> to memref<1x32xf32, strided<[32, 1], offset: ?>>
+# CHECK-NEXT:        %subview_1 = memref.subview %arg4[%arg3, 0] [1, 32] [1, 1] : memref<4x32xf32> to memref<1x32xf32, strided<[32, 1], offset: ?>>
+# CHECK-NEXT:        linalg.generic {indexing_maps = [#map, #map1, #map], iterator_types = ["parallel", "parallel"]} ins(%subview, %cst_0 : memref<1x32xf32, strided<[32, 1], offset: ?>>, f32) outs(%subview_1 : memref<1x32xf32, strided<[32, 1], offset: ?>>) attrs =  {__xtc_id_relu_} {
+# CHECK-NEXT:        ^bb0(%in: f32, %in_3: f32, %out: f32):
+# CHECK-NEXT:          %3 = arith.maximumf %in, %in_3 : f32
+# CHECK-NEXT:          linalg.yield %3 : f32
+# CHECK-NEXT:        }
+# CHECK-NEXT:        %subview_2 = memref.subview %arg4[%arg3, 0] [1, 32] [1, 1] : memref<4x32xf32> to memref<1x32xf32, strided<[32, 1], offset: ?>>
+# CHECK-NEXT:        memref.copy %subview_1, %subview_2 : memref<1x32xf32, strided<[32, 1], offset: ?>> to memref<1x32xf32, strided<[32, 1], offset: ?>>
+# CHECK-NEXT:        scf.yield %arg4 : memref<4x32xf32>
+# CHECK-NEXT:      } {"./i"}
+# CHECK-NEXT:      memref.copy %2, %arg2 : memref<4x32xf32> to memref<4x32xf32>
+# CHECK-NEXT:      return
+# CHECK-NEXT:    }
+# CHECK-NEXT:  }
 # CHECK-NEXT:  
-# CHECK-NEXT: graph:
-# CHECK-NEXT:   name: matmul_relu
-# CHECK-NEXT:   inputs:
-# CHECK-NEXT:   - %0 : 4x512xfloat32
-# CHECK-NEXT:   - %1 : 512x32xfloat32
-# CHECK-NEXT:   outputs:
-# CHECK-NEXT:   - %3 : 4x32xfloat32
-# CHECK-NEXT:   nodes:
-# CHECK-NEXT:   - %2: matmul(%0, %1) {name = 'matmul'} : [4x512xfloat32, 512x32xfloat32] -> [4x32xfloat32]
-# CHECK-NEXT:   - %3: relu(%2) {name = 'relu'} : [4x32xfloat32] -> [4x32xfloat32]
+# CHECK-NEXT:  graph:
+# CHECK-NEXT:    name: matmul_relu
+# CHECK-NEXT:    inputs:
+# CHECK-NEXT:    - %0 : 4x512xfloat32
+# CHECK-NEXT:    - %1 : 512x32xfloat32
+# CHECK-NEXT:    outputs:
+# CHECK-NEXT:    - %3 : 4x32xfloat32
+# CHECK-NEXT:    nodes:
+# CHECK-NEXT:    - %2: matmul(%0, %1) {name = 'matmul'} : [4x512xfloat32, 512x32xfloat32] -> [4x32xfloat32]
+# CHECK-NEXT:    - %3: relu(%2) {name = 'relu'} : [4x32xfloat32] -> [4x32xfloat32]
 # CHECK-NEXT:  
-# CHECK-NEXT: CODE: 0
+# CHECK-NEXT:  CODE: 0

--- a/tests/filecheck/backends/tensor_dialect/test_pad_conv2d_mlir_tensor.py
+++ b/tests/filecheck/backends/tensor_dialect/test_pad_conv2d_mlir_tensor.py
@@ -112,30 +112,21 @@ print(f"CODE: {res}")
 # CHECK-NEXT:      transform.annotate %loops_3 "./w" : !transform.any_op
 # CHECK-NEXT:      %tiled_linalg_op_4, %loops_5 = transform.structured.tile_using_for %tiled_linalg_op_2 tile_sizes [0, 0, 0, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
 # CHECK-NEXT:      transform.annotate %loops_5 "./c" : !transform.any_op
-# CHECK-NEXT:      %1 = transform.structured.match attributes {__xtc_id_conv_0_} in %arg0 : (!transform.any_op) -> !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_6, %loops_7 = transform.structured.tile_using_for %1 tile_sizes [1, 0, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      %1 = transform.structured.match attributes {__xtc_id_conv_} in %arg0 : (!transform.any_op) -> !transform.any_op
+# CHECK-NEXT:      %tiled_linalg_op_6, %loops_7 = transform.structured.tile_using_for %1 tile_sizes [1, 0, 0, 0, 0, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
 # CHECK-NEXT:      transform.annotate %loops_7 "./b" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_8, %loops_9 = transform.structured.tile_using_for %tiled_linalg_op_6 tile_sizes [0, 1, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      %tiled_linalg_op_8, %loops_9 = transform.structured.tile_using_for %tiled_linalg_op_6 tile_sizes [0, 1, 0, 0, 0, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
 # CHECK-NEXT:      transform.annotate %loops_9 "./h" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_10, %loops_11 = transform.structured.tile_using_for %tiled_linalg_op_8 tile_sizes [0, 0, 1, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      %tiled_linalg_op_10, %loops_11 = transform.structured.tile_using_for %tiled_linalg_op_8 tile_sizes [0, 0, 1, 0, 0, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
 # CHECK-NEXT:      transform.annotate %loops_11 "./w" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_12, %loops_13 = transform.structured.tile_using_for %tiled_linalg_op_10 tile_sizes [0, 0, 0, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      %tiled_linalg_op_12, %loops_13 = transform.structured.tile_using_for %tiled_linalg_op_10 tile_sizes [0, 0, 0, 1, 0, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
 # CHECK-NEXT:      transform.annotate %loops_13 "./f" : !transform.any_op
-# CHECK-NEXT:      %2 = transform.structured.match attributes {__xtc_id_conv_} in %arg0 : (!transform.any_op) -> !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_14, %loops_15 = transform.structured.tile_using_for %2 tile_sizes [1, 0, 0, 0, 0, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_15 "./b" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_16, %loops_17 = transform.structured.tile_using_for %tiled_linalg_op_14 tile_sizes [0, 1, 0, 0, 0, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_17 "./h" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_18, %loops_19 = transform.structured.tile_using_for %tiled_linalg_op_16 tile_sizes [0, 0, 1, 0, 0, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_19 "./w" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_20, %loops_21 = transform.structured.tile_using_for %tiled_linalg_op_18 tile_sizes [0, 0, 0, 1, 0, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_21 "./f" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_22, %loops_23 = transform.structured.tile_using_for %tiled_linalg_op_20 tile_sizes [0, 0, 0, 0, 1, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_23 "./r" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_24, %loops_25 = transform.structured.tile_using_for %tiled_linalg_op_22 tile_sizes [0, 0, 0, 0, 0, 1, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_25 "./s" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_26, %loops_27 = transform.structured.tile_using_for %tiled_linalg_op_24 tile_sizes [0, 0, 0, 0, 0, 0, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_27 "./c" : !transform.any_op
+# CHECK-NEXT:      %tiled_linalg_op_14, %loops_15 = transform.structured.tile_using_for %tiled_linalg_op_12 tile_sizes [0, 0, 0, 0, 1, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      transform.annotate %loops_15 "./r" : !transform.any_op
+# CHECK-NEXT:      %tiled_linalg_op_16, %loops_17 = transform.structured.tile_using_for %tiled_linalg_op_14 tile_sizes [0, 0, 0, 0, 0, 1, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      transform.annotate %loops_17 "./s" : !transform.any_op
+# CHECK-NEXT:      %tiled_linalg_op_18, %loops_19 = transform.structured.tile_using_for %tiled_linalg_op_16 tile_sizes [0, 0, 0, 0, 0, 0, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      transform.annotate %loops_19 "./c" : !transform.any_op
 # CHECK-NEXT:      transform.yield 
 # CHECK-NEXT:    }
 # CHECK-NEXT:  }
@@ -156,22 +147,22 @@ print(f"CODE: {res}")
 # CHECK-NEXT:      %c1_0 = arith.constant 1 : index
 # CHECK-NEXT:      %1 = scf.for %arg3 = %c0 to %c1 step %c1_0 iter_args(%arg4 = %0) -> (tensor<1x12x12x3xf32>) {
 # CHECK-NEXT:        %extracted_slice = tensor.extract_slice %arg4[%arg3, 0, 0, 0] [1, 12, 12, 3] [1, 1, 1, 1] : tensor<1x12x12x3xf32> to tensor<1x12x12x3xf32>
-# CHECK-NEXT:        %c0_8 = arith.constant 0 : index
+# CHECK-NEXT:        %c0_5 = arith.constant 0 : index
 # CHECK-NEXT:        %c12 = arith.constant 12 : index
-# CHECK-NEXT:        %c1_9 = arith.constant 1 : index
-# CHECK-NEXT:        %5 = scf.for %arg5 = %c0_8 to %c12 step %c1_9 iter_args(%arg6 = %extracted_slice) -> (tensor<1x12x12x3xf32>) {
-# CHECK-NEXT:          %extracted_slice_10 = tensor.extract_slice %arg6[0, %arg5, 0, 0] [1, 1, 12, 3] [1, 1, 1, 1] : tensor<1x12x12x3xf32> to tensor<1x1x12x3xf32>
-# CHECK-NEXT:          %c0_11 = arith.constant 0 : index
-# CHECK-NEXT:          %c12_12 = arith.constant 12 : index
-# CHECK-NEXT:          %c1_13 = arith.constant 1 : index
-# CHECK-NEXT:          %6 = scf.for %arg7 = %c0_11 to %c12_12 step %c1_13 iter_args(%arg8 = %extracted_slice_10) -> (tensor<1x1x12x3xf32>) {
-# CHECK-NEXT:            %extracted_slice_15 = tensor.extract_slice %arg8[0, 0, %arg7, 0] [1, 1, 1, 3] [1, 1, 1, 1] : tensor<1x1x12x3xf32> to tensor<1x1x1x3xf32>
-# CHECK-NEXT:            %c0_16 = arith.constant 0 : index
+# CHECK-NEXT:        %c1_6 = arith.constant 1 : index
+# CHECK-NEXT:        %5 = scf.for %arg5 = %c0_5 to %c12 step %c1_6 iter_args(%arg6 = %extracted_slice) -> (tensor<1x12x12x3xf32>) {
+# CHECK-NEXT:          %extracted_slice_7 = tensor.extract_slice %arg6[0, %arg5, 0, 0] [1, 1, 12, 3] [1, 1, 1, 1] : tensor<1x12x12x3xf32> to tensor<1x1x12x3xf32>
+# CHECK-NEXT:          %c0_8 = arith.constant 0 : index
+# CHECK-NEXT:          %c12_9 = arith.constant 12 : index
+# CHECK-NEXT:          %c1_10 = arith.constant 1 : index
+# CHECK-NEXT:          %6 = scf.for %arg7 = %c0_8 to %c12_9 step %c1_10 iter_args(%arg8 = %extracted_slice_7) -> (tensor<1x1x12x3xf32>) {
+# CHECK-NEXT:            %extracted_slice_12 = tensor.extract_slice %arg8[0, 0, %arg7, 0] [1, 1, 1, 3] [1, 1, 1, 1] : tensor<1x1x12x3xf32> to tensor<1x1x1x3xf32>
+# CHECK-NEXT:            %c0_13 = arith.constant 0 : index
 # CHECK-NEXT:            %c3 = arith.constant 3 : index
-# CHECK-NEXT:            %c1_17 = arith.constant 1 : index
-# CHECK-NEXT:            %7 = scf.for %arg9 = %c0_16 to %c3 step %c1_17 iter_args(%arg10 = %extracted_slice_15) -> (tensor<1x1x1x3xf32>) {
-# CHECK-NEXT:              %extracted_slice_19 = tensor.extract_slice %arg10[0, 0, 0, %arg9] [1, 1, 1, 1] [1, 1, 1, 1] : tensor<1x1x1x3xf32> to tensor<1x1x1x1xf32>
-# CHECK-NEXT:              %8 = linalg.generic {indexing_maps = [#map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} outs(%extracted_slice_19 : tensor<1x1x1x1xf32>) attrs =  {__xtc_id_pad_} {
+# CHECK-NEXT:            %c1_14 = arith.constant 1 : index
+# CHECK-NEXT:            %7 = scf.for %arg9 = %c0_13 to %c3 step %c1_14 iter_args(%arg10 = %extracted_slice_12) -> (tensor<1x1x1x3xf32>) {
+# CHECK-NEXT:              %extracted_slice_16 = tensor.extract_slice %arg10[0, 0, 0, %arg9] [1, 1, 1, 1] [1, 1, 1, 1] : tensor<1x1x1x3xf32> to tensor<1x1x1x1xf32>
+# CHECK-NEXT:              %8 = linalg.generic {indexing_maps = [#map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} outs(%extracted_slice_16 : tensor<1x1x1x1xf32>) attrs =  {__xtc_id_pad_} {
 # CHECK-NEXT:              ^bb0(%out: f32):
 # CHECK-NEXT:                %9 = linalg.index 0 : index
 # CHECK-NEXT:                %10 = affine.apply #map1(%arg3)[%9]
@@ -181,27 +172,27 @@ print(f"CODE: {res}")
 # CHECK-NEXT:                %14 = affine.apply #map1(%arg7)[%13]
 # CHECK-NEXT:                %15 = linalg.index 3 : index
 # CHECK-NEXT:                %16 = affine.apply #map1(%arg9)[%15]
-# CHECK-NEXT:                %c0_21 = arith.constant 0 : index
-# CHECK-NEXT:                %c0_22 = arith.constant 0 : index
-# CHECK-NEXT:                %17 = arith.subi %10, %c0_22 : index
-# CHECK-NEXT:                %c1_23 = arith.constant 1 : index
-# CHECK-NEXT:                %18 = arith.cmpi sge, %17, %c0_21 : index
-# CHECK-NEXT:                %19 = arith.cmpi slt, %17, %c1_23 : index
+# CHECK-NEXT:                %c0_18 = arith.constant 0 : index
+# CHECK-NEXT:                %c0_19 = arith.constant 0 : index
+# CHECK-NEXT:                %17 = arith.subi %10, %c0_19 : index
+# CHECK-NEXT:                %c1_20 = arith.constant 1 : index
+# CHECK-NEXT:                %18 = arith.cmpi sge, %17, %c0_18 : index
+# CHECK-NEXT:                %19 = arith.cmpi slt, %17, %c1_20 : index
 # CHECK-NEXT:                %c2 = arith.constant 2 : index
 # CHECK-NEXT:                %20 = arith.subi %12, %c2 : index
 # CHECK-NEXT:                %c8 = arith.constant 8 : index
-# CHECK-NEXT:                %21 = arith.cmpi sge, %20, %c0_21 : index
+# CHECK-NEXT:                %21 = arith.cmpi sge, %20, %c0_18 : index
 # CHECK-NEXT:                %22 = arith.cmpi slt, %20, %c8 : index
-# CHECK-NEXT:                %c2_24 = arith.constant 2 : index
-# CHECK-NEXT:                %23 = arith.subi %14, %c2_24 : index
-# CHECK-NEXT:                %c8_25 = arith.constant 8 : index
-# CHECK-NEXT:                %24 = arith.cmpi sge, %23, %c0_21 : index
-# CHECK-NEXT:                %25 = arith.cmpi slt, %23, %c8_25 : index
-# CHECK-NEXT:                %c0_26 = arith.constant 0 : index
-# CHECK-NEXT:                %26 = arith.subi %16, %c0_26 : index
-# CHECK-NEXT:                %c3_27 = arith.constant 3 : index
-# CHECK-NEXT:                %27 = arith.cmpi sge, %26, %c0_21 : index
-# CHECK-NEXT:                %28 = arith.cmpi slt, %26, %c3_27 : index
+# CHECK-NEXT:                %c2_21 = arith.constant 2 : index
+# CHECK-NEXT:                %23 = arith.subi %14, %c2_21 : index
+# CHECK-NEXT:                %c8_22 = arith.constant 8 : index
+# CHECK-NEXT:                %24 = arith.cmpi sge, %23, %c0_18 : index
+# CHECK-NEXT:                %25 = arith.cmpi slt, %23, %c8_22 : index
+# CHECK-NEXT:                %c0_23 = arith.constant 0 : index
+# CHECK-NEXT:                %26 = arith.subi %16, %c0_23 : index
+# CHECK-NEXT:                %c3_24 = arith.constant 3 : index
+# CHECK-NEXT:                %27 = arith.cmpi sge, %26, %c0_18 : index
+# CHECK-NEXT:                %28 = arith.cmpi slt, %26, %c3_24 : index
 # CHECK-NEXT:                %29 = arith.andi %18, %19 : i1
 # CHECK-NEXT:                %30 = arith.andi %29, %21 : i1
 # CHECK-NEXT:                %31 = arith.andi %30, %22 : i1
@@ -217,127 +208,95 @@ print(f"CODE: {res}")
 # CHECK-NEXT:                }
 # CHECK-NEXT:                linalg.yield %36 : f32
 # CHECK-NEXT:              } -> tensor<1x1x1x1xf32>
-# CHECK-NEXT:              %inserted_slice_20 = tensor.insert_slice %8 into %arg10[0, 0, 0, %arg9] [1, 1, 1, 1] [1, 1, 1, 1] : tensor<1x1x1x1xf32> into tensor<1x1x1x3xf32>
-# CHECK-NEXT:              scf.yield %inserted_slice_20 : tensor<1x1x1x3xf32>
+# CHECK-NEXT:              %inserted_slice_17 = tensor.insert_slice %8 into %arg10[0, 0, 0, %arg9] [1, 1, 1, 1] [1, 1, 1, 1] : tensor<1x1x1x1xf32> into tensor<1x1x1x3xf32>
+# CHECK-NEXT:              scf.yield %inserted_slice_17 : tensor<1x1x1x3xf32>
 # CHECK-NEXT:            } {"./c"}
-# CHECK-NEXT:            %inserted_slice_18 = tensor.insert_slice %7 into %arg8[0, 0, %arg7, 0] [1, 1, 1, 3] [1, 1, 1, 1] : tensor<1x1x1x3xf32> into tensor<1x1x12x3xf32>
-# CHECK-NEXT:            scf.yield %inserted_slice_18 : tensor<1x1x12x3xf32>
+# CHECK-NEXT:            %inserted_slice_15 = tensor.insert_slice %7 into %arg8[0, 0, %arg7, 0] [1, 1, 1, 3] [1, 1, 1, 1] : tensor<1x1x1x3xf32> into tensor<1x1x12x3xf32>
+# CHECK-NEXT:            scf.yield %inserted_slice_15 : tensor<1x1x12x3xf32>
 # CHECK-NEXT:          } {"./w"}
-# CHECK-NEXT:          %inserted_slice_14 = tensor.insert_slice %6 into %arg6[0, %arg5, 0, 0] [1, 1, 12, 3] [1, 1, 1, 1] : tensor<1x1x12x3xf32> into tensor<1x12x12x3xf32>
-# CHECK-NEXT:          scf.yield %inserted_slice_14 : tensor<1x12x12x3xf32>
+# CHECK-NEXT:          %inserted_slice_11 = tensor.insert_slice %6 into %arg6[0, %arg5, 0, 0] [1, 1, 12, 3] [1, 1, 1, 1] : tensor<1x1x12x3xf32> into tensor<1x12x12x3xf32>
+# CHECK-NEXT:          scf.yield %inserted_slice_11 : tensor<1x12x12x3xf32>
 # CHECK-NEXT:        } {"./h"}
 # CHECK-NEXT:        %inserted_slice = tensor.insert_slice %5 into %arg4[%arg3, 0, 0, 0] [1, 12, 12, 3] [1, 1, 1, 1] : tensor<1x12x12x3xf32> into tensor<1x12x12x3xf32>
 # CHECK-NEXT:        scf.yield %inserted_slice : tensor<1x12x12x3xf32>
 # CHECK-NEXT:      } {"./b"}
 # CHECK-NEXT:      %2 = tensor.empty() : tensor<1x4x4x16xf32>
 # CHECK-NEXT:      %cst_1 = arith.constant 0.000000e+00 : f32
+# CHECK-NEXT:      %3 = linalg.fill {__xtc_id_conv_0_} ins(%cst_1 : f32) outs(%2 : tensor<1x4x4x16xf32>) -> tensor<1x4x4x16xf32>
 # CHECK-NEXT:      %c0_2 = arith.constant 0 : index
 # CHECK-NEXT:      %c1_3 = arith.constant 1 : index
 # CHECK-NEXT:      %c1_4 = arith.constant 1 : index
-# CHECK-NEXT:      %3 = scf.for %arg3 = %c0_2 to %c1_3 step %c1_4 iter_args(%arg4 = %2) -> (tensor<1x4x4x16xf32>) {
-# CHECK-NEXT:        %extracted_slice = tensor.extract_slice %arg4[%arg3, 0, 0, 0] [1, 4, 4, 16] [1, 1, 1, 1] : tensor<1x4x4x16xf32> to tensor<1x4x4x16xf32>
-# CHECK-NEXT:        %c0_8 = arith.constant 0 : index
-# CHECK-NEXT:        %c4 = arith.constant 4 : index
-# CHECK-NEXT:        %c1_9 = arith.constant 1 : index
-# CHECK-NEXT:        %5 = scf.for %arg5 = %c0_8 to %c4 step %c1_9 iter_args(%arg6 = %extracted_slice) -> (tensor<1x4x4x16xf32>) {
-# CHECK-NEXT:          %extracted_slice_10 = tensor.extract_slice %arg6[0, %arg5, 0, 0] [1, 1, 4, 16] [1, 1, 1, 1] : tensor<1x4x4x16xf32> to tensor<1x1x4x16xf32>
-# CHECK-NEXT:          %c0_11 = arith.constant 0 : index
-# CHECK-NEXT:          %c4_12 = arith.constant 4 : index
-# CHECK-NEXT:          %c1_13 = arith.constant 1 : index
-# CHECK-NEXT:          %6 = scf.for %arg7 = %c0_11 to %c4_12 step %c1_13 iter_args(%arg8 = %extracted_slice_10) -> (tensor<1x1x4x16xf32>) {
-# CHECK-NEXT:            %extracted_slice_15 = tensor.extract_slice %arg8[0, 0, %arg7, 0] [1, 1, 1, 16] [1, 1, 1, 1] : tensor<1x1x4x16xf32> to tensor<1x1x1x16xf32>
-# CHECK-NEXT:            %c0_16 = arith.constant 0 : index
-# CHECK-NEXT:            %c16 = arith.constant 16 : index
-# CHECK-NEXT:            %c1_17 = arith.constant 1 : index
-# CHECK-NEXT:            %7 = scf.for %arg9 = %c0_16 to %c16 step %c1_17 iter_args(%arg10 = %extracted_slice_15) -> (tensor<1x1x1x16xf32>) {
-# CHECK-NEXT:              %extracted_slice_19 = tensor.extract_slice %arg10[0, 0, 0, %arg9] [1, 1, 1, 1] [1, 1, 1, 1] : tensor<1x1x1x16xf32> to tensor<1x1x1x1xf32>
-# CHECK-NEXT:              %8 = linalg.fill {__xtc_id_conv_0_} ins(%cst_1 : f32) outs(%extracted_slice_19 : tensor<1x1x1x1xf32>) -> tensor<1x1x1x1xf32>
-# CHECK-NEXT:              %inserted_slice_20 = tensor.insert_slice %8 into %arg10[0, 0, 0, %arg9] [1, 1, 1, 1] [1, 1, 1, 1] : tensor<1x1x1x1xf32> into tensor<1x1x1x16xf32>
-# CHECK-NEXT:              scf.yield %inserted_slice_20 : tensor<1x1x1x16xf32>
-# CHECK-NEXT:            } {"./f"}
-# CHECK-NEXT:            %inserted_slice_18 = tensor.insert_slice %7 into %arg8[0, 0, %arg7, 0] [1, 1, 1, 16] [1, 1, 1, 1] : tensor<1x1x1x16xf32> into tensor<1x1x4x16xf32>
-# CHECK-NEXT:            scf.yield %inserted_slice_18 : tensor<1x1x4x16xf32>
-# CHECK-NEXT:          } {"./w"}
-# CHECK-NEXT:          %inserted_slice_14 = tensor.insert_slice %6 into %arg6[0, %arg5, 0, 0] [1, 1, 4, 16] [1, 1, 1, 1] : tensor<1x1x4x16xf32> into tensor<1x4x4x16xf32>
-# CHECK-NEXT:          scf.yield %inserted_slice_14 : tensor<1x4x4x16xf32>
-# CHECK-NEXT:        } {"./h"}
-# CHECK-NEXT:        %inserted_slice = tensor.insert_slice %5 into %arg4[%arg3, 0, 0, 0] [1, 4, 4, 16] [1, 1, 1, 1] : tensor<1x4x4x16xf32> into tensor<1x4x4x16xf32>
-# CHECK-NEXT:        scf.yield %inserted_slice : tensor<1x4x4x16xf32>
-# CHECK-NEXT:      } {"./b"}
-# CHECK-NEXT:      %c0_5 = arith.constant 0 : index
-# CHECK-NEXT:      %c1_6 = arith.constant 1 : index
-# CHECK-NEXT:      %c1_7 = arith.constant 1 : index
-# CHECK-NEXT:      %4 = scf.for %arg3 = %c0_5 to %c1_6 step %c1_7 iter_args(%arg4 = %3) -> (tensor<1x4x4x16xf32>) {
+# CHECK-NEXT:      %4 = scf.for %arg3 = %c0_2 to %c1_3 step %c1_4 iter_args(%arg4 = %3) -> (tensor<1x4x4x16xf32>) {
 # CHECK-NEXT:        %extracted_slice = tensor.extract_slice %1[%arg3, 0, 0, 0] [1, 11, 11, 3] [1, 1, 1, 1] : tensor<1x12x12x3xf32> to tensor<1x11x11x3xf32>
-# CHECK-NEXT:        %extracted_slice_8 = tensor.extract_slice %arg1[0, 0, 0, 0] [5, 5, 3, 16] [1, 1, 1, 1] : tensor<5x5x3x16xf32> to tensor<5x5x3x16xf32>
-# CHECK-NEXT:        %extracted_slice_9 = tensor.extract_slice %arg4[%arg3, 0, 0, 0] [1, 4, 4, 16] [1, 1, 1, 1] : tensor<1x4x4x16xf32> to tensor<1x4x4x16xf32>
-# CHECK-NEXT:        %c0_10 = arith.constant 0 : index
+# CHECK-NEXT:        %extracted_slice_5 = tensor.extract_slice %arg1[0, 0, 0, 0] [5, 5, 3, 16] [1, 1, 1, 1] : tensor<5x5x3x16xf32> to tensor<5x5x3x16xf32>
+# CHECK-NEXT:        %extracted_slice_6 = tensor.extract_slice %arg4[%arg3, 0, 0, 0] [1, 4, 4, 16] [1, 1, 1, 1] : tensor<1x4x4x16xf32> to tensor<1x4x4x16xf32>
+# CHECK-NEXT:        %c0_7 = arith.constant 0 : index
 # CHECK-NEXT:        %c4 = arith.constant 4 : index
-# CHECK-NEXT:        %c1_11 = arith.constant 1 : index
-# CHECK-NEXT:        %5 = scf.for %arg5 = %c0_10 to %c4 step %c1_11 iter_args(%arg6 = %extracted_slice_9) -> (tensor<1x4x4x16xf32>) {
+# CHECK-NEXT:        %c1_8 = arith.constant 1 : index
+# CHECK-NEXT:        %5 = scf.for %arg5 = %c0_7 to %c4 step %c1_8 iter_args(%arg6 = %extracted_slice_6) -> (tensor<1x4x4x16xf32>) {
 # CHECK-NEXT:          %6 = affine.apply #map2(%arg5)
-# CHECK-NEXT:          %extracted_slice_12 = tensor.extract_slice %extracted_slice[0, %6, 0, 0] [1, 5, 11, 3] [1, 1, 1, 1] : tensor<1x11x11x3xf32> to tensor<1x5x11x3xf32>
-# CHECK-NEXT:          %extracted_slice_13 = tensor.extract_slice %extracted_slice_8[0, 0, 0, 0] [5, 5, 3, 16] [1, 1, 1, 1] : tensor<5x5x3x16xf32> to tensor<5x5x3x16xf32>
-# CHECK-NEXT:          %extracted_slice_14 = tensor.extract_slice %arg6[0, %arg5, 0, 0] [1, 1, 4, 16] [1, 1, 1, 1] : tensor<1x4x4x16xf32> to tensor<1x1x4x16xf32>
-# CHECK-NEXT:          %c0_15 = arith.constant 0 : index
-# CHECK-NEXT:          %c4_16 = arith.constant 4 : index
-# CHECK-NEXT:          %c1_17 = arith.constant 1 : index
-# CHECK-NEXT:          %7 = scf.for %arg7 = %c0_15 to %c4_16 step %c1_17 iter_args(%arg8 = %extracted_slice_14) -> (tensor<1x1x4x16xf32>) {
+# CHECK-NEXT:          %extracted_slice_9 = tensor.extract_slice %extracted_slice[0, %6, 0, 0] [1, 5, 11, 3] [1, 1, 1, 1] : tensor<1x11x11x3xf32> to tensor<1x5x11x3xf32>
+# CHECK-NEXT:          %extracted_slice_10 = tensor.extract_slice %extracted_slice_5[0, 0, 0, 0] [5, 5, 3, 16] [1, 1, 1, 1] : tensor<5x5x3x16xf32> to tensor<5x5x3x16xf32>
+# CHECK-NEXT:          %extracted_slice_11 = tensor.extract_slice %arg6[0, %arg5, 0, 0] [1, 1, 4, 16] [1, 1, 1, 1] : tensor<1x4x4x16xf32> to tensor<1x1x4x16xf32>
+# CHECK-NEXT:          %c0_12 = arith.constant 0 : index
+# CHECK-NEXT:          %c4_13 = arith.constant 4 : index
+# CHECK-NEXT:          %c1_14 = arith.constant 1 : index
+# CHECK-NEXT:          %7 = scf.for %arg7 = %c0_12 to %c4_13 step %c1_14 iter_args(%arg8 = %extracted_slice_11) -> (tensor<1x1x4x16xf32>) {
 # CHECK-NEXT:            %8 = affine.apply #map2(%arg7)
-# CHECK-NEXT:            %extracted_slice_19 = tensor.extract_slice %extracted_slice_12[0, 0, %8, 0] [1, 5, 5, 3] [1, 1, 1, 1] : tensor<1x5x11x3xf32> to tensor<1x5x5x3xf32>
-# CHECK-NEXT:            %extracted_slice_20 = tensor.extract_slice %extracted_slice_13[0, 0, 0, 0] [5, 5, 3, 16] [1, 1, 1, 1] : tensor<5x5x3x16xf32> to tensor<5x5x3x16xf32>
-# CHECK-NEXT:            %extracted_slice_21 = tensor.extract_slice %arg8[0, 0, %arg7, 0] [1, 1, 1, 16] [1, 1, 1, 1] : tensor<1x1x4x16xf32> to tensor<1x1x1x16xf32>
-# CHECK-NEXT:            %c0_22 = arith.constant 0 : index
+# CHECK-NEXT:            %extracted_slice_16 = tensor.extract_slice %extracted_slice_9[0, 0, %8, 0] [1, 5, 5, 3] [1, 1, 1, 1] : tensor<1x5x11x3xf32> to tensor<1x5x5x3xf32>
+# CHECK-NEXT:            %extracted_slice_17 = tensor.extract_slice %extracted_slice_10[0, 0, 0, 0] [5, 5, 3, 16] [1, 1, 1, 1] : tensor<5x5x3x16xf32> to tensor<5x5x3x16xf32>
+# CHECK-NEXT:            %extracted_slice_18 = tensor.extract_slice %arg8[0, 0, %arg7, 0] [1, 1, 1, 16] [1, 1, 1, 1] : tensor<1x1x4x16xf32> to tensor<1x1x1x16xf32>
+# CHECK-NEXT:            %c0_19 = arith.constant 0 : index
 # CHECK-NEXT:            %c16 = arith.constant 16 : index
-# CHECK-NEXT:            %c1_23 = arith.constant 1 : index
-# CHECK-NEXT:            %9 = scf.for %arg9 = %c0_22 to %c16 step %c1_23 iter_args(%arg10 = %extracted_slice_21) -> (tensor<1x1x1x16xf32>) {
-# CHECK-NEXT:              %extracted_slice_25 = tensor.extract_slice %extracted_slice_19[0, 0, 0, 0] [1, 5, 5, 3] [1, 1, 1, 1] : tensor<1x5x5x3xf32> to tensor<1x5x5x3xf32>
-# CHECK-NEXT:              %extracted_slice_26 = tensor.extract_slice %extracted_slice_20[0, 0, 0, %arg9] [5, 5, 3, 1] [1, 1, 1, 1] : tensor<5x5x3x16xf32> to tensor<5x5x3x1xf32>
-# CHECK-NEXT:              %extracted_slice_27 = tensor.extract_slice %arg10[0, 0, 0, %arg9] [1, 1, 1, 1] [1, 1, 1, 1] : tensor<1x1x1x16xf32> to tensor<1x1x1x1xf32>
-# CHECK-NEXT:              %c0_28 = arith.constant 0 : index
+# CHECK-NEXT:            %c1_20 = arith.constant 1 : index
+# CHECK-NEXT:            %9 = scf.for %arg9 = %c0_19 to %c16 step %c1_20 iter_args(%arg10 = %extracted_slice_18) -> (tensor<1x1x1x16xf32>) {
+# CHECK-NEXT:              %extracted_slice_22 = tensor.extract_slice %extracted_slice_16[0, 0, 0, 0] [1, 5, 5, 3] [1, 1, 1, 1] : tensor<1x5x5x3xf32> to tensor<1x5x5x3xf32>
+# CHECK-NEXT:              %extracted_slice_23 = tensor.extract_slice %extracted_slice_17[0, 0, 0, %arg9] [5, 5, 3, 1] [1, 1, 1, 1] : tensor<5x5x3x16xf32> to tensor<5x5x3x1xf32>
+# CHECK-NEXT:              %extracted_slice_24 = tensor.extract_slice %arg10[0, 0, 0, %arg9] [1, 1, 1, 1] [1, 1, 1, 1] : tensor<1x1x1x16xf32> to tensor<1x1x1x1xf32>
+# CHECK-NEXT:              %c0_25 = arith.constant 0 : index
 # CHECK-NEXT:              %c5 = arith.constant 5 : index
-# CHECK-NEXT:              %c1_29 = arith.constant 1 : index
-# CHECK-NEXT:              %10 = scf.for %arg11 = %c0_28 to %c5 step %c1_29 iter_args(%arg12 = %extracted_slice_27) -> (tensor<1x1x1x1xf32>) {
-# CHECK-NEXT:                %extracted_slice_31 = tensor.extract_slice %extracted_slice_25[0, %arg11, 0, 0] [1, 1, 5, 3] [1, 1, 1, 1] : tensor<1x5x5x3xf32> to tensor<1x1x5x3xf32>
-# CHECK-NEXT:                %extracted_slice_32 = tensor.extract_slice %extracted_slice_26[%arg11, 0, 0, 0] [1, 5, 3, 1] [1, 1, 1, 1] : tensor<5x5x3x1xf32> to tensor<1x5x3x1xf32>
-# CHECK-NEXT:                %extracted_slice_33 = tensor.extract_slice %arg12[0, 0, 0, 0] [1, 1, 1, 1] [1, 1, 1, 1] : tensor<1x1x1x1xf32> to tensor<1x1x1x1xf32>
-# CHECK-NEXT:                %c0_34 = arith.constant 0 : index
-# CHECK-NEXT:                %c5_35 = arith.constant 5 : index
-# CHECK-NEXT:                %c1_36 = arith.constant 1 : index
-# CHECK-NEXT:                %11 = scf.for %arg13 = %c0_34 to %c5_35 step %c1_36 iter_args(%arg14 = %extracted_slice_33) -> (tensor<1x1x1x1xf32>) {
-# CHECK-NEXT:                  %extracted_slice_38 = tensor.extract_slice %extracted_slice_31[0, 0, %arg13, 0] [1, 1, 1, 3] [1, 1, 1, 1] : tensor<1x1x5x3xf32> to tensor<1x1x1x3xf32>
-# CHECK-NEXT:                  %extracted_slice_39 = tensor.extract_slice %extracted_slice_32[0, %arg13, 0, 0] [1, 1, 3, 1] [1, 1, 1, 1] : tensor<1x5x3x1xf32> to tensor<1x1x3x1xf32>
-# CHECK-NEXT:                  %extracted_slice_40 = tensor.extract_slice %arg14[0, 0, 0, 0] [1, 1, 1, 1] [1, 1, 1, 1] : tensor<1x1x1x1xf32> to tensor<1x1x1x1xf32>
-# CHECK-NEXT:                  %c0_41 = arith.constant 0 : index
+# CHECK-NEXT:              %c1_26 = arith.constant 1 : index
+# CHECK-NEXT:              %10 = scf.for %arg11 = %c0_25 to %c5 step %c1_26 iter_args(%arg12 = %extracted_slice_24) -> (tensor<1x1x1x1xf32>) {
+# CHECK-NEXT:                %extracted_slice_28 = tensor.extract_slice %extracted_slice_22[0, %arg11, 0, 0] [1, 1, 5, 3] [1, 1, 1, 1] : tensor<1x5x5x3xf32> to tensor<1x1x5x3xf32>
+# CHECK-NEXT:                %extracted_slice_29 = tensor.extract_slice %extracted_slice_23[%arg11, 0, 0, 0] [1, 5, 3, 1] [1, 1, 1, 1] : tensor<5x5x3x1xf32> to tensor<1x5x3x1xf32>
+# CHECK-NEXT:                %extracted_slice_30 = tensor.extract_slice %arg12[0, 0, 0, 0] [1, 1, 1, 1] [1, 1, 1, 1] : tensor<1x1x1x1xf32> to tensor<1x1x1x1xf32>
+# CHECK-NEXT:                %c0_31 = arith.constant 0 : index
+# CHECK-NEXT:                %c5_32 = arith.constant 5 : index
+# CHECK-NEXT:                %c1_33 = arith.constant 1 : index
+# CHECK-NEXT:                %11 = scf.for %arg13 = %c0_31 to %c5_32 step %c1_33 iter_args(%arg14 = %extracted_slice_30) -> (tensor<1x1x1x1xf32>) {
+# CHECK-NEXT:                  %extracted_slice_35 = tensor.extract_slice %extracted_slice_28[0, 0, %arg13, 0] [1, 1, 1, 3] [1, 1, 1, 1] : tensor<1x1x5x3xf32> to tensor<1x1x1x3xf32>
+# CHECK-NEXT:                  %extracted_slice_36 = tensor.extract_slice %extracted_slice_29[0, %arg13, 0, 0] [1, 1, 3, 1] [1, 1, 1, 1] : tensor<1x5x3x1xf32> to tensor<1x1x3x1xf32>
+# CHECK-NEXT:                  %extracted_slice_37 = tensor.extract_slice %arg14[0, 0, 0, 0] [1, 1, 1, 1] [1, 1, 1, 1] : tensor<1x1x1x1xf32> to tensor<1x1x1x1xf32>
+# CHECK-NEXT:                  %c0_38 = arith.constant 0 : index
 # CHECK-NEXT:                  %c3 = arith.constant 3 : index
-# CHECK-NEXT:                  %c1_42 = arith.constant 1 : index
-# CHECK-NEXT:                  %12 = scf.for %arg15 = %c0_41 to %c3 step %c1_42 iter_args(%arg16 = %extracted_slice_40) -> (tensor<1x1x1x1xf32>) {
-# CHECK-NEXT:                    %extracted_slice_44 = tensor.extract_slice %extracted_slice_38[0, 0, 0, %arg15] [1, 1, 1, 1] [1, 1, 1, 1] : tensor<1x1x1x3xf32> to tensor<1x1x1x1xf32>
-# CHECK-NEXT:                    %extracted_slice_45 = tensor.extract_slice %extracted_slice_39[0, 0, %arg15, 0] [1, 1, 1, 1] [1, 1, 1, 1] : tensor<1x1x3x1xf32> to tensor<1x1x1x1xf32>
-# CHECK-NEXT:                    %extracted_slice_46 = tensor.extract_slice %arg16[0, 0, 0, 0] [1, 1, 1, 1] [1, 1, 1, 1] : tensor<1x1x1x1xf32> to tensor<1x1x1x1xf32>
-# CHECK-NEXT:                    %13 = linalg.generic {indexing_maps = [#map3, #map4, #map5], iterator_types = ["parallel", "parallel", "parallel", "parallel", "reduction", "reduction", "reduction"]} ins(%extracted_slice_44, %extracted_slice_45 : tensor<1x1x1x1xf32>, tensor<1x1x1x1xf32>) outs(%extracted_slice_46 : tensor<1x1x1x1xf32>) attrs =  {__xtc_id_conv_} {
-# CHECK-NEXT:                    ^bb0(%in: f32, %in_48: f32, %out: f32):
-# CHECK-NEXT:                      %14 = arith.mulf %in, %in_48 fastmath<fast> : f32
+# CHECK-NEXT:                  %c1_39 = arith.constant 1 : index
+# CHECK-NEXT:                  %12 = scf.for %arg15 = %c0_38 to %c3 step %c1_39 iter_args(%arg16 = %extracted_slice_37) -> (tensor<1x1x1x1xf32>) {
+# CHECK-NEXT:                    %extracted_slice_41 = tensor.extract_slice %extracted_slice_35[0, 0, 0, %arg15] [1, 1, 1, 1] [1, 1, 1, 1] : tensor<1x1x1x3xf32> to tensor<1x1x1x1xf32>
+# CHECK-NEXT:                    %extracted_slice_42 = tensor.extract_slice %extracted_slice_36[0, 0, %arg15, 0] [1, 1, 1, 1] [1, 1, 1, 1] : tensor<1x1x3x1xf32> to tensor<1x1x1x1xf32>
+# CHECK-NEXT:                    %extracted_slice_43 = tensor.extract_slice %arg16[0, 0, 0, 0] [1, 1, 1, 1] [1, 1, 1, 1] : tensor<1x1x1x1xf32> to tensor<1x1x1x1xf32>
+# CHECK-NEXT:                    %13 = linalg.generic {indexing_maps = [#map3, #map4, #map5], iterator_types = ["parallel", "parallel", "parallel", "parallel", "reduction", "reduction", "reduction"]} ins(%extracted_slice_41, %extracted_slice_42 : tensor<1x1x1x1xf32>, tensor<1x1x1x1xf32>) outs(%extracted_slice_43 : tensor<1x1x1x1xf32>) attrs =  {__xtc_id_conv_} {
+# CHECK-NEXT:                    ^bb0(%in: f32, %in_45: f32, %out: f32):
+# CHECK-NEXT:                      %14 = arith.mulf %in, %in_45 fastmath<fast> : f32
 # CHECK-NEXT:                      %15 = arith.addf %out, %14 fastmath<fast> : f32
 # CHECK-NEXT:                      linalg.yield %15 : f32
 # CHECK-NEXT:                    } -> tensor<1x1x1x1xf32>
-# CHECK-NEXT:                    %inserted_slice_47 = tensor.insert_slice %13 into %arg16[0, 0, 0, 0] [1, 1, 1, 1] [1, 1, 1, 1] : tensor<1x1x1x1xf32> into tensor<1x1x1x1xf32>
-# CHECK-NEXT:                    scf.yield %inserted_slice_47 : tensor<1x1x1x1xf32>
+# CHECK-NEXT:                    %inserted_slice_44 = tensor.insert_slice %13 into %arg16[0, 0, 0, 0] [1, 1, 1, 1] [1, 1, 1, 1] : tensor<1x1x1x1xf32> into tensor<1x1x1x1xf32>
+# CHECK-NEXT:                    scf.yield %inserted_slice_44 : tensor<1x1x1x1xf32>
 # CHECK-NEXT:                  } {"./c"}
-# CHECK-NEXT:                  %inserted_slice_43 = tensor.insert_slice %12 into %arg14[0, 0, 0, 0] [1, 1, 1, 1] [1, 1, 1, 1] : tensor<1x1x1x1xf32> into tensor<1x1x1x1xf32>
-# CHECK-NEXT:                  scf.yield %inserted_slice_43 : tensor<1x1x1x1xf32>
+# CHECK-NEXT:                  %inserted_slice_40 = tensor.insert_slice %12 into %arg14[0, 0, 0, 0] [1, 1, 1, 1] [1, 1, 1, 1] : tensor<1x1x1x1xf32> into tensor<1x1x1x1xf32>
+# CHECK-NEXT:                  scf.yield %inserted_slice_40 : tensor<1x1x1x1xf32>
 # CHECK-NEXT:                } {"./s"}
-# CHECK-NEXT:                %inserted_slice_37 = tensor.insert_slice %11 into %arg12[0, 0, 0, 0] [1, 1, 1, 1] [1, 1, 1, 1] : tensor<1x1x1x1xf32> into tensor<1x1x1x1xf32>
-# CHECK-NEXT:                scf.yield %inserted_slice_37 : tensor<1x1x1x1xf32>
+# CHECK-NEXT:                %inserted_slice_34 = tensor.insert_slice %11 into %arg12[0, 0, 0, 0] [1, 1, 1, 1] [1, 1, 1, 1] : tensor<1x1x1x1xf32> into tensor<1x1x1x1xf32>
+# CHECK-NEXT:                scf.yield %inserted_slice_34 : tensor<1x1x1x1xf32>
 # CHECK-NEXT:              } {"./r"}
-# CHECK-NEXT:              %inserted_slice_30 = tensor.insert_slice %10 into %arg10[0, 0, 0, %arg9] [1, 1, 1, 1] [1, 1, 1, 1] : tensor<1x1x1x1xf32> into tensor<1x1x1x16xf32>
-# CHECK-NEXT:              scf.yield %inserted_slice_30 : tensor<1x1x1x16xf32>
+# CHECK-NEXT:              %inserted_slice_27 = tensor.insert_slice %10 into %arg10[0, 0, 0, %arg9] [1, 1, 1, 1] [1, 1, 1, 1] : tensor<1x1x1x1xf32> into tensor<1x1x1x16xf32>
+# CHECK-NEXT:              scf.yield %inserted_slice_27 : tensor<1x1x1x16xf32>
 # CHECK-NEXT:            } {"./f"}
-# CHECK-NEXT:            %inserted_slice_24 = tensor.insert_slice %9 into %arg8[0, 0, %arg7, 0] [1, 1, 1, 16] [1, 1, 1, 1] : tensor<1x1x1x16xf32> into tensor<1x1x4x16xf32>
-# CHECK-NEXT:            scf.yield %inserted_slice_24 : tensor<1x1x4x16xf32>
+# CHECK-NEXT:            %inserted_slice_21 = tensor.insert_slice %9 into %arg8[0, 0, %arg7, 0] [1, 1, 1, 16] [1, 1, 1, 1] : tensor<1x1x1x16xf32> into tensor<1x1x4x16xf32>
+# CHECK-NEXT:            scf.yield %inserted_slice_21 : tensor<1x1x4x16xf32>
 # CHECK-NEXT:          } {"./w"}
-# CHECK-NEXT:          %inserted_slice_18 = tensor.insert_slice %7 into %arg6[0, %arg5, 0, 0] [1, 1, 4, 16] [1, 1, 1, 1] : tensor<1x1x4x16xf32> into tensor<1x4x4x16xf32>
-# CHECK-NEXT:          scf.yield %inserted_slice_18 : tensor<1x4x4x16xf32>
+# CHECK-NEXT:          %inserted_slice_15 = tensor.insert_slice %7 into %arg6[0, %arg5, 0, 0] [1, 1, 4, 16] [1, 1, 1, 1] : tensor<1x1x4x16xf32> into tensor<1x4x4x16xf32>
+# CHECK-NEXT:          scf.yield %inserted_slice_15 : tensor<1x4x4x16xf32>
 # CHECK-NEXT:        } {"./h"}
 # CHECK-NEXT:        %inserted_slice = tensor.insert_slice %5 into %arg4[%arg3, 0, 0, 0] [1, 4, 4, 16] [1, 1, 1, 1] : tensor<1x4x4x16xf32> into tensor<1x4x4x16xf32>
 # CHECK-NEXT:        scf.yield %inserted_slice : tensor<1x4x4x16xf32>
@@ -375,110 +334,92 @@ print(f"CODE: {res}")
 # CHECK-NEXT:      %alloc = memref.alloc() {alignment = 256 : i64} : memref<1x12x12x3xf32>
 # CHECK-NEXT:      %0 = scf.for %arg3 = %c0 to %c12 step %c1 iter_args(%arg4 = %alloc) -> (memref<1x12x12x3xf32>) {
 # CHECK-NEXT:        %subview_0 = memref.subview %arg4[0, %arg3, 0, 0] [1, 1, 12, 3] [1, 1, 1, 1] : memref<1x12x12x3xf32> to memref<1x1x12x3xf32, strided<[432, 36, 3, 1], offset: ?>>
-# CHECK-NEXT:        %3 = scf.for %arg5 = %c0 to %c12 step %c1 iter_args(%arg6 = %subview_0) -> (memref<1x1x12x3xf32, strided<[432, 36, 3, 1], offset: ?>>) {
+# CHECK-NEXT:        %2 = scf.for %arg5 = %c0 to %c12 step %c1 iter_args(%arg6 = %subview_0) -> (memref<1x1x12x3xf32, strided<[432, 36, 3, 1], offset: ?>>) {
 # CHECK-NEXT:          %subview_2 = memref.subview %arg6[0, 0, %arg5, 0] [1, 1, 1, 3] [1, 1, 1, 1] : memref<1x1x12x3xf32, strided<[432, 36, 3, 1], offset: ?>> to memref<1x1x1x3xf32, strided<[432, 36, 3, 1], offset: ?>>
-# CHECK-NEXT:          %4 = scf.for %arg7 = %c0 to %c3 step %c1 iter_args(%arg8 = %subview_2) -> (memref<1x1x1x3xf32, strided<[432, 36, 3, 1], offset: ?>>) {
+# CHECK-NEXT:          %3 = scf.for %arg7 = %c0 to %c3 step %c1 iter_args(%arg8 = %subview_2) -> (memref<1x1x1x3xf32, strided<[432, 36, 3, 1], offset: ?>>) {
 # CHECK-NEXT:            %subview_4 = memref.subview %arg8[0, 0, 0, %arg7] [1, 1, 1, 1] [1, 1, 1, 1] : memref<1x1x1x3xf32, strided<[432, 36, 3, 1], offset: ?>> to memref<1x1x1x1xf32, strided<[432, 36, 3, 1], offset: ?>>
 # CHECK-NEXT:            linalg.generic {indexing_maps = [#map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} outs(%subview_4 : memref<1x1x1x1xf32, strided<[432, 36, 3, 1], offset: ?>>) attrs =  {__xtc_id_pad_} {
 # CHECK-NEXT:            ^bb0(%out: f32):
-# CHECK-NEXT:              %5 = arith.subi %arg3, %c2 : index
-# CHECK-NEXT:              %6 = arith.cmpi sge, %5, %c0 : index
-# CHECK-NEXT:              %7 = arith.cmpi slt, %5, %c8 : index
-# CHECK-NEXT:              %8 = arith.subi %arg5, %c2 : index
-# CHECK-NEXT:              %9 = arith.cmpi sge, %8, %c0 : index
-# CHECK-NEXT:              %10 = arith.cmpi slt, %8, %c8 : index
-# CHECK-NEXT:              %11 = arith.cmpi sge, %arg7, %c0 : index
-# CHECK-NEXT:              %12 = arith.cmpi slt, %arg7, %c3 : index
-# CHECK-NEXT:              %13 = arith.andi %6, %7 : i1
+# CHECK-NEXT:              %4 = arith.subi %arg3, %c2 : index
+# CHECK-NEXT:              %5 = arith.cmpi sge, %4, %c0 : index
+# CHECK-NEXT:              %6 = arith.cmpi slt, %4, %c8 : index
+# CHECK-NEXT:              %7 = arith.subi %arg5, %c2 : index
+# CHECK-NEXT:              %8 = arith.cmpi sge, %7, %c0 : index
+# CHECK-NEXT:              %9 = arith.cmpi slt, %7, %c8 : index
+# CHECK-NEXT:              %10 = arith.cmpi sge, %arg7, %c0 : index
+# CHECK-NEXT:              %11 = arith.cmpi slt, %arg7, %c3 : index
+# CHECK-NEXT:              %12 = arith.andi %5, %6 : i1
+# CHECK-NEXT:              %13 = arith.andi %12, %8 : i1
 # CHECK-NEXT:              %14 = arith.andi %13, %9 : i1
 # CHECK-NEXT:              %15 = arith.andi %14, %10 : i1
 # CHECK-NEXT:              %16 = arith.andi %15, %11 : i1
-# CHECK-NEXT:              %17 = arith.andi %16, %12 : i1
-# CHECK-NEXT:              %18 = scf.if %17 -> (f32) {
-# CHECK-NEXT:                %19 = memref.load %arg0[%c0, %5, %8, %arg7] : memref<1x8x8x3xf32>
-# CHECK-NEXT:                scf.yield %19 : f32
+# CHECK-NEXT:              %17 = scf.if %16 -> (f32) {
+# CHECK-NEXT:                %18 = memref.load %arg0[%c0, %4, %7, %arg7] : memref<1x8x8x3xf32>
+# CHECK-NEXT:                scf.yield %18 : f32
 # CHECK-NEXT:              } else {
 # CHECK-NEXT:                scf.yield %cst : f32
 # CHECK-NEXT:              }
-# CHECK-NEXT:              linalg.yield %18 : f32
+# CHECK-NEXT:              linalg.yield %17 : f32
 # CHECK-NEXT:            }
 # CHECK-NEXT:            %subview_5 = memref.subview %arg8[0, 0, 0, %arg7] [1, 1, 1, 1] [1, 1, 1, 1] : memref<1x1x1x3xf32, strided<[432, 36, 3, 1], offset: ?>> to memref<1x1x1x1xf32, strided<[432, 36, 3, 1], offset: ?>>
 # CHECK-NEXT:            memref.copy %subview_4, %subview_5 : memref<1x1x1x1xf32, strided<[432, 36, 3, 1], offset: ?>> to memref<1x1x1x1xf32, strided<[432, 36, 3, 1], offset: ?>>
 # CHECK-NEXT:            scf.yield %arg8 : memref<1x1x1x3xf32, strided<[432, 36, 3, 1], offset: ?>>
 # CHECK-NEXT:          } {"./c"}
 # CHECK-NEXT:          %subview_3 = memref.subview %arg6[0, 0, %arg5, 0] [1, 1, 1, 3] [1, 1, 1, 1] : memref<1x1x12x3xf32, strided<[432, 36, 3, 1], offset: ?>> to memref<1x1x1x3xf32, strided<[432, 36, 3, 1], offset: ?>>
-# CHECK-NEXT:          memref.copy %4, %subview_3 : memref<1x1x1x3xf32, strided<[432, 36, 3, 1], offset: ?>> to memref<1x1x1x3xf32, strided<[432, 36, 3, 1], offset: ?>>
+# CHECK-NEXT:          memref.copy %3, %subview_3 : memref<1x1x1x3xf32, strided<[432, 36, 3, 1], offset: ?>> to memref<1x1x1x3xf32, strided<[432, 36, 3, 1], offset: ?>>
 # CHECK-NEXT:          scf.yield %arg6 : memref<1x1x12x3xf32, strided<[432, 36, 3, 1], offset: ?>>
 # CHECK-NEXT:        } {"./w"}
 # CHECK-NEXT:        %subview_1 = memref.subview %arg4[0, %arg3, 0, 0] [1, 1, 12, 3] [1, 1, 1, 1] : memref<1x12x12x3xf32> to memref<1x1x12x3xf32, strided<[432, 36, 3, 1], offset: ?>>
-# CHECK-NEXT:        memref.copy %3, %subview_1 : memref<1x1x12x3xf32, strided<[432, 36, 3, 1], offset: ?>> to memref<1x1x12x3xf32, strided<[432, 36, 3, 1], offset: ?>>
+# CHECK-NEXT:        memref.copy %2, %subview_1 : memref<1x1x12x3xf32, strided<[432, 36, 3, 1], offset: ?>> to memref<1x1x12x3xf32, strided<[432, 36, 3, 1], offset: ?>>
 # CHECK-NEXT:        scf.yield %arg4 : memref<1x12x12x3xf32>
 # CHECK-NEXT:      } {"./h"}
-# CHECK-NEXT:      %1 = scf.for %arg3 = %c0 to %c4 step %c1 iter_args(%arg4 = %arg2) -> (memref<1x4x4x16xf32>) {
-# CHECK-NEXT:        %subview_0 = memref.subview %arg4[0, %arg3, 0, 0] [1, 1, 4, 16] [1, 1, 1, 1] : memref<1x4x4x16xf32> to memref<1x1x4x16xf32, strided<[256, 64, 16, 1], offset: ?>>
-# CHECK-NEXT:        %3 = scf.for %arg5 = %c0 to %c4 step %c1 iter_args(%arg6 = %subview_0) -> (memref<1x1x4x16xf32, strided<[256, 64, 16, 1], offset: ?>>) {
-# CHECK-NEXT:          %subview_2 = memref.subview %arg6[0, 0, %arg5, 0] [1, 1, 1, 16] [1, 1, 1, 1] : memref<1x1x4x16xf32, strided<[256, 64, 16, 1], offset: ?>> to memref<1x1x1x16xf32, strided<[256, 64, 16, 1], offset: ?>>
-# CHECK-NEXT:          %4 = scf.for %arg7 = %c0 to %c16 step %c1 iter_args(%arg8 = %subview_2) -> (memref<1x1x1x16xf32, strided<[256, 64, 16, 1], offset: ?>>) {
-# CHECK-NEXT:            %subview_4 = memref.subview %arg8[0, 0, 0, %arg7] [1, 1, 1, 1] [1, 1, 1, 1] : memref<1x1x1x16xf32, strided<[256, 64, 16, 1], offset: ?>> to memref<1x1x1x1xf32, strided<[256, 64, 16, 1], offset: ?>>
-# CHECK-NEXT:            linalg.fill {__xtc_id_conv_0_} ins(%cst : f32) outs(%subview_4 : memref<1x1x1x1xf32, strided<[256, 64, 16, 1], offset: ?>>)
-# CHECK-NEXT:            %subview_5 = memref.subview %arg8[0, 0, 0, %arg7] [1, 1, 1, 1] [1, 1, 1, 1] : memref<1x1x1x16xf32, strided<[256, 64, 16, 1], offset: ?>> to memref<1x1x1x1xf32, strided<[256, 64, 16, 1], offset: ?>>
-# CHECK-NEXT:            memref.copy %subview_4, %subview_5 : memref<1x1x1x1xf32, strided<[256, 64, 16, 1], offset: ?>> to memref<1x1x1x1xf32, strided<[256, 64, 16, 1], offset: ?>>
-# CHECK-NEXT:            scf.yield %arg8 : memref<1x1x1x16xf32, strided<[256, 64, 16, 1], offset: ?>>
-# CHECK-NEXT:          } {"./f"}
-# CHECK-NEXT:          %subview_3 = memref.subview %arg6[0, 0, %arg5, 0] [1, 1, 1, 16] [1, 1, 1, 1] : memref<1x1x4x16xf32, strided<[256, 64, 16, 1], offset: ?>> to memref<1x1x1x16xf32, strided<[256, 64, 16, 1], offset: ?>>
-# CHECK-NEXT:          memref.copy %4, %subview_3 : memref<1x1x1x16xf32, strided<[256, 64, 16, 1], offset: ?>> to memref<1x1x1x16xf32, strided<[256, 64, 16, 1], offset: ?>>
-# CHECK-NEXT:          scf.yield %arg6 : memref<1x1x4x16xf32, strided<[256, 64, 16, 1], offset: ?>>
-# CHECK-NEXT:        } {"./w"}
-# CHECK-NEXT:        %subview_1 = memref.subview %arg4[0, %arg3, 0, 0] [1, 1, 4, 16] [1, 1, 1, 1] : memref<1x4x4x16xf32> to memref<1x1x4x16xf32, strided<[256, 64, 16, 1], offset: ?>>
-# CHECK-NEXT:        memref.copy %3, %subview_1 : memref<1x1x4x16xf32, strided<[256, 64, 16, 1], offset: ?>> to memref<1x1x4x16xf32, strided<[256, 64, 16, 1], offset: ?>>
-# CHECK-NEXT:        scf.yield %arg4 : memref<1x4x4x16xf32>
-# CHECK-NEXT:      } {"./h"}
+# CHECK-NEXT:      linalg.fill {__xtc_id_conv_0_} ins(%cst : f32) outs(%arg2 : memref<1x4x4x16xf32>)
 # CHECK-NEXT:      %subview = memref.subview %0[0, 0, 0, 0] [1, 11, 11, 3] [1, 1, 1, 1] : memref<1x12x12x3xf32> to memref<1x11x11x3xf32, strided<[432, 36, 3, 1]>>
-# CHECK-NEXT:      %2 = scf.for %arg3 = %c0 to %c4 step %c1 iter_args(%arg4 = %1) -> (memref<1x4x4x16xf32>) {
-# CHECK-NEXT:        %3 = affine.apply #map1(%arg3)
-# CHECK-NEXT:        %subview_0 = memref.subview %subview[0, %3, 0, 0] [1, 5, 11, 3] [1, 1, 1, 1] : memref<1x11x11x3xf32, strided<[432, 36, 3, 1]>> to memref<1x5x11x3xf32, strided<[432, 36, 3, 1], offset: ?>>
+# CHECK-NEXT:      %1 = scf.for %arg3 = %c0 to %c4 step %c1 iter_args(%arg4 = %arg2) -> (memref<1x4x4x16xf32>) {
+# CHECK-NEXT:        %2 = affine.apply #map1(%arg3)
+# CHECK-NEXT:        %subview_0 = memref.subview %subview[0, %2, 0, 0] [1, 5, 11, 3] [1, 1, 1, 1] : memref<1x11x11x3xf32, strided<[432, 36, 3, 1]>> to memref<1x5x11x3xf32, strided<[432, 36, 3, 1], offset: ?>>
 # CHECK-NEXT:        %subview_1 = memref.subview %arg4[0, %arg3, 0, 0] [1, 1, 4, 16] [1, 1, 1, 1] : memref<1x4x4x16xf32> to memref<1x1x4x16xf32, strided<[256, 64, 16, 1], offset: ?>>
-# CHECK-NEXT:        %4 = scf.for %arg5 = %c0 to %c4 step %c1 iter_args(%arg6 = %subview_1) -> (memref<1x1x4x16xf32, strided<[256, 64, 16, 1], offset: ?>>) {
-# CHECK-NEXT:          %5 = affine.apply #map1(%arg5)
-# CHECK-NEXT:          %subview_3 = memref.subview %subview_0[0, 0, %5, 0] [1, 5, 5, 3] [1, 1, 1, 1] : memref<1x5x11x3xf32, strided<[432, 36, 3, 1], offset: ?>> to memref<1x5x5x3xf32, strided<[432, 36, 3, 1], offset: ?>>
+# CHECK-NEXT:        %3 = scf.for %arg5 = %c0 to %c4 step %c1 iter_args(%arg6 = %subview_1) -> (memref<1x1x4x16xf32, strided<[256, 64, 16, 1], offset: ?>>) {
+# CHECK-NEXT:          %4 = affine.apply #map1(%arg5)
+# CHECK-NEXT:          %subview_3 = memref.subview %subview_0[0, 0, %4, 0] [1, 5, 5, 3] [1, 1, 1, 1] : memref<1x5x11x3xf32, strided<[432, 36, 3, 1], offset: ?>> to memref<1x5x5x3xf32, strided<[432, 36, 3, 1], offset: ?>>
 # CHECK-NEXT:          %subview_4 = memref.subview %arg6[0, 0, %arg5, 0] [1, 1, 1, 16] [1, 1, 1, 1] : memref<1x1x4x16xf32, strided<[256, 64, 16, 1], offset: ?>> to memref<1x1x1x16xf32, strided<[256, 64, 16, 1], offset: ?>>
-# CHECK-NEXT:          %6 = scf.for %arg7 = %c0 to %c16 step %c1 iter_args(%arg8 = %subview_4) -> (memref<1x1x1x16xf32, strided<[256, 64, 16, 1], offset: ?>>) {
+# CHECK-NEXT:          %5 = scf.for %arg7 = %c0 to %c16 step %c1 iter_args(%arg8 = %subview_4) -> (memref<1x1x1x16xf32, strided<[256, 64, 16, 1], offset: ?>>) {
 # CHECK-NEXT:            %subview_6 = memref.subview %arg1[0, 0, 0, %arg7] [5, 5, 3, 1] [1, 1, 1, 1] : memref<5x5x3x16xf32> to memref<5x5x3x1xf32, strided<[240, 48, 16, 1], offset: ?>>
 # CHECK-NEXT:            %subview_7 = memref.subview %arg8[0, 0, 0, %arg7] [1, 1, 1, 1] [1, 1, 1, 1] : memref<1x1x1x16xf32, strided<[256, 64, 16, 1], offset: ?>> to memref<1x1x1x1xf32, strided<[256, 64, 16, 1], offset: ?>>
-# CHECK-NEXT:            %7 = scf.for %arg9 = %c0 to %c5 step %c1 iter_args(%arg10 = %subview_7) -> (memref<1x1x1x1xf32, strided<[256, 64, 16, 1], offset: ?>>) {
+# CHECK-NEXT:            %6 = scf.for %arg9 = %c0 to %c5 step %c1 iter_args(%arg10 = %subview_7) -> (memref<1x1x1x1xf32, strided<[256, 64, 16, 1], offset: ?>>) {
 # CHECK-NEXT:              %subview_9 = memref.subview %subview_3[0, %arg9, 0, 0] [1, 1, 5, 3] [1, 1, 1, 1] : memref<1x5x5x3xf32, strided<[432, 36, 3, 1], offset: ?>> to memref<1x1x5x3xf32, strided<[432, 36, 3, 1], offset: ?>>
 # CHECK-NEXT:              %subview_10 = memref.subview %subview_6[%arg9, 0, 0, 0] [1, 5, 3, 1] [1, 1, 1, 1] : memref<5x5x3x1xf32, strided<[240, 48, 16, 1], offset: ?>> to memref<1x5x3x1xf32, strided<[240, 48, 16, 1], offset: ?>>
-# CHECK-NEXT:              %8 = scf.for %arg11 = %c0 to %c5 step %c1 iter_args(%arg12 = %arg10) -> (memref<1x1x1x1xf32, strided<[256, 64, 16, 1], offset: ?>>) {
+# CHECK-NEXT:              %7 = scf.for %arg11 = %c0 to %c5 step %c1 iter_args(%arg12 = %arg10) -> (memref<1x1x1x1xf32, strided<[256, 64, 16, 1], offset: ?>>) {
 # CHECK-NEXT:                %subview_11 = memref.subview %subview_9[0, 0, %arg11, 0] [1, 1, 1, 3] [1, 1, 1, 1] : memref<1x1x5x3xf32, strided<[432, 36, 3, 1], offset: ?>> to memref<1x1x1x3xf32, strided<[432, 36, 3, 1], offset: ?>>
 # CHECK-NEXT:                %subview_12 = memref.subview %subview_10[0, %arg11, 0, 0] [1, 1, 3, 1] [1, 1, 1, 1] : memref<1x5x3x1xf32, strided<[240, 48, 16, 1], offset: ?>> to memref<1x1x3x1xf32, strided<[240, 48, 16, 1], offset: ?>>
-# CHECK-NEXT:                %9 = scf.for %arg13 = %c0 to %c3 step %c1 iter_args(%arg14 = %arg12) -> (memref<1x1x1x1xf32, strided<[256, 64, 16, 1], offset: ?>>) {
+# CHECK-NEXT:                %8 = scf.for %arg13 = %c0 to %c3 step %c1 iter_args(%arg14 = %arg12) -> (memref<1x1x1x1xf32, strided<[256, 64, 16, 1], offset: ?>>) {
 # CHECK-NEXT:                  %subview_13 = memref.subview %subview_11[0, 0, 0, %arg13] [1, 1, 1, 1] [1, 1, 1, 1] : memref<1x1x1x3xf32, strided<[432, 36, 3, 1], offset: ?>> to memref<1x1x1x1xf32, strided<[432, 36, 3, 1], offset: ?>>
 # CHECK-NEXT:                  %subview_14 = memref.subview %subview_12[0, 0, %arg13, 0] [1, 1, 1, 1] [1, 1, 1, 1] : memref<1x1x3x1xf32, strided<[240, 48, 16, 1], offset: ?>> to memref<1x1x1x1xf32, strided<[240, 48, 16, 1], offset: ?>>
 # CHECK-NEXT:                  linalg.generic {indexing_maps = [#map2, #map3, #map4], iterator_types = ["parallel", "parallel", "parallel", "parallel", "reduction", "reduction", "reduction"]} ins(%subview_13, %subview_14 : memref<1x1x1x1xf32, strided<[432, 36, 3, 1], offset: ?>>, memref<1x1x1x1xf32, strided<[240, 48, 16, 1], offset: ?>>) outs(%arg14 : memref<1x1x1x1xf32, strided<[256, 64, 16, 1], offset: ?>>) attrs =  {__xtc_id_conv_} {
 # CHECK-NEXT:                  ^bb0(%in: f32, %in_15: f32, %out: f32):
-# CHECK-NEXT:                    %10 = arith.mulf %in, %in_15 fastmath<fast> : f32
-# CHECK-NEXT:                    %11 = arith.addf %out, %10 fastmath<fast> : f32
-# CHECK-NEXT:                    linalg.yield %11 : f32
+# CHECK-NEXT:                    %9 = arith.mulf %in, %in_15 fastmath<fast> : f32
+# CHECK-NEXT:                    %10 = arith.addf %out, %9 fastmath<fast> : f32
+# CHECK-NEXT:                    linalg.yield %10 : f32
 # CHECK-NEXT:                  }
 # CHECK-NEXT:                  scf.yield %arg14 : memref<1x1x1x1xf32, strided<[256, 64, 16, 1], offset: ?>>
 # CHECK-NEXT:                } {"./c"}
-# CHECK-NEXT:                scf.yield %9 : memref<1x1x1x1xf32, strided<[256, 64, 16, 1], offset: ?>>
+# CHECK-NEXT:                scf.yield %8 : memref<1x1x1x1xf32, strided<[256, 64, 16, 1], offset: ?>>
 # CHECK-NEXT:              } {"./s"}
-# CHECK-NEXT:              scf.yield %8 : memref<1x1x1x1xf32, strided<[256, 64, 16, 1], offset: ?>>
+# CHECK-NEXT:              scf.yield %7 : memref<1x1x1x1xf32, strided<[256, 64, 16, 1], offset: ?>>
 # CHECK-NEXT:            } {"./r"}
 # CHECK-NEXT:            %subview_8 = memref.subview %arg8[0, 0, 0, %arg7] [1, 1, 1, 1] [1, 1, 1, 1] : memref<1x1x1x16xf32, strided<[256, 64, 16, 1], offset: ?>> to memref<1x1x1x1xf32, strided<[256, 64, 16, 1], offset: ?>>
-# CHECK-NEXT:            memref.copy %7, %subview_8 : memref<1x1x1x1xf32, strided<[256, 64, 16, 1], offset: ?>> to memref<1x1x1x1xf32, strided<[256, 64, 16, 1], offset: ?>>
+# CHECK-NEXT:            memref.copy %6, %subview_8 : memref<1x1x1x1xf32, strided<[256, 64, 16, 1], offset: ?>> to memref<1x1x1x1xf32, strided<[256, 64, 16, 1], offset: ?>>
 # CHECK-NEXT:            scf.yield %arg8 : memref<1x1x1x16xf32, strided<[256, 64, 16, 1], offset: ?>>
 # CHECK-NEXT:          } {"./f"}
 # CHECK-NEXT:          %subview_5 = memref.subview %arg6[0, 0, %arg5, 0] [1, 1, 1, 16] [1, 1, 1, 1] : memref<1x1x4x16xf32, strided<[256, 64, 16, 1], offset: ?>> to memref<1x1x1x16xf32, strided<[256, 64, 16, 1], offset: ?>>
-# CHECK-NEXT:          memref.copy %6, %subview_5 : memref<1x1x1x16xf32, strided<[256, 64, 16, 1], offset: ?>> to memref<1x1x1x16xf32, strided<[256, 64, 16, 1], offset: ?>>
+# CHECK-NEXT:          memref.copy %5, %subview_5 : memref<1x1x1x16xf32, strided<[256, 64, 16, 1], offset: ?>> to memref<1x1x1x16xf32, strided<[256, 64, 16, 1], offset: ?>>
 # CHECK-NEXT:          scf.yield %arg6 : memref<1x1x4x16xf32, strided<[256, 64, 16, 1], offset: ?>>
 # CHECK-NEXT:        } {"./w"}
 # CHECK-NEXT:        %subview_2 = memref.subview %arg4[0, %arg3, 0, 0] [1, 1, 4, 16] [1, 1, 1, 1] : memref<1x4x4x16xf32> to memref<1x1x4x16xf32, strided<[256, 64, 16, 1], offset: ?>>
-# CHECK-NEXT:        memref.copy %4, %subview_2 : memref<1x1x4x16xf32, strided<[256, 64, 16, 1], offset: ?>> to memref<1x1x4x16xf32, strided<[256, 64, 16, 1], offset: ?>>
+# CHECK-NEXT:        memref.copy %3, %subview_2 : memref<1x1x4x16xf32, strided<[256, 64, 16, 1], offset: ?>> to memref<1x1x4x16xf32, strided<[256, 64, 16, 1], offset: ?>>
 # CHECK-NEXT:        scf.yield %arg4 : memref<1x4x4x16xf32>
 # CHECK-NEXT:      } {"./h"}
-# CHECK-NEXT:      memref.copy %2, %arg2 : memref<1x4x4x16xf32> to memref<1x4x4x16xf32>
+# CHECK-NEXT:      memref.copy %1, %arg2 : memref<1x4x4x16xf32> to memref<1x4x4x16xf32>
 # CHECK-NEXT:      return
 # CHECK-NEXT:    }
 # CHECK-NEXT:  }

--- a/tests/filecheck/backends/tensor_dialect/test_pad_matmul_unpad_mlir_tensor.py
+++ b/tests/filecheck/backends/tensor_dialect/test_pad_matmul_unpad_mlir_tensor.py
@@ -31,390 +31,357 @@ module = comp.compile(sched)
 executor = module.get_executor(validate=True)
 res = executor.execute()
 print(f"CODE: {res}")
-# CHECK: // -----// IR Dump Before transform //----- //
-# CHECK-NEXT: #map = affine_map<(d0, d1) -> (d0, d1)>
-# CHECK-NEXT: module attributes {transform.with_named_sequence} {
-# CHECK-NEXT:   func.func @pad_matmul_unpad(%arg0: tensor<14x14xf32> {llvm.noalias}, %arg1: tensor<14x14xf32> {llvm.noalias}, %arg2: memref<14x14xf32> {llvm.noalias}) {
-# CHECK-NEXT:     %0 = tensor.empty() : tensor<16x16xf32>
-# CHECK-NEXT:     %cst = arith.constant 0.000000e+00 : f32
-# CHECK-NEXT:     %1 = linalg.generic {indexing_maps = [#map], iterator_types = ["parallel", "parallel"]} outs(%0 : tensor<16x16xf32>) attrs =  {__xtc_id_A_pad_} {
-# CHECK-NEXT:     ^bb0(%out: f32):
-# CHECK-NEXT:       %8 = linalg.index 0 : index
-# CHECK-NEXT:       %9 = linalg.index 1 : index
-# CHECK-NEXT:       %c0 = arith.constant 0 : index
-# CHECK-NEXT:       %c0_2 = arith.constant 0 : index
-# CHECK-NEXT:       %10 = arith.subi %8, %c0_2 : index
-# CHECK-NEXT:       %c14 = arith.constant 14 : index
-# CHECK-NEXT:       %11 = arith.cmpi sge, %10, %c0 : index
-# CHECK-NEXT:       %12 = arith.cmpi slt, %10, %c14 : index
-# CHECK-NEXT:       %c0_3 = arith.constant 0 : index
-# CHECK-NEXT:       %13 = arith.subi %9, %c0_3 : index
-# CHECK-NEXT:       %c14_4 = arith.constant 14 : index
-# CHECK-NEXT:       %14 = arith.cmpi sge, %13, %c0 : index
-# CHECK-NEXT:       %15 = arith.cmpi slt, %13, %c14_4 : index
-# CHECK-NEXT:       %16 = arith.andi %11, %12 : i1
-# CHECK-NEXT:       %17 = arith.andi %16, %14 : i1
-# CHECK-NEXT:       %18 = arith.andi %17, %15 : i1
-# CHECK-NEXT:       %19 = scf.if %18 -> (f32) {
-# CHECK-NEXT:         %extracted = tensor.extract %arg0[%10, %13] : tensor<14x14xf32>
-# CHECK-NEXT:         scf.yield %extracted : f32
-# CHECK-NEXT:       } else {
-# CHECK-NEXT:         scf.yield %cst : f32
-# CHECK-NEXT:       }
-# CHECK-NEXT:       linalg.yield %19 : f32
-# CHECK-NEXT:     } -> tensor<16x16xf32>
-# CHECK-NEXT:     %2 = tensor.empty() : tensor<16x16xf32>
-# CHECK-NEXT:     %cst_0 = arith.constant 0.000000e+00 : f32
-# CHECK-NEXT:     %3 = linalg.generic {indexing_maps = [#map], iterator_types = ["parallel", "parallel"]} outs(%2 : tensor<16x16xf32>) attrs =  {__xtc_id_B_pad_} {
-# CHECK-NEXT:     ^bb0(%out: f32):
-# CHECK-NEXT:       %8 = linalg.index 0 : index
-# CHECK-NEXT:       %9 = linalg.index 1 : index
-# CHECK-NEXT:       %c0 = arith.constant 0 : index
-# CHECK-NEXT:       %c0_2 = arith.constant 0 : index
-# CHECK-NEXT:       %10 = arith.subi %8, %c0_2 : index
-# CHECK-NEXT:       %c14 = arith.constant 14 : index
-# CHECK-NEXT:       %11 = arith.cmpi sge, %10, %c0 : index
-# CHECK-NEXT:       %12 = arith.cmpi slt, %10, %c14 : index
-# CHECK-NEXT:       %c0_3 = arith.constant 0 : index
-# CHECK-NEXT:       %13 = arith.subi %9, %c0_3 : index
-# CHECK-NEXT:       %c14_4 = arith.constant 14 : index
-# CHECK-NEXT:       %14 = arith.cmpi sge, %13, %c0 : index
-# CHECK-NEXT:       %15 = arith.cmpi slt, %13, %c14_4 : index
-# CHECK-NEXT:       %16 = arith.andi %11, %12 : i1
-# CHECK-NEXT:       %17 = arith.andi %16, %14 : i1
-# CHECK-NEXT:       %18 = arith.andi %17, %15 : i1
-# CHECK-NEXT:       %19 = scf.if %18 -> (f32) {
-# CHECK-NEXT:         %extracted = tensor.extract %arg1[%10, %13] : tensor<14x14xf32>
-# CHECK-NEXT:         scf.yield %extracted : f32
-# CHECK-NEXT:       } else {
-# CHECK-NEXT:         scf.yield %cst_0 : f32
-# CHECK-NEXT:       }
-# CHECK-NEXT:       linalg.yield %19 : f32
-# CHECK-NEXT:     } -> tensor<16x16xf32>
-# CHECK-NEXT:     %4 = tensor.empty() : tensor<16x16xf32>
-# CHECK-NEXT:     %cst_1 = arith.constant 0.000000e+00 : f32
-# CHECK-NEXT:     %5 = linalg.fill {__xtc_id_matmul_padded_0_} ins(%cst_1 : f32) outs(%4 : tensor<16x16xf32>) -> tensor<16x16xf32>
-# CHECK-NEXT:     %6 = linalg.matmul {__xtc_id_matmul_padded_} ins(%1, %3 : tensor<16x16xf32>, tensor<16x16xf32>) outs(%5 : tensor<16x16xf32>) -> tensor<16x16xf32>
-# CHECK-NEXT:     %7 = tensor.empty() : tensor<14x14xf32>
-# CHECK-NEXT:     %extracted_slice = tensor.extract_slice %6[0, 0] [14, 14] [1, 1] {__xtc_id_C_} : tensor<16x16xf32> to tensor<14x14xf32>
-# CHECK-NEXT:     bufferization.materialize_in_destination %extracted_slice in restrict writable %arg2 : (tensor<14x14xf32>, memref<14x14xf32>) -> ()
-# CHECK-NEXT:     return
-# CHECK-NEXT:   }
-# CHECK-NEXT:   transform.named_sequence @_vecto(%arg0: !transform.any_op {transform.consumed}) {
-# CHECK-NEXT:     transform.structured.vectorize %arg0 : !transform.any_op
-# CHECK-NEXT:     transform.yield 
-# CHECK-NEXT:   }
-# CHECK-NEXT:   transform.named_sequence @_post_bufferize(%arg0: !transform.any_op {transform.readonly}) {
-# CHECK-NEXT:     transform.yield 
-# CHECK-NEXT:   }
-# CHECK-NEXT:   transform.named_sequence @__transform_main(%arg0: !transform.any_op {transform.readonly}) {
-# CHECK-NEXT:     %0 = transform.structured.match attributes {__xtc_id_A_pad_} in %arg0 : (!transform.any_op) -> !transform.any_op
-# CHECK-NEXT:     %tiled_linalg_op, %loops = transform.structured.tile_using_for %0 tile_sizes [1, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:     transform.annotate %loops "./i" : !transform.any_op
-# CHECK-NEXT:     %tiled_linalg_op_0, %loops_1 = transform.structured.tile_using_for %tiled_linalg_op tile_sizes [0, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:     transform.annotate %loops_1 "./j" : !transform.any_op
-# CHECK-NEXT:     %1 = transform.structured.match attributes {__xtc_id_B_pad_} in %arg0 : (!transform.any_op) -> !transform.any_op
-# CHECK-NEXT:     %tiled_linalg_op_2, %loops_3 = transform.structured.tile_using_for %1 tile_sizes [1, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:     transform.annotate %loops_3 "./i" : !transform.any_op
-# CHECK-NEXT:     %tiled_linalg_op_4, %loops_5 = transform.structured.tile_using_for %tiled_linalg_op_2 tile_sizes [0, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:     transform.annotate %loops_5 "./j" : !transform.any_op
-# CHECK-NEXT:     %2 = transform.structured.match attributes {__xtc_id_matmul_padded_0_} in %arg0 : (!transform.any_op) -> !transform.any_op
-# CHECK-NEXT:     %tiled_linalg_op_6, %loops_7 = transform.structured.tile_using_for %2 tile_sizes [1, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:     transform.annotate %loops_7 "./i" : !transform.any_op
-# CHECK-NEXT:     %tiled_linalg_op_8, %loops_9 = transform.structured.tile_using_for %tiled_linalg_op_6 tile_sizes [0, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:     transform.annotate %loops_9 "./j" : !transform.any_op
-# CHECK-NEXT:     %3 = transform.structured.match attributes {__xtc_id_matmul_padded_} in %arg0 : (!transform.any_op) -> !transform.any_op
-# CHECK-NEXT:     %tiled_linalg_op_10, %loops_11 = transform.structured.tile_using_for %3 tile_sizes [1, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:     transform.annotate %loops_11 "./i" : !transform.any_op
-# CHECK-NEXT:     %tiled_linalg_op_12, %loops_13 = transform.structured.tile_using_for %tiled_linalg_op_10 tile_sizes [0, 1, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:     transform.annotate %loops_13 "./j" : !transform.any_op
-# CHECK-NEXT:     %tiled_linalg_op_14, %loops_15 = transform.structured.tile_using_for %tiled_linalg_op_12 tile_sizes [0, 0, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:     transform.annotate %loops_15 "./k" : !transform.any_op
-# CHECK-NEXT:     transform.yield 
-# CHECK-NEXT:   }
-# CHECK-NEXT: }
+# CHECK:       // -----// IR Dump Before transform //----- //
+# CHECK-NEXT:  #map = affine_map<(d0, d1) -> (d0, d1)>
+# CHECK-NEXT:  module attributes {transform.with_named_sequence} {
+# CHECK-NEXT:    func.func @pad_matmul_unpad(%arg0: tensor<14x14xf32> {llvm.noalias}, %arg1: tensor<14x14xf32> {llvm.noalias}, %arg2: memref<14x14xf32> {llvm.noalias}) {
+# CHECK-NEXT:      %0 = tensor.empty() : tensor<16x16xf32>
+# CHECK-NEXT:      %cst = arith.constant 0.000000e+00 : f32
+# CHECK-NEXT:      %1 = linalg.generic {indexing_maps = [#map], iterator_types = ["parallel", "parallel"]} outs(%0 : tensor<16x16xf32>) attrs =  {__xtc_id_A_pad_} {
+# CHECK-NEXT:      ^bb0(%out: f32):
+# CHECK-NEXT:        %8 = linalg.index 0 : index
+# CHECK-NEXT:        %9 = linalg.index 1 : index
+# CHECK-NEXT:        %c0 = arith.constant 0 : index
+# CHECK-NEXT:        %c0_2 = arith.constant 0 : index
+# CHECK-NEXT:        %10 = arith.subi %8, %c0_2 : index
+# CHECK-NEXT:        %c14 = arith.constant 14 : index
+# CHECK-NEXT:        %11 = arith.cmpi sge, %10, %c0 : index
+# CHECK-NEXT:        %12 = arith.cmpi slt, %10, %c14 : index
+# CHECK-NEXT:        %c0_3 = arith.constant 0 : index
+# CHECK-NEXT:        %13 = arith.subi %9, %c0_3 : index
+# CHECK-NEXT:        %c14_4 = arith.constant 14 : index
+# CHECK-NEXT:        %14 = arith.cmpi sge, %13, %c0 : index
+# CHECK-NEXT:        %15 = arith.cmpi slt, %13, %c14_4 : index
+# CHECK-NEXT:        %16 = arith.andi %11, %12 : i1
+# CHECK-NEXT:        %17 = arith.andi %16, %14 : i1
+# CHECK-NEXT:        %18 = arith.andi %17, %15 : i1
+# CHECK-NEXT:        %19 = scf.if %18 -> (f32) {
+# CHECK-NEXT:          %extracted = tensor.extract %arg0[%10, %13] : tensor<14x14xf32>
+# CHECK-NEXT:          scf.yield %extracted : f32
+# CHECK-NEXT:        } else {
+# CHECK-NEXT:          scf.yield %cst : f32
+# CHECK-NEXT:        }
+# CHECK-NEXT:        linalg.yield %19 : f32
+# CHECK-NEXT:      } -> tensor<16x16xf32>
+# CHECK-NEXT:      %2 = tensor.empty() : tensor<16x16xf32>
+# CHECK-NEXT:      %cst_0 = arith.constant 0.000000e+00 : f32
+# CHECK-NEXT:      %3 = linalg.generic {indexing_maps = [#map], iterator_types = ["parallel", "parallel"]} outs(%2 : tensor<16x16xf32>) attrs =  {__xtc_id_B_pad_} {
+# CHECK-NEXT:      ^bb0(%out: f32):
+# CHECK-NEXT:        %8 = linalg.index 0 : index
+# CHECK-NEXT:        %9 = linalg.index 1 : index
+# CHECK-NEXT:        %c0 = arith.constant 0 : index
+# CHECK-NEXT:        %c0_2 = arith.constant 0 : index
+# CHECK-NEXT:        %10 = arith.subi %8, %c0_2 : index
+# CHECK-NEXT:        %c14 = arith.constant 14 : index
+# CHECK-NEXT:        %11 = arith.cmpi sge, %10, %c0 : index
+# CHECK-NEXT:        %12 = arith.cmpi slt, %10, %c14 : index
+# CHECK-NEXT:        %c0_3 = arith.constant 0 : index
+# CHECK-NEXT:        %13 = arith.subi %9, %c0_3 : index
+# CHECK-NEXT:        %c14_4 = arith.constant 14 : index
+# CHECK-NEXT:        %14 = arith.cmpi sge, %13, %c0 : index
+# CHECK-NEXT:        %15 = arith.cmpi slt, %13, %c14_4 : index
+# CHECK-NEXT:        %16 = arith.andi %11, %12 : i1
+# CHECK-NEXT:        %17 = arith.andi %16, %14 : i1
+# CHECK-NEXT:        %18 = arith.andi %17, %15 : i1
+# CHECK-NEXT:        %19 = scf.if %18 -> (f32) {
+# CHECK-NEXT:          %extracted = tensor.extract %arg1[%10, %13] : tensor<14x14xf32>
+# CHECK-NEXT:          scf.yield %extracted : f32
+# CHECK-NEXT:        } else {
+# CHECK-NEXT:          scf.yield %cst_0 : f32
+# CHECK-NEXT:        }
+# CHECK-NEXT:        linalg.yield %19 : f32
+# CHECK-NEXT:      } -> tensor<16x16xf32>
+# CHECK-NEXT:      %4 = tensor.empty() : tensor<16x16xf32>
+# CHECK-NEXT:      %cst_1 = arith.constant 0.000000e+00 : f32
+# CHECK-NEXT:      %5 = linalg.fill {__xtc_id_matmul_padded_0_} ins(%cst_1 : f32) outs(%4 : tensor<16x16xf32>) -> tensor<16x16xf32>
+# CHECK-NEXT:      %6 = linalg.matmul {__xtc_id_matmul_padded_} ins(%1, %3 : tensor<16x16xf32>, tensor<16x16xf32>) outs(%5 : tensor<16x16xf32>) -> tensor<16x16xf32>
+# CHECK-NEXT:      %7 = tensor.empty() : tensor<14x14xf32>
+# CHECK-NEXT:      %extracted_slice = tensor.extract_slice %6[0, 0] [14, 14] [1, 1] {__xtc_id_C_} : tensor<16x16xf32> to tensor<14x14xf32>
+# CHECK-NEXT:      bufferization.materialize_in_destination %extracted_slice in restrict writable %arg2 : (tensor<14x14xf32>, memref<14x14xf32>) -> ()
+# CHECK-NEXT:      return
+# CHECK-NEXT:    }
+# CHECK-NEXT:    transform.named_sequence @_vecto(%arg0: !transform.any_op {transform.consumed}) {
+# CHECK-NEXT:      transform.structured.vectorize %arg0 : !transform.any_op
+# CHECK-NEXT:      transform.yield 
+# CHECK-NEXT:    }
+# CHECK-NEXT:    transform.named_sequence @_post_bufferize(%arg0: !transform.any_op {transform.readonly}) {
+# CHECK-NEXT:      transform.yield 
+# CHECK-NEXT:    }
+# CHECK-NEXT:    transform.named_sequence @__transform_main(%arg0: !transform.any_op {transform.readonly}) {
+# CHECK-NEXT:      %0 = transform.structured.match attributes {__xtc_id_A_pad_} in %arg0 : (!transform.any_op) -> !transform.any_op
+# CHECK-NEXT:      %tiled_linalg_op, %loops = transform.structured.tile_using_for %0 tile_sizes [1, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      transform.annotate %loops "./i" : !transform.any_op
+# CHECK-NEXT:      %tiled_linalg_op_0, %loops_1 = transform.structured.tile_using_for %tiled_linalg_op tile_sizes [0, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      transform.annotate %loops_1 "./j" : !transform.any_op
+# CHECK-NEXT:      %1 = transform.structured.match attributes {__xtc_id_B_pad_} in %arg0 : (!transform.any_op) -> !transform.any_op
+# CHECK-NEXT:      %tiled_linalg_op_2, %loops_3 = transform.structured.tile_using_for %1 tile_sizes [1, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      transform.annotate %loops_3 "./i" : !transform.any_op
+# CHECK-NEXT:      %tiled_linalg_op_4, %loops_5 = transform.structured.tile_using_for %tiled_linalg_op_2 tile_sizes [0, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      transform.annotate %loops_5 "./j" : !transform.any_op
+# CHECK-NEXT:      %2 = transform.structured.match attributes {__xtc_id_matmul_padded_} in %arg0 : (!transform.any_op) -> !transform.any_op
+# CHECK-NEXT:      %tiled_linalg_op_6, %loops_7 = transform.structured.tile_using_for %2 tile_sizes [1, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      transform.annotate %loops_7 "./i" : !transform.any_op
+# CHECK-NEXT:      %tiled_linalg_op_8, %loops_9 = transform.structured.tile_using_for %tiled_linalg_op_6 tile_sizes [0, 1, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      transform.annotate %loops_9 "./j" : !transform.any_op
+# CHECK-NEXT:      %tiled_linalg_op_10, %loops_11 = transform.structured.tile_using_for %tiled_linalg_op_8 tile_sizes [0, 0, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      transform.annotate %loops_11 "./k" : !transform.any_op
+# CHECK-NEXT:      transform.yield 
+# CHECK-NEXT:    }
+# CHECK-NEXT:  }
 # CHECK-NEXT:  
-# CHECK-NEXT: // -----// IR Dump After transform //----- //
-# CHECK-NEXT: #map = affine_map<(d0, d1) -> (d0, d1)>
-# CHECK-NEXT: #map1 = affine_map<(d0)[s0] -> (d0 + s0)>
-# CHECK-NEXT: module attributes {transform.with_named_sequence} {
-# CHECK-NEXT:   func.func @pad_matmul_unpad(%arg0: tensor<14x14xf32> {llvm.noalias}, %arg1: tensor<14x14xf32> {llvm.noalias}, %arg2: memref<14x14xf32> {llvm.noalias}) {
-# CHECK-NEXT:     %0 = tensor.empty() : tensor<16x16xf32>
-# CHECK-NEXT:     %cst = arith.constant 0.000000e+00 : f32
-# CHECK-NEXT:     %c0 = arith.constant 0 : index
-# CHECK-NEXT:     %c16 = arith.constant 16 : index
-# CHECK-NEXT:     %c1 = arith.constant 1 : index
-# CHECK-NEXT:     %1 = scf.for %arg3 = %c0 to %c16 step %c1 iter_args(%arg4 = %0) -> (tensor<16x16xf32>) {
-# CHECK-NEXT:       %extracted_slice_11 = tensor.extract_slice %arg4[%arg3, 0] [1, 16] [1, 1] : tensor<16x16xf32> to tensor<1x16xf32>
-# CHECK-NEXT:       %c0_12 = arith.constant 0 : index
-# CHECK-NEXT:       %c16_13 = arith.constant 16 : index
-# CHECK-NEXT:       %c1_14 = arith.constant 1 : index
-# CHECK-NEXT:       %8 = scf.for %arg5 = %c0_12 to %c16_13 step %c1_14 iter_args(%arg6 = %extracted_slice_11) -> (tensor<1x16xf32>) {
-# CHECK-NEXT:         %extracted_slice_15 = tensor.extract_slice %arg6[0, %arg5] [1, 1] [1, 1] : tensor<1x16xf32> to tensor<1x1xf32>
-# CHECK-NEXT:         %9 = linalg.generic {indexing_maps = [#map], iterator_types = ["parallel", "parallel"]} outs(%extracted_slice_15 : tensor<1x1xf32>) attrs =  {__xtc_id_A_pad_} {
-# CHECK-NEXT:         ^bb0(%out: f32):
-# CHECK-NEXT:           %10 = linalg.index 0 : index
-# CHECK-NEXT:           %11 = affine.apply #map1(%arg3)[%10]
-# CHECK-NEXT:           %12 = linalg.index 1 : index
-# CHECK-NEXT:           %13 = affine.apply #map1(%arg5)[%12]
-# CHECK-NEXT:           %c0_17 = arith.constant 0 : index
-# CHECK-NEXT:           %c0_18 = arith.constant 0 : index
-# CHECK-NEXT:           %14 = arith.subi %11, %c0_18 : index
-# CHECK-NEXT:           %c14 = arith.constant 14 : index
-# CHECK-NEXT:           %15 = arith.cmpi sge, %14, %c0_17 : index
-# CHECK-NEXT:           %16 = arith.cmpi slt, %14, %c14 : index
-# CHECK-NEXT:           %c0_19 = arith.constant 0 : index
-# CHECK-NEXT:           %17 = arith.subi %13, %c0_19 : index
-# CHECK-NEXT:           %c14_20 = arith.constant 14 : index
-# CHECK-NEXT:           %18 = arith.cmpi sge, %17, %c0_17 : index
-# CHECK-NEXT:           %19 = arith.cmpi slt, %17, %c14_20 : index
-# CHECK-NEXT:           %20 = arith.andi %15, %16 : i1
-# CHECK-NEXT:           %21 = arith.andi %20, %18 : i1
-# CHECK-NEXT:           %22 = arith.andi %21, %19 : i1
-# CHECK-NEXT:           %23 = scf.if %22 -> (f32) {
-# CHECK-NEXT:             %extracted = tensor.extract %arg0[%14, %17] : tensor<14x14xf32>
-# CHECK-NEXT:             scf.yield %extracted : f32
-# CHECK-NEXT:           } else {
-# CHECK-NEXT:             scf.yield %cst : f32
-# CHECK-NEXT:           }
-# CHECK-NEXT:           linalg.yield %23 : f32
-# CHECK-NEXT:         } -> tensor<1x1xf32>
-# CHECK-NEXT:         %inserted_slice_16 = tensor.insert_slice %9 into %arg6[0, %arg5] [1, 1] [1, 1] : tensor<1x1xf32> into tensor<1x16xf32>
-# CHECK-NEXT:         scf.yield %inserted_slice_16 : tensor<1x16xf32>
-# CHECK-NEXT:       } {"./j"}
-# CHECK-NEXT:       %inserted_slice = tensor.insert_slice %8 into %arg4[%arg3, 0] [1, 16] [1, 1] : tensor<1x16xf32> into tensor<16x16xf32>
-# CHECK-NEXT:       scf.yield %inserted_slice : tensor<16x16xf32>
-# CHECK-NEXT:     } {"./i"}
-# CHECK-NEXT:     %2 = tensor.empty() : tensor<16x16xf32>
-# CHECK-NEXT:     %cst_0 = arith.constant 0.000000e+00 : f32
-# CHECK-NEXT:     %c0_1 = arith.constant 0 : index
-# CHECK-NEXT:     %c16_2 = arith.constant 16 : index
-# CHECK-NEXT:     %c1_3 = arith.constant 1 : index
-# CHECK-NEXT:     %3 = scf.for %arg3 = %c0_1 to %c16_2 step %c1_3 iter_args(%arg4 = %2) -> (tensor<16x16xf32>) {
-# CHECK-NEXT:       %extracted_slice_11 = tensor.extract_slice %arg4[%arg3, 0] [1, 16] [1, 1] : tensor<16x16xf32> to tensor<1x16xf32>
-# CHECK-NEXT:       %c0_12 = arith.constant 0 : index
-# CHECK-NEXT:       %c16_13 = arith.constant 16 : index
-# CHECK-NEXT:       %c1_14 = arith.constant 1 : index
-# CHECK-NEXT:       %8 = scf.for %arg5 = %c0_12 to %c16_13 step %c1_14 iter_args(%arg6 = %extracted_slice_11) -> (tensor<1x16xf32>) {
-# CHECK-NEXT:         %extracted_slice_15 = tensor.extract_slice %arg6[0, %arg5] [1, 1] [1, 1] : tensor<1x16xf32> to tensor<1x1xf32>
-# CHECK-NEXT:         %9 = linalg.generic {indexing_maps = [#map], iterator_types = ["parallel", "parallel"]} outs(%extracted_slice_15 : tensor<1x1xf32>) attrs =  {__xtc_id_B_pad_} {
-# CHECK-NEXT:         ^bb0(%out: f32):
-# CHECK-NEXT:           %10 = linalg.index 0 : index
-# CHECK-NEXT:           %11 = affine.apply #map1(%arg3)[%10]
-# CHECK-NEXT:           %12 = linalg.index 1 : index
-# CHECK-NEXT:           %13 = affine.apply #map1(%arg5)[%12]
-# CHECK-NEXT:           %c0_17 = arith.constant 0 : index
-# CHECK-NEXT:           %c0_18 = arith.constant 0 : index
-# CHECK-NEXT:           %14 = arith.subi %11, %c0_18 : index
-# CHECK-NEXT:           %c14 = arith.constant 14 : index
-# CHECK-NEXT:           %15 = arith.cmpi sge, %14, %c0_17 : index
-# CHECK-NEXT:           %16 = arith.cmpi slt, %14, %c14 : index
-# CHECK-NEXT:           %c0_19 = arith.constant 0 : index
-# CHECK-NEXT:           %17 = arith.subi %13, %c0_19 : index
-# CHECK-NEXT:           %c14_20 = arith.constant 14 : index
-# CHECK-NEXT:           %18 = arith.cmpi sge, %17, %c0_17 : index
-# CHECK-NEXT:           %19 = arith.cmpi slt, %17, %c14_20 : index
-# CHECK-NEXT:           %20 = arith.andi %15, %16 : i1
-# CHECK-NEXT:           %21 = arith.andi %20, %18 : i1
-# CHECK-NEXT:           %22 = arith.andi %21, %19 : i1
-# CHECK-NEXT:           %23 = scf.if %22 -> (f32) {
-# CHECK-NEXT:             %extracted = tensor.extract %arg1[%14, %17] : tensor<14x14xf32>
-# CHECK-NEXT:             scf.yield %extracted : f32
-# CHECK-NEXT:           } else {
-# CHECK-NEXT:             scf.yield %cst_0 : f32
-# CHECK-NEXT:           }
-# CHECK-NEXT:           linalg.yield %23 : f32
-# CHECK-NEXT:         } -> tensor<1x1xf32>
-# CHECK-NEXT:         %inserted_slice_16 = tensor.insert_slice %9 into %arg6[0, %arg5] [1, 1] [1, 1] : tensor<1x1xf32> into tensor<1x16xf32>
-# CHECK-NEXT:         scf.yield %inserted_slice_16 : tensor<1x16xf32>
-# CHECK-NEXT:       } {"./j"}
-# CHECK-NEXT:       %inserted_slice = tensor.insert_slice %8 into %arg4[%arg3, 0] [1, 16] [1, 1] : tensor<1x16xf32> into tensor<16x16xf32>
-# CHECK-NEXT:       scf.yield %inserted_slice : tensor<16x16xf32>
-# CHECK-NEXT:     } {"./i"}
-# CHECK-NEXT:     %4 = tensor.empty() : tensor<16x16xf32>
-# CHECK-NEXT:     %cst_4 = arith.constant 0.000000e+00 : f32
-# CHECK-NEXT:     %c0_5 = arith.constant 0 : index
-# CHECK-NEXT:     %c16_6 = arith.constant 16 : index
-# CHECK-NEXT:     %c1_7 = arith.constant 1 : index
-# CHECK-NEXT:     %5 = scf.for %arg3 = %c0_5 to %c16_6 step %c1_7 iter_args(%arg4 = %4) -> (tensor<16x16xf32>) {
-# CHECK-NEXT:       %extracted_slice_11 = tensor.extract_slice %arg4[%arg3, 0] [1, 16] [1, 1] : tensor<16x16xf32> to tensor<1x16xf32>
-# CHECK-NEXT:       %c0_12 = arith.constant 0 : index
-# CHECK-NEXT:       %c16_13 = arith.constant 16 : index
-# CHECK-NEXT:       %c1_14 = arith.constant 1 : index
-# CHECK-NEXT:       %8 = scf.for %arg5 = %c0_12 to %c16_13 step %c1_14 iter_args(%arg6 = %extracted_slice_11) -> (tensor<1x16xf32>) {
-# CHECK-NEXT:         %extracted_slice_15 = tensor.extract_slice %arg6[0, %arg5] [1, 1] [1, 1] : tensor<1x16xf32> to tensor<1x1xf32>
-# CHECK-NEXT:         %9 = linalg.fill {__xtc_id_matmul_padded_0_} ins(%cst_4 : f32) outs(%extracted_slice_15 : tensor<1x1xf32>) -> tensor<1x1xf32>
-# CHECK-NEXT:         %inserted_slice_16 = tensor.insert_slice %9 into %arg6[0, %arg5] [1, 1] [1, 1] : tensor<1x1xf32> into tensor<1x16xf32>
-# CHECK-NEXT:         scf.yield %inserted_slice_16 : tensor<1x16xf32>
-# CHECK-NEXT:       } {"./j"}
-# CHECK-NEXT:       %inserted_slice = tensor.insert_slice %8 into %arg4[%arg3, 0] [1, 16] [1, 1] : tensor<1x16xf32> into tensor<16x16xf32>
-# CHECK-NEXT:       scf.yield %inserted_slice : tensor<16x16xf32>
-# CHECK-NEXT:     } {"./i"}
-# CHECK-NEXT:     %c0_8 = arith.constant 0 : index
-# CHECK-NEXT:     %c16_9 = arith.constant 16 : index
-# CHECK-NEXT:     %c1_10 = arith.constant 1 : index
-# CHECK-NEXT:     %6 = scf.for %arg3 = %c0_8 to %c16_9 step %c1_10 iter_args(%arg4 = %5) -> (tensor<16x16xf32>) {
-# CHECK-NEXT:       %extracted_slice_11 = tensor.extract_slice %1[%arg3, 0] [1, 16] [1, 1] : tensor<16x16xf32> to tensor<1x16xf32>
-# CHECK-NEXT:       %extracted_slice_12 = tensor.extract_slice %3[0, 0] [16, 16] [1, 1] : tensor<16x16xf32> to tensor<16x16xf32>
-# CHECK-NEXT:       %extracted_slice_13 = tensor.extract_slice %arg4[%arg3, 0] [1, 16] [1, 1] : tensor<16x16xf32> to tensor<1x16xf32>
-# CHECK-NEXT:       %c0_14 = arith.constant 0 : index
-# CHECK-NEXT:       %c16_15 = arith.constant 16 : index
-# CHECK-NEXT:       %c1_16 = arith.constant 1 : index
-# CHECK-NEXT:       %8 = scf.for %arg5 = %c0_14 to %c16_15 step %c1_16 iter_args(%arg6 = %extracted_slice_13) -> (tensor<1x16xf32>) {
-# CHECK-NEXT:         %extracted_slice_17 = tensor.extract_slice %extracted_slice_11[0, 0] [1, 16] [1, 1] : tensor<1x16xf32> to tensor<1x16xf32>
-# CHECK-NEXT:         %extracted_slice_18 = tensor.extract_slice %extracted_slice_12[0, %arg5] [16, 1] [1, 1] : tensor<16x16xf32> to tensor<16x1xf32>
-# CHECK-NEXT:         %extracted_slice_19 = tensor.extract_slice %arg6[0, %arg5] [1, 1] [1, 1] : tensor<1x16xf32> to tensor<1x1xf32>
-# CHECK-NEXT:         %c0_20 = arith.constant 0 : index
-# CHECK-NEXT:         %c16_21 = arith.constant 16 : index
-# CHECK-NEXT:         %c1_22 = arith.constant 1 : index
-# CHECK-NEXT:         %9 = scf.for %arg7 = %c0_20 to %c16_21 step %c1_22 iter_args(%arg8 = %extracted_slice_19) -> (tensor<1x1xf32>) {
-# CHECK-NEXT:           %extracted_slice_24 = tensor.extract_slice %extracted_slice_17[0, %arg7] [1, 1] [1, 1] : tensor<1x16xf32> to tensor<1x1xf32>
-# CHECK-NEXT:           %extracted_slice_25 = tensor.extract_slice %extracted_slice_18[%arg7, 0] [1, 1] [1, 1] : tensor<16x1xf32> to tensor<1x1xf32>
-# CHECK-NEXT:           %extracted_slice_26 = tensor.extract_slice %arg8[0, 0] [1, 1] [1, 1] : tensor<1x1xf32> to tensor<1x1xf32>
-# CHECK-NEXT:           %10 = linalg.matmul {__xtc_id_matmul_padded_} ins(%extracted_slice_24, %extracted_slice_25 : tensor<1x1xf32>, tensor<1x1xf32>) outs(%extracted_slice_26 : tensor<1x1xf32>) -> tensor<1x1xf32>
-# CHECK-NEXT:           %inserted_slice_27 = tensor.insert_slice %10 into %arg8[0, 0] [1, 1] [1, 1] : tensor<1x1xf32> into tensor<1x1xf32>
-# CHECK-NEXT:           scf.yield %inserted_slice_27 : tensor<1x1xf32>
-# CHECK-NEXT:         } {"./k"}
-# CHECK-NEXT:         %inserted_slice_23 = tensor.insert_slice %9 into %arg6[0, %arg5] [1, 1] [1, 1] : tensor<1x1xf32> into tensor<1x16xf32>
-# CHECK-NEXT:         scf.yield %inserted_slice_23 : tensor<1x16xf32>
-# CHECK-NEXT:       } {"./j"}
-# CHECK-NEXT:       %inserted_slice = tensor.insert_slice %8 into %arg4[%arg3, 0] [1, 16] [1, 1] : tensor<1x16xf32> into tensor<16x16xf32>
-# CHECK-NEXT:       scf.yield %inserted_slice : tensor<16x16xf32>
-# CHECK-NEXT:     } {"./i"}
-# CHECK-NEXT:     %7 = tensor.empty() : tensor<14x14xf32>
-# CHECK-NEXT:     %extracted_slice = tensor.extract_slice %6[0, 0] [14, 14] [1, 1] {__xtc_id_C_} : tensor<16x16xf32> to tensor<14x14xf32>
-# CHECK-NEXT:     bufferization.materialize_in_destination %extracted_slice in restrict writable %arg2 : (tensor<14x14xf32>, memref<14x14xf32>) -> ()
-# CHECK-NEXT:     return
-# CHECK-NEXT:   }
-# CHECK-NEXT:   transform.named_sequence @_vecto(%arg0: !transform.any_op {transform.consumed}) {
-# CHECK-NEXT:     transform.structured.vectorize %arg0 : !transform.any_op
-# CHECK-NEXT:     transform.yield 
-# CHECK-NEXT:   }
-# CHECK-NEXT:   transform.named_sequence @_post_bufferize(%arg0: !transform.any_op {transform.readonly}) {
-# CHECK-NEXT:     transform.yield 
-# CHECK-NEXT:   }
-# CHECK-NEXT: }
+# CHECK-NEXT:  // -----// IR Dump After transform //----- //
+# CHECK-NEXT:  #map = affine_map<(d0, d1) -> (d0, d1)>
+# CHECK-NEXT:  #map1 = affine_map<(d0)[s0] -> (d0 + s0)>
+# CHECK-NEXT:  module attributes {transform.with_named_sequence} {
+# CHECK-NEXT:    func.func @pad_matmul_unpad(%arg0: tensor<14x14xf32> {llvm.noalias}, %arg1: tensor<14x14xf32> {llvm.noalias}, %arg2: memref<14x14xf32> {llvm.noalias}) {
+# CHECK-NEXT:      %0 = tensor.empty() : tensor<16x16xf32>
+# CHECK-NEXT:      %cst = arith.constant 0.000000e+00 : f32
+# CHECK-NEXT:      %c0 = arith.constant 0 : index
+# CHECK-NEXT:      %c16 = arith.constant 16 : index
+# CHECK-NEXT:      %c1 = arith.constant 1 : index
+# CHECK-NEXT:      %1 = scf.for %arg3 = %c0 to %c16 step %c1 iter_args(%arg4 = %0) -> (tensor<16x16xf32>) {
+# CHECK-NEXT:        %extracted_slice_8 = tensor.extract_slice %arg4[%arg3, 0] [1, 16] [1, 1] : tensor<16x16xf32> to tensor<1x16xf32>
+# CHECK-NEXT:        %c0_9 = arith.constant 0 : index
+# CHECK-NEXT:        %c16_10 = arith.constant 16 : index
+# CHECK-NEXT:        %c1_11 = arith.constant 1 : index
+# CHECK-NEXT:        %8 = scf.for %arg5 = %c0_9 to %c16_10 step %c1_11 iter_args(%arg6 = %extracted_slice_8) -> (tensor<1x16xf32>) {
+# CHECK-NEXT:          %extracted_slice_12 = tensor.extract_slice %arg6[0, %arg5] [1, 1] [1, 1] : tensor<1x16xf32> to tensor<1x1xf32>
+# CHECK-NEXT:          %9 = linalg.generic {indexing_maps = [#map], iterator_types = ["parallel", "parallel"]} outs(%extracted_slice_12 : tensor<1x1xf32>) attrs =  {__xtc_id_A_pad_} {
+# CHECK-NEXT:          ^bb0(%out: f32):
+# CHECK-NEXT:            %10 = linalg.index 0 : index
+# CHECK-NEXT:            %11 = affine.apply #map1(%arg3)[%10]
+# CHECK-NEXT:            %12 = linalg.index 1 : index
+# CHECK-NEXT:            %13 = affine.apply #map1(%arg5)[%12]
+# CHECK-NEXT:            %c0_14 = arith.constant 0 : index
+# CHECK-NEXT:            %c0_15 = arith.constant 0 : index
+# CHECK-NEXT:            %14 = arith.subi %11, %c0_15 : index
+# CHECK-NEXT:            %c14 = arith.constant 14 : index
+# CHECK-NEXT:            %15 = arith.cmpi sge, %14, %c0_14 : index
+# CHECK-NEXT:            %16 = arith.cmpi slt, %14, %c14 : index
+# CHECK-NEXT:            %c0_16 = arith.constant 0 : index
+# CHECK-NEXT:            %17 = arith.subi %13, %c0_16 : index
+# CHECK-NEXT:            %c14_17 = arith.constant 14 : index
+# CHECK-NEXT:            %18 = arith.cmpi sge, %17, %c0_14 : index
+# CHECK-NEXT:            %19 = arith.cmpi slt, %17, %c14_17 : index
+# CHECK-NEXT:            %20 = arith.andi %15, %16 : i1
+# CHECK-NEXT:            %21 = arith.andi %20, %18 : i1
+# CHECK-NEXT:            %22 = arith.andi %21, %19 : i1
+# CHECK-NEXT:            %23 = scf.if %22 -> (f32) {
+# CHECK-NEXT:              %extracted = tensor.extract %arg0[%14, %17] : tensor<14x14xf32>
+# CHECK-NEXT:              scf.yield %extracted : f32
+# CHECK-NEXT:            } else {
+# CHECK-NEXT:              scf.yield %cst : f32
+# CHECK-NEXT:            }
+# CHECK-NEXT:            linalg.yield %23 : f32
+# CHECK-NEXT:          } -> tensor<1x1xf32>
+# CHECK-NEXT:          %inserted_slice_13 = tensor.insert_slice %9 into %arg6[0, %arg5] [1, 1] [1, 1] : tensor<1x1xf32> into tensor<1x16xf32>
+# CHECK-NEXT:          scf.yield %inserted_slice_13 : tensor<1x16xf32>
+# CHECK-NEXT:        } {"./j"}
+# CHECK-NEXT:        %inserted_slice = tensor.insert_slice %8 into %arg4[%arg3, 0] [1, 16] [1, 1] : tensor<1x16xf32> into tensor<16x16xf32>
+# CHECK-NEXT:        scf.yield %inserted_slice : tensor<16x16xf32>
+# CHECK-NEXT:      } {"./i"}
+# CHECK-NEXT:      %2 = tensor.empty() : tensor<16x16xf32>
+# CHECK-NEXT:      %cst_0 = arith.constant 0.000000e+00 : f32
+# CHECK-NEXT:      %c0_1 = arith.constant 0 : index
+# CHECK-NEXT:      %c16_2 = arith.constant 16 : index
+# CHECK-NEXT:      %c1_3 = arith.constant 1 : index
+# CHECK-NEXT:      %3 = scf.for %arg3 = %c0_1 to %c16_2 step %c1_3 iter_args(%arg4 = %2) -> (tensor<16x16xf32>) {
+# CHECK-NEXT:        %extracted_slice_8 = tensor.extract_slice %arg4[%arg3, 0] [1, 16] [1, 1] : tensor<16x16xf32> to tensor<1x16xf32>
+# CHECK-NEXT:        %c0_9 = arith.constant 0 : index
+# CHECK-NEXT:        %c16_10 = arith.constant 16 : index
+# CHECK-NEXT:        %c1_11 = arith.constant 1 : index
+# CHECK-NEXT:        %8 = scf.for %arg5 = %c0_9 to %c16_10 step %c1_11 iter_args(%arg6 = %extracted_slice_8) -> (tensor<1x16xf32>) {
+# CHECK-NEXT:          %extracted_slice_12 = tensor.extract_slice %arg6[0, %arg5] [1, 1] [1, 1] : tensor<1x16xf32> to tensor<1x1xf32>
+# CHECK-NEXT:          %9 = linalg.generic {indexing_maps = [#map], iterator_types = ["parallel", "parallel"]} outs(%extracted_slice_12 : tensor<1x1xf32>) attrs =  {__xtc_id_B_pad_} {
+# CHECK-NEXT:          ^bb0(%out: f32):
+# CHECK-NEXT:            %10 = linalg.index 0 : index
+# CHECK-NEXT:            %11 = affine.apply #map1(%arg3)[%10]
+# CHECK-NEXT:            %12 = linalg.index 1 : index
+# CHECK-NEXT:            %13 = affine.apply #map1(%arg5)[%12]
+# CHECK-NEXT:            %c0_14 = arith.constant 0 : index
+# CHECK-NEXT:            %c0_15 = arith.constant 0 : index
+# CHECK-NEXT:            %14 = arith.subi %11, %c0_15 : index
+# CHECK-NEXT:            %c14 = arith.constant 14 : index
+# CHECK-NEXT:            %15 = arith.cmpi sge, %14, %c0_14 : index
+# CHECK-NEXT:            %16 = arith.cmpi slt, %14, %c14 : index
+# CHECK-NEXT:            %c0_16 = arith.constant 0 : index
+# CHECK-NEXT:            %17 = arith.subi %13, %c0_16 : index
+# CHECK-NEXT:            %c14_17 = arith.constant 14 : index
+# CHECK-NEXT:            %18 = arith.cmpi sge, %17, %c0_14 : index
+# CHECK-NEXT:            %19 = arith.cmpi slt, %17, %c14_17 : index
+# CHECK-NEXT:            %20 = arith.andi %15, %16 : i1
+# CHECK-NEXT:            %21 = arith.andi %20, %18 : i1
+# CHECK-NEXT:            %22 = arith.andi %21, %19 : i1
+# CHECK-NEXT:            %23 = scf.if %22 -> (f32) {
+# CHECK-NEXT:              %extracted = tensor.extract %arg1[%14, %17] : tensor<14x14xf32>
+# CHECK-NEXT:              scf.yield %extracted : f32
+# CHECK-NEXT:            } else {
+# CHECK-NEXT:              scf.yield %cst_0 : f32
+# CHECK-NEXT:            }
+# CHECK-NEXT:            linalg.yield %23 : f32
+# CHECK-NEXT:          } -> tensor<1x1xf32>
+# CHECK-NEXT:          %inserted_slice_13 = tensor.insert_slice %9 into %arg6[0, %arg5] [1, 1] [1, 1] : tensor<1x1xf32> into tensor<1x16xf32>
+# CHECK-NEXT:          scf.yield %inserted_slice_13 : tensor<1x16xf32>
+# CHECK-NEXT:        } {"./j"}
+# CHECK-NEXT:        %inserted_slice = tensor.insert_slice %8 into %arg4[%arg3, 0] [1, 16] [1, 1] : tensor<1x16xf32> into tensor<16x16xf32>
+# CHECK-NEXT:        scf.yield %inserted_slice : tensor<16x16xf32>
+# CHECK-NEXT:      } {"./i"}
+# CHECK-NEXT:      %4 = tensor.empty() : tensor<16x16xf32>
+# CHECK-NEXT:      %cst_4 = arith.constant 0.000000e+00 : f32
+# CHECK-NEXT:      %5 = linalg.fill {__xtc_id_matmul_padded_0_} ins(%cst_4 : f32) outs(%4 : tensor<16x16xf32>) -> tensor<16x16xf32>
+# CHECK-NEXT:      %c0_5 = arith.constant 0 : index
+# CHECK-NEXT:      %c16_6 = arith.constant 16 : index
+# CHECK-NEXT:      %c1_7 = arith.constant 1 : index
+# CHECK-NEXT:      %6 = scf.for %arg3 = %c0_5 to %c16_6 step %c1_7 iter_args(%arg4 = %5) -> (tensor<16x16xf32>) {
+# CHECK-NEXT:        %extracted_slice_8 = tensor.extract_slice %1[%arg3, 0] [1, 16] [1, 1] : tensor<16x16xf32> to tensor<1x16xf32>
+# CHECK-NEXT:        %extracted_slice_9 = tensor.extract_slice %3[0, 0] [16, 16] [1, 1] : tensor<16x16xf32> to tensor<16x16xf32>
+# CHECK-NEXT:        %extracted_slice_10 = tensor.extract_slice %arg4[%arg3, 0] [1, 16] [1, 1] : tensor<16x16xf32> to tensor<1x16xf32>
+# CHECK-NEXT:        %c0_11 = arith.constant 0 : index
+# CHECK-NEXT:        %c16_12 = arith.constant 16 : index
+# CHECK-NEXT:        %c1_13 = arith.constant 1 : index
+# CHECK-NEXT:        %8 = scf.for %arg5 = %c0_11 to %c16_12 step %c1_13 iter_args(%arg6 = %extracted_slice_10) -> (tensor<1x16xf32>) {
+# CHECK-NEXT:          %extracted_slice_14 = tensor.extract_slice %extracted_slice_8[0, 0] [1, 16] [1, 1] : tensor<1x16xf32> to tensor<1x16xf32>
+# CHECK-NEXT:          %extracted_slice_15 = tensor.extract_slice %extracted_slice_9[0, %arg5] [16, 1] [1, 1] : tensor<16x16xf32> to tensor<16x1xf32>
+# CHECK-NEXT:          %extracted_slice_16 = tensor.extract_slice %arg6[0, %arg5] [1, 1] [1, 1] : tensor<1x16xf32> to tensor<1x1xf32>
+# CHECK-NEXT:          %c0_17 = arith.constant 0 : index
+# CHECK-NEXT:          %c16_18 = arith.constant 16 : index
+# CHECK-NEXT:          %c1_19 = arith.constant 1 : index
+# CHECK-NEXT:          %9 = scf.for %arg7 = %c0_17 to %c16_18 step %c1_19 iter_args(%arg8 = %extracted_slice_16) -> (tensor<1x1xf32>) {
+# CHECK-NEXT:            %extracted_slice_21 = tensor.extract_slice %extracted_slice_14[0, %arg7] [1, 1] [1, 1] : tensor<1x16xf32> to tensor<1x1xf32>
+# CHECK-NEXT:            %extracted_slice_22 = tensor.extract_slice %extracted_slice_15[%arg7, 0] [1, 1] [1, 1] : tensor<16x1xf32> to tensor<1x1xf32>
+# CHECK-NEXT:            %extracted_slice_23 = tensor.extract_slice %arg8[0, 0] [1, 1] [1, 1] : tensor<1x1xf32> to tensor<1x1xf32>
+# CHECK-NEXT:            %10 = linalg.matmul {__xtc_id_matmul_padded_} ins(%extracted_slice_21, %extracted_slice_22 : tensor<1x1xf32>, tensor<1x1xf32>) outs(%extracted_slice_23 : tensor<1x1xf32>) -> tensor<1x1xf32>
+# CHECK-NEXT:            %inserted_slice_24 = tensor.insert_slice %10 into %arg8[0, 0] [1, 1] [1, 1] : tensor<1x1xf32> into tensor<1x1xf32>
+# CHECK-NEXT:            scf.yield %inserted_slice_24 : tensor<1x1xf32>
+# CHECK-NEXT:          } {"./k"}
+# CHECK-NEXT:          %inserted_slice_20 = tensor.insert_slice %9 into %arg6[0, %arg5] [1, 1] [1, 1] : tensor<1x1xf32> into tensor<1x16xf32>
+# CHECK-NEXT:          scf.yield %inserted_slice_20 : tensor<1x16xf32>
+# CHECK-NEXT:        } {"./j"}
+# CHECK-NEXT:        %inserted_slice = tensor.insert_slice %8 into %arg4[%arg3, 0] [1, 16] [1, 1] : tensor<1x16xf32> into tensor<16x16xf32>
+# CHECK-NEXT:        scf.yield %inserted_slice : tensor<16x16xf32>
+# CHECK-NEXT:      } {"./i"}
+# CHECK-NEXT:      %7 = tensor.empty() : tensor<14x14xf32>
+# CHECK-NEXT:      %extracted_slice = tensor.extract_slice %6[0, 0] [14, 14] [1, 1] {__xtc_id_C_} : tensor<16x16xf32> to tensor<14x14xf32>
+# CHECK-NEXT:      bufferization.materialize_in_destination %extracted_slice in restrict writable %arg2 : (tensor<14x14xf32>, memref<14x14xf32>) -> ()
+# CHECK-NEXT:      return
+# CHECK-NEXT:    }
+# CHECK-NEXT:    transform.named_sequence @_vecto(%arg0: !transform.any_op {transform.consumed}) {
+# CHECK-NEXT:      transform.structured.vectorize %arg0 : !transform.any_op
+# CHECK-NEXT:      transform.yield 
+# CHECK-NEXT:    }
+# CHECK-NEXT:    transform.named_sequence @_post_bufferize(%arg0: !transform.any_op {transform.readonly}) {
+# CHECK-NEXT:      transform.yield 
+# CHECK-NEXT:    }
+# CHECK-NEXT:  }
 # CHECK-NEXT:  
-# CHECK-NEXT: // -----// IR Dump After Tensor Lowering //----- //
-# CHECK-NEXT: #map = affine_map<(d0, d1) -> (d0, d1)>
-# CHECK-NEXT: module attributes {transform.with_named_sequence} {
-# CHECK-NEXT:   func.func @pad_matmul_unpad(%arg0: memref<14x14xf32> {llvm.noalias}, %arg1: memref<14x14xf32> {llvm.noalias}, %arg2: memref<14x14xf32> {llvm.noalias}) {
-# CHECK-NEXT:     %c14 = arith.constant 14 : index
-# CHECK-NEXT:     %c1 = arith.constant 1 : index
-# CHECK-NEXT:     %c16 = arith.constant 16 : index
-# CHECK-NEXT:     %c0 = arith.constant 0 : index
-# CHECK-NEXT:     %cst = arith.constant 0.000000e+00 : f32
-# CHECK-NEXT:     %alloca = memref.alloca() {alignment = 256 : i64} : memref<16x16xf32>
-# CHECK-NEXT:     %alloca_0 = memref.alloca() {alignment = 256 : i64} : memref<16x16xf32>
-# CHECK-NEXT:     %0 = scf.for %arg3 = %c0 to %c16 step %c1 iter_args(%arg4 = %alloca_0) -> (memref<16x16xf32>) {
-# CHECK-NEXT:       %subview_2 = memref.subview %arg4[%arg3, 0] [1, 16] [1, 1] : memref<16x16xf32> to memref<1x16xf32, strided<[16, 1], offset: ?>>
-# CHECK-NEXT:       %4 = scf.for %arg5 = %c0 to %c16 step %c1 iter_args(%arg6 = %subview_2) -> (memref<1x16xf32, strided<[16, 1], offset: ?>>) {
-# CHECK-NEXT:         %subview_4 = memref.subview %arg6[0, %arg5] [1, 1] [1, 1] : memref<1x16xf32, strided<[16, 1], offset: ?>> to memref<1x1xf32, strided<[16, 1], offset: ?>>
-# CHECK-NEXT:         linalg.generic {indexing_maps = [#map], iterator_types = ["parallel", "parallel"]} outs(%subview_4 : memref<1x1xf32, strided<[16, 1], offset: ?>>) attrs =  {__xtc_id_A_pad_} {
-# CHECK-NEXT:         ^bb0(%out: f32):
-# CHECK-NEXT:           %5 = arith.cmpi sge, %arg3, %c0 : index
-# CHECK-NEXT:           %6 = arith.cmpi slt, %arg3, %c14 : index
-# CHECK-NEXT:           %7 = arith.cmpi sge, %arg5, %c0 : index
-# CHECK-NEXT:           %8 = arith.cmpi slt, %arg5, %c14 : index
-# CHECK-NEXT:           %9 = arith.andi %5, %6 : i1
-# CHECK-NEXT:           %10 = arith.andi %9, %7 : i1
-# CHECK-NEXT:           %11 = arith.andi %10, %8 : i1
-# CHECK-NEXT:           %12 = scf.if %11 -> (f32) {
-# CHECK-NEXT:             %13 = memref.load %arg0[%arg3, %arg5] : memref<14x14xf32>
-# CHECK-NEXT:             scf.yield %13 : f32
-# CHECK-NEXT:           } else {
-# CHECK-NEXT:             scf.yield %cst : f32
-# CHECK-NEXT:           }
-# CHECK-NEXT:           linalg.yield %12 : f32
-# CHECK-NEXT:         }
-# CHECK-NEXT:         %subview_5 = memref.subview %arg6[0, %arg5] [1, 1] [1, 1] : memref<1x16xf32, strided<[16, 1], offset: ?>> to memref<1x1xf32, strided<[16, 1], offset: ?>>
-# CHECK-NEXT:         memref.copy %subview_4, %subview_5 : memref<1x1xf32, strided<[16, 1], offset: ?>> to memref<1x1xf32, strided<[16, 1], offset: ?>>
-# CHECK-NEXT:         scf.yield %arg6 : memref<1x16xf32, strided<[16, 1], offset: ?>>
-# CHECK-NEXT:       } {"./j"}
-# CHECK-NEXT:       %subview_3 = memref.subview %arg4[%arg3, 0] [1, 16] [1, 1] : memref<16x16xf32> to memref<1x16xf32, strided<[16, 1], offset: ?>>
-# CHECK-NEXT:       memref.copy %4, %subview_3 : memref<1x16xf32, strided<[16, 1], offset: ?>> to memref<1x16xf32, strided<[16, 1], offset: ?>>
-# CHECK-NEXT:       scf.yield %arg4 : memref<16x16xf32>
-# CHECK-NEXT:     } {"./i"}
-# CHECK-NEXT:     %alloca_1 = memref.alloca() {alignment = 256 : i64} : memref<16x16xf32>
-# CHECK-NEXT:     %1 = scf.for %arg3 = %c0 to %c16 step %c1 iter_args(%arg4 = %alloca_1) -> (memref<16x16xf32>) {
-# CHECK-NEXT:       %subview_2 = memref.subview %arg4[%arg3, 0] [1, 16] [1, 1] : memref<16x16xf32> to memref<1x16xf32, strided<[16, 1], offset: ?>>
-# CHECK-NEXT:       %4 = scf.for %arg5 = %c0 to %c16 step %c1 iter_args(%arg6 = %subview_2) -> (memref<1x16xf32, strided<[16, 1], offset: ?>>) {
-# CHECK-NEXT:         %subview_4 = memref.subview %arg6[0, %arg5] [1, 1] [1, 1] : memref<1x16xf32, strided<[16, 1], offset: ?>> to memref<1x1xf32, strided<[16, 1], offset: ?>>
-# CHECK-NEXT:         linalg.generic {indexing_maps = [#map], iterator_types = ["parallel", "parallel"]} outs(%subview_4 : memref<1x1xf32, strided<[16, 1], offset: ?>>) attrs =  {__xtc_id_B_pad_} {
-# CHECK-NEXT:         ^bb0(%out: f32):
-# CHECK-NEXT:           %5 = arith.cmpi sge, %arg3, %c0 : index
-# CHECK-NEXT:           %6 = arith.cmpi slt, %arg3, %c14 : index
-# CHECK-NEXT:           %7 = arith.cmpi sge, %arg5, %c0 : index
-# CHECK-NEXT:           %8 = arith.cmpi slt, %arg5, %c14 : index
-# CHECK-NEXT:           %9 = arith.andi %5, %6 : i1
-# CHECK-NEXT:           %10 = arith.andi %9, %7 : i1
-# CHECK-NEXT:           %11 = arith.andi %10, %8 : i1
-# CHECK-NEXT:           %12 = scf.if %11 -> (f32) {
-# CHECK-NEXT:             %13 = memref.load %arg1[%arg3, %arg5] : memref<14x14xf32>
-# CHECK-NEXT:             scf.yield %13 : f32
-# CHECK-NEXT:           } else {
-# CHECK-NEXT:             scf.yield %cst : f32
-# CHECK-NEXT:           }
-# CHECK-NEXT:           linalg.yield %12 : f32
-# CHECK-NEXT:         }
-# CHECK-NEXT:         %subview_5 = memref.subview %arg6[0, %arg5] [1, 1] [1, 1] : memref<1x16xf32, strided<[16, 1], offset: ?>> to memref<1x1xf32, strided<[16, 1], offset: ?>>
-# CHECK-NEXT:         memref.copy %subview_4, %subview_5 : memref<1x1xf32, strided<[16, 1], offset: ?>> to memref<1x1xf32, strided<[16, 1], offset: ?>>
-# CHECK-NEXT:         scf.yield %arg6 : memref<1x16xf32, strided<[16, 1], offset: ?>>
-# CHECK-NEXT:       } {"./j"}
-# CHECK-NEXT:       %subview_3 = memref.subview %arg4[%arg3, 0] [1, 16] [1, 1] : memref<16x16xf32> to memref<1x16xf32, strided<[16, 1], offset: ?>>
-# CHECK-NEXT:       memref.copy %4, %subview_3 : memref<1x16xf32, strided<[16, 1], offset: ?>> to memref<1x16xf32, strided<[16, 1], offset: ?>>
-# CHECK-NEXT:       scf.yield %arg4 : memref<16x16xf32>
-# CHECK-NEXT:     } {"./i"}
-# CHECK-NEXT:     %2 = scf.for %arg3 = %c0 to %c16 step %c1 iter_args(%arg4 = %alloca) -> (memref<16x16xf32>) {
-# CHECK-NEXT:       %subview_2 = memref.subview %arg4[%arg3, 0] [1, 16] [1, 1] : memref<16x16xf32> to memref<1x16xf32, strided<[16, 1], offset: ?>>
-# CHECK-NEXT:       %4 = scf.for %arg5 = %c0 to %c16 step %c1 iter_args(%arg6 = %subview_2) -> (memref<1x16xf32, strided<[16, 1], offset: ?>>) {
-# CHECK-NEXT:         %subview_4 = memref.subview %arg6[0, %arg5] [1, 1] [1, 1] : memref<1x16xf32, strided<[16, 1], offset: ?>> to memref<1x1xf32, strided<[16, 1], offset: ?>>
-# CHECK-NEXT:         linalg.fill {__xtc_id_matmul_padded_0_} ins(%cst : f32) outs(%subview_4 : memref<1x1xf32, strided<[16, 1], offset: ?>>)
-# CHECK-NEXT:         %subview_5 = memref.subview %arg6[0, %arg5] [1, 1] [1, 1] : memref<1x16xf32, strided<[16, 1], offset: ?>> to memref<1x1xf32, strided<[16, 1], offset: ?>>
-# CHECK-NEXT:         memref.copy %subview_4, %subview_5 : memref<1x1xf32, strided<[16, 1], offset: ?>> to memref<1x1xf32, strided<[16, 1], offset: ?>>
-# CHECK-NEXT:         scf.yield %arg6 : memref<1x16xf32, strided<[16, 1], offset: ?>>
-# CHECK-NEXT:       } {"./j"}
-# CHECK-NEXT:       %subview_3 = memref.subview %arg4[%arg3, 0] [1, 16] [1, 1] : memref<16x16xf32> to memref<1x16xf32, strided<[16, 1], offset: ?>>
-# CHECK-NEXT:       memref.copy %4, %subview_3 : memref<1x16xf32, strided<[16, 1], offset: ?>> to memref<1x16xf32, strided<[16, 1], offset: ?>>
-# CHECK-NEXT:       scf.yield %arg4 : memref<16x16xf32>
-# CHECK-NEXT:     } {"./i"}
-# CHECK-NEXT:     %3 = scf.for %arg3 = %c0 to %c16 step %c1 iter_args(%arg4 = %2) -> (memref<16x16xf32>) {
-# CHECK-NEXT:       %subview_2 = memref.subview %0[%arg3, 0] [1, 16] [1, 1] : memref<16x16xf32> to memref<1x16xf32, strided<[16, 1], offset: ?>>
-# CHECK-NEXT:       %subview_3 = memref.subview %arg4[%arg3, 0] [1, 16] [1, 1] : memref<16x16xf32> to memref<1x16xf32, strided<[16, 1], offset: ?>>
-# CHECK-NEXT:       %4 = scf.for %arg5 = %c0 to %c16 step %c1 iter_args(%arg6 = %subview_3) -> (memref<1x16xf32, strided<[16, 1], offset: ?>>) {
-# CHECK-NEXT:         %subview_5 = memref.subview %1[0, %arg5] [16, 1] [1, 1] : memref<16x16xf32> to memref<16x1xf32, strided<[16, 1], offset: ?>>
-# CHECK-NEXT:         %subview_6 = memref.subview %arg6[0, %arg5] [1, 1] [1, 1] : memref<1x16xf32, strided<[16, 1], offset: ?>> to memref<1x1xf32, strided<[16, 1], offset: ?>>
-# CHECK-NEXT:         %5 = scf.for %arg7 = %c0 to %c16 step %c1 iter_args(%arg8 = %subview_6) -> (memref<1x1xf32, strided<[16, 1], offset: ?>>) {
-# CHECK-NEXT:           %subview_8 = memref.subview %subview_2[0, %arg7] [1, 1] [1, 1] : memref<1x16xf32, strided<[16, 1], offset: ?>> to memref<1x1xf32, strided<[16, 1], offset: ?>>
-# CHECK-NEXT:           %subview_9 = memref.subview %subview_5[%arg7, 0] [1, 1] [1, 1] : memref<16x1xf32, strided<[16, 1], offset: ?>> to memref<1x1xf32, strided<[16, 1], offset: ?>>
-# CHECK-NEXT:           linalg.matmul {__xtc_id_matmul_padded_} ins(%subview_8, %subview_9 : memref<1x1xf32, strided<[16, 1], offset: ?>>, memref<1x1xf32, strided<[16, 1], offset: ?>>) outs(%arg8 : memref<1x1xf32, strided<[16, 1], offset: ?>>)
-# CHECK-NEXT:           scf.yield %arg8 : memref<1x1xf32, strided<[16, 1], offset: ?>>
-# CHECK-NEXT:         } {"./k"}
-# CHECK-NEXT:         %subview_7 = memref.subview %arg6[0, %arg5] [1, 1] [1, 1] : memref<1x16xf32, strided<[16, 1], offset: ?>> to memref<1x1xf32, strided<[16, 1], offset: ?>>
-# CHECK-NEXT:         memref.copy %5, %subview_7 : memref<1x1xf32, strided<[16, 1], offset: ?>> to memref<1x1xf32, strided<[16, 1], offset: ?>>
-# CHECK-NEXT:         scf.yield %arg6 : memref<1x16xf32, strided<[16, 1], offset: ?>>
-# CHECK-NEXT:       } {"./j"}
-# CHECK-NEXT:       %subview_4 = memref.subview %arg4[%arg3, 0] [1, 16] [1, 1] : memref<16x16xf32> to memref<1x16xf32, strided<[16, 1], offset: ?>>
-# CHECK-NEXT:       memref.copy %4, %subview_4 : memref<1x16xf32, strided<[16, 1], offset: ?>> to memref<1x16xf32, strided<[16, 1], offset: ?>>
-# CHECK-NEXT:       scf.yield %arg4 : memref<16x16xf32>
-# CHECK-NEXT:     } {"./i"}
-# CHECK-NEXT:     %subview = memref.subview %3[0, 0] [14, 14] [1, 1] : memref<16x16xf32> to memref<14x14xf32, strided<[16, 1]>>
-# CHECK-NEXT:     memref.copy %subview, %arg2 : memref<14x14xf32, strided<[16, 1]>> to memref<14x14xf32>
-# CHECK-NEXT:     return
-# CHECK-NEXT:   }
-# CHECK-NEXT: }
+# CHECK-NEXT:  // -----// IR Dump After Tensor Lowering //----- //
+# CHECK-NEXT:  #map = affine_map<(d0, d1) -> (d0, d1)>
+# CHECK-NEXT:  module attributes {transform.with_named_sequence} {
+# CHECK-NEXT:    func.func @pad_matmul_unpad(%arg0: memref<14x14xf32> {llvm.noalias}, %arg1: memref<14x14xf32> {llvm.noalias}, %arg2: memref<14x14xf32> {llvm.noalias}) {
+# CHECK-NEXT:      %c14 = arith.constant 14 : index
+# CHECK-NEXT:      %c1 = arith.constant 1 : index
+# CHECK-NEXT:      %c16 = arith.constant 16 : index
+# CHECK-NEXT:      %c0 = arith.constant 0 : index
+# CHECK-NEXT:      %cst = arith.constant 0.000000e+00 : f32
+# CHECK-NEXT:      %alloca = memref.alloca() {alignment = 256 : i64} : memref<16x16xf32>
+# CHECK-NEXT:      %alloca_0 = memref.alloca() {alignment = 256 : i64} : memref<16x16xf32>
+# CHECK-NEXT:      %0 = scf.for %arg3 = %c0 to %c16 step %c1 iter_args(%arg4 = %alloca_0) -> (memref<16x16xf32>) {
+# CHECK-NEXT:        %subview_2 = memref.subview %arg4[%arg3, 0] [1, 16] [1, 1] : memref<16x16xf32> to memref<1x16xf32, strided<[16, 1], offset: ?>>
+# CHECK-NEXT:        %3 = scf.for %arg5 = %c0 to %c16 step %c1 iter_args(%arg6 = %subview_2) -> (memref<1x16xf32, strided<[16, 1], offset: ?>>) {
+# CHECK-NEXT:          %subview_4 = memref.subview %arg6[0, %arg5] [1, 1] [1, 1] : memref<1x16xf32, strided<[16, 1], offset: ?>> to memref<1x1xf32, strided<[16, 1], offset: ?>>
+# CHECK-NEXT:          linalg.generic {indexing_maps = [#map], iterator_types = ["parallel", "parallel"]} outs(%subview_4 : memref<1x1xf32, strided<[16, 1], offset: ?>>) attrs =  {__xtc_id_A_pad_} {
+# CHECK-NEXT:          ^bb0(%out: f32):
+# CHECK-NEXT:            %4 = arith.cmpi sge, %arg3, %c0 : index
+# CHECK-NEXT:            %5 = arith.cmpi slt, %arg3, %c14 : index
+# CHECK-NEXT:            %6 = arith.cmpi sge, %arg5, %c0 : index
+# CHECK-NEXT:            %7 = arith.cmpi slt, %arg5, %c14 : index
+# CHECK-NEXT:            %8 = arith.andi %4, %5 : i1
+# CHECK-NEXT:            %9 = arith.andi %8, %6 : i1
+# CHECK-NEXT:            %10 = arith.andi %9, %7 : i1
+# CHECK-NEXT:            %11 = scf.if %10 -> (f32) {
+# CHECK-NEXT:              %12 = memref.load %arg0[%arg3, %arg5] : memref<14x14xf32>
+# CHECK-NEXT:              scf.yield %12 : f32
+# CHECK-NEXT:            } else {
+# CHECK-NEXT:              scf.yield %cst : f32
+# CHECK-NEXT:            }
+# CHECK-NEXT:            linalg.yield %11 : f32
+# CHECK-NEXT:          }
+# CHECK-NEXT:          %subview_5 = memref.subview %arg6[0, %arg5] [1, 1] [1, 1] : memref<1x16xf32, strided<[16, 1], offset: ?>> to memref<1x1xf32, strided<[16, 1], offset: ?>>
+# CHECK-NEXT:          memref.copy %subview_4, %subview_5 : memref<1x1xf32, strided<[16, 1], offset: ?>> to memref<1x1xf32, strided<[16, 1], offset: ?>>
+# CHECK-NEXT:          scf.yield %arg6 : memref<1x16xf32, strided<[16, 1], offset: ?>>
+# CHECK-NEXT:        } {"./j"}
+# CHECK-NEXT:        %subview_3 = memref.subview %arg4[%arg3, 0] [1, 16] [1, 1] : memref<16x16xf32> to memref<1x16xf32, strided<[16, 1], offset: ?>>
+# CHECK-NEXT:        memref.copy %3, %subview_3 : memref<1x16xf32, strided<[16, 1], offset: ?>> to memref<1x16xf32, strided<[16, 1], offset: ?>>
+# CHECK-NEXT:        scf.yield %arg4 : memref<16x16xf32>
+# CHECK-NEXT:      } {"./i"}
+# CHECK-NEXT:      %alloca_1 = memref.alloca() {alignment = 256 : i64} : memref<16x16xf32>
+# CHECK-NEXT:      %1 = scf.for %arg3 = %c0 to %c16 step %c1 iter_args(%arg4 = %alloca_1) -> (memref<16x16xf32>) {
+# CHECK-NEXT:        %subview_2 = memref.subview %arg4[%arg3, 0] [1, 16] [1, 1] : memref<16x16xf32> to memref<1x16xf32, strided<[16, 1], offset: ?>>
+# CHECK-NEXT:        %3 = scf.for %arg5 = %c0 to %c16 step %c1 iter_args(%arg6 = %subview_2) -> (memref<1x16xf32, strided<[16, 1], offset: ?>>) {
+# CHECK-NEXT:          %subview_4 = memref.subview %arg6[0, %arg5] [1, 1] [1, 1] : memref<1x16xf32, strided<[16, 1], offset: ?>> to memref<1x1xf32, strided<[16, 1], offset: ?>>
+# CHECK-NEXT:          linalg.generic {indexing_maps = [#map], iterator_types = ["parallel", "parallel"]} outs(%subview_4 : memref<1x1xf32, strided<[16, 1], offset: ?>>) attrs =  {__xtc_id_B_pad_} {
+# CHECK-NEXT:          ^bb0(%out: f32):
+# CHECK-NEXT:            %4 = arith.cmpi sge, %arg3, %c0 : index
+# CHECK-NEXT:            %5 = arith.cmpi slt, %arg3, %c14 : index
+# CHECK-NEXT:            %6 = arith.cmpi sge, %arg5, %c0 : index
+# CHECK-NEXT:            %7 = arith.cmpi slt, %arg5, %c14 : index
+# CHECK-NEXT:            %8 = arith.andi %4, %5 : i1
+# CHECK-NEXT:            %9 = arith.andi %8, %6 : i1
+# CHECK-NEXT:            %10 = arith.andi %9, %7 : i1
+# CHECK-NEXT:            %11 = scf.if %10 -> (f32) {
+# CHECK-NEXT:              %12 = memref.load %arg1[%arg3, %arg5] : memref<14x14xf32>
+# CHECK-NEXT:              scf.yield %12 : f32
+# CHECK-NEXT:            } else {
+# CHECK-NEXT:              scf.yield %cst : f32
+# CHECK-NEXT:            }
+# CHECK-NEXT:            linalg.yield %11 : f32
+# CHECK-NEXT:          }
+# CHECK-NEXT:          %subview_5 = memref.subview %arg6[0, %arg5] [1, 1] [1, 1] : memref<1x16xf32, strided<[16, 1], offset: ?>> to memref<1x1xf32, strided<[16, 1], offset: ?>>
+# CHECK-NEXT:          memref.copy %subview_4, %subview_5 : memref<1x1xf32, strided<[16, 1], offset: ?>> to memref<1x1xf32, strided<[16, 1], offset: ?>>
+# CHECK-NEXT:          scf.yield %arg6 : memref<1x16xf32, strided<[16, 1], offset: ?>>
+# CHECK-NEXT:        } {"./j"}
+# CHECK-NEXT:        %subview_3 = memref.subview %arg4[%arg3, 0] [1, 16] [1, 1] : memref<16x16xf32> to memref<1x16xf32, strided<[16, 1], offset: ?>>
+# CHECK-NEXT:        memref.copy %3, %subview_3 : memref<1x16xf32, strided<[16, 1], offset: ?>> to memref<1x16xf32, strided<[16, 1], offset: ?>>
+# CHECK-NEXT:        scf.yield %arg4 : memref<16x16xf32>
+# CHECK-NEXT:      } {"./i"}
+# CHECK-NEXT:      linalg.fill {__xtc_id_matmul_padded_0_} ins(%cst : f32) outs(%alloca : memref<16x16xf32>)
+# CHECK-NEXT:      %2 = scf.for %arg3 = %c0 to %c16 step %c1 iter_args(%arg4 = %alloca) -> (memref<16x16xf32>) {
+# CHECK-NEXT:        %subview_2 = memref.subview %0[%arg3, 0] [1, 16] [1, 1] : memref<16x16xf32> to memref<1x16xf32, strided<[16, 1], offset: ?>>
+# CHECK-NEXT:        %subview_3 = memref.subview %arg4[%arg3, 0] [1, 16] [1, 1] : memref<16x16xf32> to memref<1x16xf32, strided<[16, 1], offset: ?>>
+# CHECK-NEXT:        %3 = scf.for %arg5 = %c0 to %c16 step %c1 iter_args(%arg6 = %subview_3) -> (memref<1x16xf32, strided<[16, 1], offset: ?>>) {
+# CHECK-NEXT:          %subview_5 = memref.subview %1[0, %arg5] [16, 1] [1, 1] : memref<16x16xf32> to memref<16x1xf32, strided<[16, 1], offset: ?>>
+# CHECK-NEXT:          %subview_6 = memref.subview %arg6[0, %arg5] [1, 1] [1, 1] : memref<1x16xf32, strided<[16, 1], offset: ?>> to memref<1x1xf32, strided<[16, 1], offset: ?>>
+# CHECK-NEXT:          %4 = scf.for %arg7 = %c0 to %c16 step %c1 iter_args(%arg8 = %subview_6) -> (memref<1x1xf32, strided<[16, 1], offset: ?>>) {
+# CHECK-NEXT:            %subview_8 = memref.subview %subview_2[0, %arg7] [1, 1] [1, 1] : memref<1x16xf32, strided<[16, 1], offset: ?>> to memref<1x1xf32, strided<[16, 1], offset: ?>>
+# CHECK-NEXT:            %subview_9 = memref.subview %subview_5[%arg7, 0] [1, 1] [1, 1] : memref<16x1xf32, strided<[16, 1], offset: ?>> to memref<1x1xf32, strided<[16, 1], offset: ?>>
+# CHECK-NEXT:            linalg.matmul {__xtc_id_matmul_padded_} ins(%subview_8, %subview_9 : memref<1x1xf32, strided<[16, 1], offset: ?>>, memref<1x1xf32, strided<[16, 1], offset: ?>>) outs(%arg8 : memref<1x1xf32, strided<[16, 1], offset: ?>>)
+# CHECK-NEXT:            scf.yield %arg8 : memref<1x1xf32, strided<[16, 1], offset: ?>>
+# CHECK-NEXT:          } {"./k"}
+# CHECK-NEXT:          %subview_7 = memref.subview %arg6[0, %arg5] [1, 1] [1, 1] : memref<1x16xf32, strided<[16, 1], offset: ?>> to memref<1x1xf32, strided<[16, 1], offset: ?>>
+# CHECK-NEXT:          memref.copy %4, %subview_7 : memref<1x1xf32, strided<[16, 1], offset: ?>> to memref<1x1xf32, strided<[16, 1], offset: ?>>
+# CHECK-NEXT:          scf.yield %arg6 : memref<1x16xf32, strided<[16, 1], offset: ?>>
+# CHECK-NEXT:        } {"./j"}
+# CHECK-NEXT:        %subview_4 = memref.subview %arg4[%arg3, 0] [1, 16] [1, 1] : memref<16x16xf32> to memref<1x16xf32, strided<[16, 1], offset: ?>>
+# CHECK-NEXT:        memref.copy %3, %subview_4 : memref<1x16xf32, strided<[16, 1], offset: ?>> to memref<1x16xf32, strided<[16, 1], offset: ?>>
+# CHECK-NEXT:        scf.yield %arg4 : memref<16x16xf32>
+# CHECK-NEXT:      } {"./i"}
+# CHECK-NEXT:      %subview = memref.subview %2[0, 0] [14, 14] [1, 1] : memref<16x16xf32> to memref<14x14xf32, strided<[16, 1]>>
+# CHECK-NEXT:      memref.copy %subview, %arg2 : memref<14x14xf32, strided<[16, 1]>> to memref<14x14xf32>
+# CHECK-NEXT:      return
+# CHECK-NEXT:    }
+# CHECK-NEXT:  }
 # CHECK-NEXT:  
-# CHECK-NEXT: graph:
-# CHECK-NEXT:   name: pad_matmul_unpad
-# CHECK-NEXT:   inputs:
-# CHECK-NEXT:   - %0 : 14x14xfloat32
-# CHECK-NEXT:   - %1 : 14x14xfloat32
-# CHECK-NEXT:   outputs:
-# CHECK-NEXT:   - %5 : 14x14xfloat32
-# CHECK-NEXT:   nodes:
-# CHECK-NEXT:   - %2: pad(%0, padding=(0, 2), constant_value=0) {name = 'A_pad'} : [14x14xfloat32] -> [16x16xfloat32]
-# CHECK-NEXT:   - %3: pad(%1, padding=(0, 2), constant_value=0) {name = 'B_pad'} : [14x14xfloat32] -> [16x16xfloat32]
-# CHECK-NEXT:   - %4: matmul(%2, %3) {name = 'matmul_padded'} : [16x16xfloat32, 16x16xfloat32] -> [16x16xfloat32]
-# CHECK-NEXT:   - %5: unpad(%4, padding=(0, 2)) {name = 'C'} : [16x16xfloat32] -> [14x14xfloat32]
+# CHECK-NEXT:  graph:
+# CHECK-NEXT:    name: pad_matmul_unpad
+# CHECK-NEXT:    inputs:
+# CHECK-NEXT:    - %0 : 14x14xfloat32
+# CHECK-NEXT:    - %1 : 14x14xfloat32
+# CHECK-NEXT:    outputs:
+# CHECK-NEXT:    - %5 : 14x14xfloat32
+# CHECK-NEXT:    nodes:
+# CHECK-NEXT:    - %2: pad(%0, padding=(0, 2), constant_value=0) {name = 'A_pad'} : [14x14xfloat32] -> [16x16xfloat32]
+# CHECK-NEXT:    - %3: pad(%1, padding=(0, 2), constant_value=0) {name = 'B_pad'} : [14x14xfloat32] -> [16x16xfloat32]
+# CHECK-NEXT:    - %4: matmul(%2, %3) {name = 'matmul_padded'} : [16x16xfloat32, 16x16xfloat32] -> [16x16xfloat32]
+# CHECK-NEXT:    - %5: unpad(%4, padding=(0, 2)) {name = 'C'} : [16x16xfloat32] -> [14x14xfloat32]
 # CHECK-NEXT:  
-# CHECK-NEXT: CODE: 0
+# CHECK-NEXT:  CODE: 0

--- a/tests/filecheck/backends/tensor_dialect/test_two_matmuls_mlir_tensor.py
+++ b/tests/filecheck/backends/tensor_dialect/test_two_matmuls_mlir_tensor.py
@@ -33,262 +33,196 @@ executor = module.get_executor(validate=True)
 res = executor.execute()
 print(f"CODE: {res}")
 
-# CHECK: // -----// IR Dump Before transform //----- //
-# CHECK-NEXT: module attributes {transform.with_named_sequence} {
-# CHECK-NEXT:   func.func @matmul(%arg0: tensor<4x512xf32> {llvm.noalias}, %arg1: tensor<512x32xf32> {llvm.noalias}, %arg2: tensor<32x4xf32> {llvm.noalias}, %arg3: memref<32x32xf32> {llvm.noalias}) {
-# CHECK-NEXT:     %0 = tensor.empty() : tensor<4x32xf32>
-# CHECK-NEXT:     %cst = arith.constant 0.000000e+00 : f32
-# CHECK-NEXT:     %1 = linalg.fill {__xtc_id_D_0_} ins(%cst : f32) outs(%0 : tensor<4x32xf32>) -> tensor<4x32xf32>
-# CHECK-NEXT:     %2 = linalg.matmul {__xtc_id_D_} ins(%arg0, %arg1 : tensor<4x512xf32>, tensor<512x32xf32>) outs(%1 : tensor<4x32xf32>) -> tensor<4x32xf32>
-# CHECK-NEXT:     %3 = tensor.empty() : tensor<32x32xf32>
-# CHECK-NEXT:     %cst_0 = arith.constant 0.000000e+00 : f32
-# CHECK-NEXT:     %4 = linalg.fill {__xtc_id_E_0_} ins(%cst_0 : f32) outs(%3 : tensor<32x32xf32>) -> tensor<32x32xf32>
-# CHECK-NEXT:     %5 = linalg.matmul {__xtc_id_E_} ins(%arg2, %2 : tensor<32x4xf32>, tensor<4x32xf32>) outs(%4 : tensor<32x32xf32>) -> tensor<32x32xf32>
-# CHECK-NEXT:     bufferization.materialize_in_destination %5 in restrict writable %arg3 : (tensor<32x32xf32>, memref<32x32xf32>) -> ()
-# CHECK-NEXT:     return
-# CHECK-NEXT:   }
-# CHECK-NEXT:   transform.named_sequence @_vecto(%arg0: !transform.any_op {transform.consumed}) {
-# CHECK-NEXT:     transform.structured.vectorize %arg0 : !transform.any_op
-# CHECK-NEXT:     transform.yield 
-# CHECK-NEXT:   }
-# CHECK-NEXT:   transform.named_sequence @_post_bufferize(%arg0: !transform.any_op {transform.readonly}) {
-# CHECK-NEXT:     transform.yield 
-# CHECK-NEXT:   }
-# CHECK-NEXT:   transform.named_sequence @__transform_main(%arg0: !transform.any_op {transform.readonly}) {
-# CHECK-NEXT:     %0 = transform.structured.match attributes {__xtc_id_D_0_} in %arg0 : (!transform.any_op) -> !transform.any_op
-# CHECK-NEXT:     %tiled_linalg_op, %loops = transform.structured.tile_using_for %0 tile_sizes [1, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:     transform.annotate %loops "./i" : !transform.any_op
-# CHECK-NEXT:     %tiled_linalg_op_0, %loops_1 = transform.structured.tile_using_for %tiled_linalg_op tile_sizes [0, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:     transform.annotate %loops_1 "./j" : !transform.any_op
-# CHECK-NEXT:     %1 = transform.structured.match attributes {__xtc_id_D_} in %arg0 : (!transform.any_op) -> !transform.any_op
-# CHECK-NEXT:     %tiled_linalg_op_2, %loops_3 = transform.structured.tile_using_for %1 tile_sizes [1, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:     transform.annotate %loops_3 "./i" : !transform.any_op
-# CHECK-NEXT:     %tiled_linalg_op_4, %loops_5 = transform.structured.tile_using_for %tiled_linalg_op_2 tile_sizes [0, 1, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:     transform.annotate %loops_5 "./j" : !transform.any_op
-# CHECK-NEXT:     %tiled_linalg_op_6, %loops_7 = transform.structured.tile_using_for %tiled_linalg_op_4 tile_sizes [0, 0, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:     transform.annotate %loops_7 "./k" : !transform.any_op
-# CHECK-NEXT:     %2 = transform.structured.match attributes {__xtc_id_E_0_} in %arg0 : (!transform.any_op) -> !transform.any_op
-# CHECK-NEXT:     %tiled_linalg_op_8, %loops_9 = transform.structured.tile_using_for %2 tile_sizes [1, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:     transform.annotate %loops_9 "./i" : !transform.any_op
-# CHECK-NEXT:     %tiled_linalg_op_10, %loops_11 = transform.structured.tile_using_for %tiled_linalg_op_8 tile_sizes [0, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:     transform.annotate %loops_11 "./j" : !transform.any_op
-# CHECK-NEXT:     %3 = transform.structured.match attributes {__xtc_id_E_} in %arg0 : (!transform.any_op) -> !transform.any_op
-# CHECK-NEXT:     %tiled_linalg_op_12, %loops_13 = transform.structured.tile_using_for %3 tile_sizes [1, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:     transform.annotate %loops_13 "./i" : !transform.any_op
-# CHECK-NEXT:     %tiled_linalg_op_14, %loops_15 = transform.structured.tile_using_for %tiled_linalg_op_12 tile_sizes [0, 1, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:     transform.annotate %loops_15 "./j" : !transform.any_op
-# CHECK-NEXT:     %tiled_linalg_op_16, %loops_17 = transform.structured.tile_using_for %tiled_linalg_op_14 tile_sizes [0, 0, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:     transform.annotate %loops_17 "./k" : !transform.any_op
-# CHECK-NEXT:     transform.yield 
-# CHECK-NEXT:   }
-# CHECK-NEXT: }
+# CHECK:       // -----// IR Dump Before transform //----- //
+# CHECK-NEXT:  module attributes {transform.with_named_sequence} {
+# CHECK-NEXT:    func.func @matmul(%arg0: tensor<4x512xf32> {llvm.noalias}, %arg1: tensor<512x32xf32> {llvm.noalias}, %arg2: tensor<32x4xf32> {llvm.noalias}, %arg3: memref<32x32xf32> {llvm.noalias}) {
+# CHECK-NEXT:      %0 = tensor.empty() : tensor<4x32xf32>
+# CHECK-NEXT:      %cst = arith.constant 0.000000e+00 : f32
+# CHECK-NEXT:      %1 = linalg.fill {__xtc_id_D_0_} ins(%cst : f32) outs(%0 : tensor<4x32xf32>) -> tensor<4x32xf32>
+# CHECK-NEXT:      %2 = linalg.matmul {__xtc_id_D_} ins(%arg0, %arg1 : tensor<4x512xf32>, tensor<512x32xf32>) outs(%1 : tensor<4x32xf32>) -> tensor<4x32xf32>
+# CHECK-NEXT:      %3 = tensor.empty() : tensor<32x32xf32>
+# CHECK-NEXT:      %cst_0 = arith.constant 0.000000e+00 : f32
+# CHECK-NEXT:      %4 = linalg.fill {__xtc_id_E_0_} ins(%cst_0 : f32) outs(%3 : tensor<32x32xf32>) -> tensor<32x32xf32>
+# CHECK-NEXT:      %5 = linalg.matmul {__xtc_id_E_} ins(%arg2, %2 : tensor<32x4xf32>, tensor<4x32xf32>) outs(%4 : tensor<32x32xf32>) -> tensor<32x32xf32>
+# CHECK-NEXT:      bufferization.materialize_in_destination %5 in restrict writable %arg3 : (tensor<32x32xf32>, memref<32x32xf32>) -> ()
+# CHECK-NEXT:      return
+# CHECK-NEXT:    }
+# CHECK-NEXT:    transform.named_sequence @_vecto(%arg0: !transform.any_op {transform.consumed}) {
+# CHECK-NEXT:      transform.structured.vectorize %arg0 : !transform.any_op
+# CHECK-NEXT:      transform.yield 
+# CHECK-NEXT:    }
+# CHECK-NEXT:    transform.named_sequence @_post_bufferize(%arg0: !transform.any_op {transform.readonly}) {
+# CHECK-NEXT:      transform.yield 
+# CHECK-NEXT:    }
+# CHECK-NEXT:    transform.named_sequence @__transform_main(%arg0: !transform.any_op {transform.readonly}) {
+# CHECK-NEXT:      %0 = transform.structured.match attributes {__xtc_id_D_} in %arg0 : (!transform.any_op) -> !transform.any_op
+# CHECK-NEXT:      %tiled_linalg_op, %loops = transform.structured.tile_using_for %0 tile_sizes [1, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      transform.annotate %loops "./i" : !transform.any_op
+# CHECK-NEXT:      %tiled_linalg_op_0, %loops_1 = transform.structured.tile_using_for %tiled_linalg_op tile_sizes [0, 1, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      transform.annotate %loops_1 "./j" : !transform.any_op
+# CHECK-NEXT:      %tiled_linalg_op_2, %loops_3 = transform.structured.tile_using_for %tiled_linalg_op_0 tile_sizes [0, 0, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      transform.annotate %loops_3 "./k" : !transform.any_op
+# CHECK-NEXT:      %1 = transform.structured.match attributes {__xtc_id_E_} in %arg0 : (!transform.any_op) -> !transform.any_op
+# CHECK-NEXT:      %tiled_linalg_op_4, %loops_5 = transform.structured.tile_using_for %1 tile_sizes [1, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      transform.annotate %loops_5 "./i" : !transform.any_op
+# CHECK-NEXT:      %tiled_linalg_op_6, %loops_7 = transform.structured.tile_using_for %tiled_linalg_op_4 tile_sizes [0, 1, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      transform.annotate %loops_7 "./j" : !transform.any_op
+# CHECK-NEXT:      %tiled_linalg_op_8, %loops_9 = transform.structured.tile_using_for %tiled_linalg_op_6 tile_sizes [0, 0, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      transform.annotate %loops_9 "./k" : !transform.any_op
+# CHECK-NEXT:      transform.yield 
+# CHECK-NEXT:    }
+# CHECK-NEXT:  }
 # CHECK-NEXT:  
-# CHECK-NEXT: // -----// IR Dump After transform //----- //
-# CHECK-NEXT: module attributes {transform.with_named_sequence} {
-# CHECK-NEXT:   func.func @matmul(%arg0: tensor<4x512xf32> {llvm.noalias}, %arg1: tensor<512x32xf32> {llvm.noalias}, %arg2: tensor<32x4xf32> {llvm.noalias}, %arg3: memref<32x32xf32> {llvm.noalias}) {
-# CHECK-NEXT:     %0 = tensor.empty() : tensor<4x32xf32>
-# CHECK-NEXT:     %cst = arith.constant 0.000000e+00 : f32
-# CHECK-NEXT:     %c0 = arith.constant 0 : index
-# CHECK-NEXT:     %c4 = arith.constant 4 : index
-# CHECK-NEXT:     %c1 = arith.constant 1 : index
-# CHECK-NEXT:     %1 = scf.for %arg4 = %c0 to %c4 step %c1 iter_args(%arg5 = %0) -> (tensor<4x32xf32>) {
-# CHECK-NEXT:       %extracted_slice = tensor.extract_slice %arg5[%arg4, 0] [1, 32] [1, 1] : tensor<4x32xf32> to tensor<1x32xf32>
-# CHECK-NEXT:       %c0_9 = arith.constant 0 : index
-# CHECK-NEXT:       %c32_10 = arith.constant 32 : index
-# CHECK-NEXT:       %c1_11 = arith.constant 1 : index
-# CHECK-NEXT:       %6 = scf.for %arg6 = %c0_9 to %c32_10 step %c1_11 iter_args(%arg7 = %extracted_slice) -> (tensor<1x32xf32>) {
-# CHECK-NEXT:         %extracted_slice_12 = tensor.extract_slice %arg7[0, %arg6] [1, 1] [1, 1] : tensor<1x32xf32> to tensor<1x1xf32>
-# CHECK-NEXT:         %7 = linalg.fill {__xtc_id_D_0_} ins(%cst : f32) outs(%extracted_slice_12 : tensor<1x1xf32>) -> tensor<1x1xf32>
-# CHECK-NEXT:         %inserted_slice_13 = tensor.insert_slice %7 into %arg7[0, %arg6] [1, 1] [1, 1] : tensor<1x1xf32> into tensor<1x32xf32>
-# CHECK-NEXT:         scf.yield %inserted_slice_13 : tensor<1x32xf32>
-# CHECK-NEXT:       } {"./j"}
-# CHECK-NEXT:       %inserted_slice = tensor.insert_slice %6 into %arg5[%arg4, 0] [1, 32] [1, 1] : tensor<1x32xf32> into tensor<4x32xf32>
-# CHECK-NEXT:       scf.yield %inserted_slice : tensor<4x32xf32>
-# CHECK-NEXT:     } {"./i"}
-# CHECK-NEXT:     %c0_0 = arith.constant 0 : index
-# CHECK-NEXT:     %c4_1 = arith.constant 4 : index
-# CHECK-NEXT:     %c1_2 = arith.constant 1 : index
-# CHECK-NEXT:     %2 = scf.for %arg4 = %c0_0 to %c4_1 step %c1_2 iter_args(%arg5 = %1) -> (tensor<4x32xf32>) {
-# CHECK-NEXT:       %extracted_slice = tensor.extract_slice %arg0[%arg4, 0] [1, 512] [1, 1] : tensor<4x512xf32> to tensor<1x512xf32>
-# CHECK-NEXT:       %extracted_slice_9 = tensor.extract_slice %arg1[0, 0] [512, 32] [1, 1] : tensor<512x32xf32> to tensor<512x32xf32>
-# CHECK-NEXT:       %extracted_slice_10 = tensor.extract_slice %arg5[%arg4, 0] [1, 32] [1, 1] : tensor<4x32xf32> to tensor<1x32xf32>
-# CHECK-NEXT:       %c0_11 = arith.constant 0 : index
-# CHECK-NEXT:       %c32_12 = arith.constant 32 : index
-# CHECK-NEXT:       %c1_13 = arith.constant 1 : index
-# CHECK-NEXT:       %6 = scf.for %arg6 = %c0_11 to %c32_12 step %c1_13 iter_args(%arg7 = %extracted_slice_10) -> (tensor<1x32xf32>) {
-# CHECK-NEXT:         %extracted_slice_14 = tensor.extract_slice %extracted_slice[0, 0] [1, 512] [1, 1] : tensor<1x512xf32> to tensor<1x512xf32>
-# CHECK-NEXT:         %extracted_slice_15 = tensor.extract_slice %extracted_slice_9[0, %arg6] [512, 1] [1, 1] : tensor<512x32xf32> to tensor<512x1xf32>
-# CHECK-NEXT:         %extracted_slice_16 = tensor.extract_slice %arg7[0, %arg6] [1, 1] [1, 1] : tensor<1x32xf32> to tensor<1x1xf32>
-# CHECK-NEXT:         %c0_17 = arith.constant 0 : index
-# CHECK-NEXT:         %c512 = arith.constant 512 : index
-# CHECK-NEXT:         %c1_18 = arith.constant 1 : index
-# CHECK-NEXT:         %7 = scf.for %arg8 = %c0_17 to %c512 step %c1_18 iter_args(%arg9 = %extracted_slice_16) -> (tensor<1x1xf32>) {
-# CHECK-NEXT:           %extracted_slice_20 = tensor.extract_slice %extracted_slice_14[0, %arg8] [1, 1] [1, 1] : tensor<1x512xf32> to tensor<1x1xf32>
-# CHECK-NEXT:           %extracted_slice_21 = tensor.extract_slice %extracted_slice_15[%arg8, 0] [1, 1] [1, 1] : tensor<512x1xf32> to tensor<1x1xf32>
-# CHECK-NEXT:           %extracted_slice_22 = tensor.extract_slice %arg9[0, 0] [1, 1] [1, 1] : tensor<1x1xf32> to tensor<1x1xf32>
-# CHECK-NEXT:           %8 = linalg.matmul {__xtc_id_D_} ins(%extracted_slice_20, %extracted_slice_21 : tensor<1x1xf32>, tensor<1x1xf32>) outs(%extracted_slice_22 : tensor<1x1xf32>) -> tensor<1x1xf32>
-# CHECK-NEXT:           %inserted_slice_23 = tensor.insert_slice %8 into %arg9[0, 0] [1, 1] [1, 1] : tensor<1x1xf32> into tensor<1x1xf32>
-# CHECK-NEXT:           scf.yield %inserted_slice_23 : tensor<1x1xf32>
-# CHECK-NEXT:         } {"./k"}
-# CHECK-NEXT:         %inserted_slice_19 = tensor.insert_slice %7 into %arg7[0, %arg6] [1, 1] [1, 1] : tensor<1x1xf32> into tensor<1x32xf32>
-# CHECK-NEXT:         scf.yield %inserted_slice_19 : tensor<1x32xf32>
-# CHECK-NEXT:       } {"./j"}
-# CHECK-NEXT:       %inserted_slice = tensor.insert_slice %6 into %arg5[%arg4, 0] [1, 32] [1, 1] : tensor<1x32xf32> into tensor<4x32xf32>
-# CHECK-NEXT:       scf.yield %inserted_slice : tensor<4x32xf32>
-# CHECK-NEXT:     } {"./i"}
-# CHECK-NEXT:     %3 = tensor.empty() : tensor<32x32xf32>
-# CHECK-NEXT:     %cst_3 = arith.constant 0.000000e+00 : f32
-# CHECK-NEXT:     %c0_4 = arith.constant 0 : index
-# CHECK-NEXT:     %c32 = arith.constant 32 : index
-# CHECK-NEXT:     %c1_5 = arith.constant 1 : index
-# CHECK-NEXT:     %4 = scf.for %arg4 = %c0_4 to %c32 step %c1_5 iter_args(%arg5 = %3) -> (tensor<32x32xf32>) {
-# CHECK-NEXT:       %extracted_slice = tensor.extract_slice %arg5[%arg4, 0] [1, 32] [1, 1] : tensor<32x32xf32> to tensor<1x32xf32>
-# CHECK-NEXT:       %c0_9 = arith.constant 0 : index
-# CHECK-NEXT:       %c32_10 = arith.constant 32 : index
-# CHECK-NEXT:       %c1_11 = arith.constant 1 : index
-# CHECK-NEXT:       %6 = scf.for %arg6 = %c0_9 to %c32_10 step %c1_11 iter_args(%arg7 = %extracted_slice) -> (tensor<1x32xf32>) {
-# CHECK-NEXT:         %extracted_slice_12 = tensor.extract_slice %arg7[0, %arg6] [1, 1] [1, 1] : tensor<1x32xf32> to tensor<1x1xf32>
-# CHECK-NEXT:         %7 = linalg.fill {__xtc_id_E_0_} ins(%cst_3 : f32) outs(%extracted_slice_12 : tensor<1x1xf32>) -> tensor<1x1xf32>
-# CHECK-NEXT:         %inserted_slice_13 = tensor.insert_slice %7 into %arg7[0, %arg6] [1, 1] [1, 1] : tensor<1x1xf32> into tensor<1x32xf32>
-# CHECK-NEXT:         scf.yield %inserted_slice_13 : tensor<1x32xf32>
-# CHECK-NEXT:       } {"./j"}
-# CHECK-NEXT:       %inserted_slice = tensor.insert_slice %6 into %arg5[%arg4, 0] [1, 32] [1, 1] : tensor<1x32xf32> into tensor<32x32xf32>
-# CHECK-NEXT:       scf.yield %inserted_slice : tensor<32x32xf32>
-# CHECK-NEXT:     } {"./i"}
-# CHECK-NEXT:     %c0_6 = arith.constant 0 : index
-# CHECK-NEXT:     %c32_7 = arith.constant 32 : index
-# CHECK-NEXT:     %c1_8 = arith.constant 1 : index
-# CHECK-NEXT:     %5 = scf.for %arg4 = %c0_6 to %c32_7 step %c1_8 iter_args(%arg5 = %4) -> (tensor<32x32xf32>) {
-# CHECK-NEXT:       %extracted_slice = tensor.extract_slice %arg2[%arg4, 0] [1, 4] [1, 1] : tensor<32x4xf32> to tensor<1x4xf32>
-# CHECK-NEXT:       %extracted_slice_9 = tensor.extract_slice %2[0, 0] [4, 32] [1, 1] : tensor<4x32xf32> to tensor<4x32xf32>
-# CHECK-NEXT:       %extracted_slice_10 = tensor.extract_slice %arg5[%arg4, 0] [1, 32] [1, 1] : tensor<32x32xf32> to tensor<1x32xf32>
-# CHECK-NEXT:       %c0_11 = arith.constant 0 : index
-# CHECK-NEXT:       %c32_12 = arith.constant 32 : index
-# CHECK-NEXT:       %c1_13 = arith.constant 1 : index
-# CHECK-NEXT:       %6 = scf.for %arg6 = %c0_11 to %c32_12 step %c1_13 iter_args(%arg7 = %extracted_slice_10) -> (tensor<1x32xf32>) {
-# CHECK-NEXT:         %extracted_slice_14 = tensor.extract_slice %extracted_slice[0, 0] [1, 4] [1, 1] : tensor<1x4xf32> to tensor<1x4xf32>
-# CHECK-NEXT:         %extracted_slice_15 = tensor.extract_slice %extracted_slice_9[0, %arg6] [4, 1] [1, 1] : tensor<4x32xf32> to tensor<4x1xf32>
-# CHECK-NEXT:         %extracted_slice_16 = tensor.extract_slice %arg7[0, %arg6] [1, 1] [1, 1] : tensor<1x32xf32> to tensor<1x1xf32>
-# CHECK-NEXT:         %c0_17 = arith.constant 0 : index
-# CHECK-NEXT:         %c4_18 = arith.constant 4 : index
-# CHECK-NEXT:         %c1_19 = arith.constant 1 : index
-# CHECK-NEXT:         %7 = scf.for %arg8 = %c0_17 to %c4_18 step %c1_19 iter_args(%arg9 = %extracted_slice_16) -> (tensor<1x1xf32>) {
-# CHECK-NEXT:           %extracted_slice_21 = tensor.extract_slice %extracted_slice_14[0, %arg8] [1, 1] [1, 1] : tensor<1x4xf32> to tensor<1x1xf32>
-# CHECK-NEXT:           %extracted_slice_22 = tensor.extract_slice %extracted_slice_15[%arg8, 0] [1, 1] [1, 1] : tensor<4x1xf32> to tensor<1x1xf32>
-# CHECK-NEXT:           %extracted_slice_23 = tensor.extract_slice %arg9[0, 0] [1, 1] [1, 1] : tensor<1x1xf32> to tensor<1x1xf32>
-# CHECK-NEXT:           %8 = linalg.matmul {__xtc_id_E_} ins(%extracted_slice_21, %extracted_slice_22 : tensor<1x1xf32>, tensor<1x1xf32>) outs(%extracted_slice_23 : tensor<1x1xf32>) -> tensor<1x1xf32>
-# CHECK-NEXT:           %inserted_slice_24 = tensor.insert_slice %8 into %arg9[0, 0] [1, 1] [1, 1] : tensor<1x1xf32> into tensor<1x1xf32>
-# CHECK-NEXT:           scf.yield %inserted_slice_24 : tensor<1x1xf32>
-# CHECK-NEXT:         } {"./k"}
-# CHECK-NEXT:         %inserted_slice_20 = tensor.insert_slice %7 into %arg7[0, %arg6] [1, 1] [1, 1] : tensor<1x1xf32> into tensor<1x32xf32>
-# CHECK-NEXT:         scf.yield %inserted_slice_20 : tensor<1x32xf32>
-# CHECK-NEXT:       } {"./j"}
-# CHECK-NEXT:       %inserted_slice = tensor.insert_slice %6 into %arg5[%arg4, 0] [1, 32] [1, 1] : tensor<1x32xf32> into tensor<32x32xf32>
-# CHECK-NEXT:       scf.yield %inserted_slice : tensor<32x32xf32>
-# CHECK-NEXT:     } {"./i"}
-# CHECK-NEXT:     bufferization.materialize_in_destination %5 in restrict writable %arg3 : (tensor<32x32xf32>, memref<32x32xf32>) -> ()
-# CHECK-NEXT:     return
-# CHECK-NEXT:   }
-# CHECK-NEXT:   transform.named_sequence @_vecto(%arg0: !transform.any_op {transform.consumed}) {
-# CHECK-NEXT:     transform.structured.vectorize %arg0 : !transform.any_op
-# CHECK-NEXT:     transform.yield 
-# CHECK-NEXT:   }
-# CHECK-NEXT:   transform.named_sequence @_post_bufferize(%arg0: !transform.any_op {transform.readonly}) {
-# CHECK-NEXT:     transform.yield 
-# CHECK-NEXT:   }
-# CHECK-NEXT: }
+# CHECK-NEXT:  // -----// IR Dump After transform //----- //
+# CHECK-NEXT:  module attributes {transform.with_named_sequence} {
+# CHECK-NEXT:    func.func @matmul(%arg0: tensor<4x512xf32> {llvm.noalias}, %arg1: tensor<512x32xf32> {llvm.noalias}, %arg2: tensor<32x4xf32> {llvm.noalias}, %arg3: memref<32x32xf32> {llvm.noalias}) {
+# CHECK-NEXT:      %0 = tensor.empty() : tensor<4x32xf32>
+# CHECK-NEXT:      %cst = arith.constant 0.000000e+00 : f32
+# CHECK-NEXT:      %1 = linalg.fill {__xtc_id_D_0_} ins(%cst : f32) outs(%0 : tensor<4x32xf32>) -> tensor<4x32xf32>
+# CHECK-NEXT:      %c0 = arith.constant 0 : index
+# CHECK-NEXT:      %c4 = arith.constant 4 : index
+# CHECK-NEXT:      %c1 = arith.constant 1 : index
+# CHECK-NEXT:      %2 = scf.for %arg4 = %c0 to %c4 step %c1 iter_args(%arg5 = %1) -> (tensor<4x32xf32>) {
+# CHECK-NEXT:        %extracted_slice = tensor.extract_slice %arg0[%arg4, 0] [1, 512] [1, 1] : tensor<4x512xf32> to tensor<1x512xf32>
+# CHECK-NEXT:        %extracted_slice_3 = tensor.extract_slice %arg1[0, 0] [512, 32] [1, 1] : tensor<512x32xf32> to tensor<512x32xf32>
+# CHECK-NEXT:        %extracted_slice_4 = tensor.extract_slice %arg5[%arg4, 0] [1, 32] [1, 1] : tensor<4x32xf32> to tensor<1x32xf32>
+# CHECK-NEXT:        %c0_5 = arith.constant 0 : index
+# CHECK-NEXT:        %c32_6 = arith.constant 32 : index
+# CHECK-NEXT:        %c1_7 = arith.constant 1 : index
+# CHECK-NEXT:        %6 = scf.for %arg6 = %c0_5 to %c32_6 step %c1_7 iter_args(%arg7 = %extracted_slice_4) -> (tensor<1x32xf32>) {
+# CHECK-NEXT:          %extracted_slice_8 = tensor.extract_slice %extracted_slice[0, 0] [1, 512] [1, 1] : tensor<1x512xf32> to tensor<1x512xf32>
+# CHECK-NEXT:          %extracted_slice_9 = tensor.extract_slice %extracted_slice_3[0, %arg6] [512, 1] [1, 1] : tensor<512x32xf32> to tensor<512x1xf32>
+# CHECK-NEXT:          %extracted_slice_10 = tensor.extract_slice %arg7[0, %arg6] [1, 1] [1, 1] : tensor<1x32xf32> to tensor<1x1xf32>
+# CHECK-NEXT:          %c0_11 = arith.constant 0 : index
+# CHECK-NEXT:          %c512 = arith.constant 512 : index
+# CHECK-NEXT:          %c1_12 = arith.constant 1 : index
+# CHECK-NEXT:          %7 = scf.for %arg8 = %c0_11 to %c512 step %c1_12 iter_args(%arg9 = %extracted_slice_10) -> (tensor<1x1xf32>) {
+# CHECK-NEXT:            %extracted_slice_14 = tensor.extract_slice %extracted_slice_8[0, %arg8] [1, 1] [1, 1] : tensor<1x512xf32> to tensor<1x1xf32>
+# CHECK-NEXT:            %extracted_slice_15 = tensor.extract_slice %extracted_slice_9[%arg8, 0] [1, 1] [1, 1] : tensor<512x1xf32> to tensor<1x1xf32>
+# CHECK-NEXT:            %extracted_slice_16 = tensor.extract_slice %arg9[0, 0] [1, 1] [1, 1] : tensor<1x1xf32> to tensor<1x1xf32>
+# CHECK-NEXT:            %8 = linalg.matmul {__xtc_id_D_} ins(%extracted_slice_14, %extracted_slice_15 : tensor<1x1xf32>, tensor<1x1xf32>) outs(%extracted_slice_16 : tensor<1x1xf32>) -> tensor<1x1xf32>
+# CHECK-NEXT:            %inserted_slice_17 = tensor.insert_slice %8 into %arg9[0, 0] [1, 1] [1, 1] : tensor<1x1xf32> into tensor<1x1xf32>
+# CHECK-NEXT:            scf.yield %inserted_slice_17 : tensor<1x1xf32>
+# CHECK-NEXT:          } {"./k"}
+# CHECK-NEXT:          %inserted_slice_13 = tensor.insert_slice %7 into %arg7[0, %arg6] [1, 1] [1, 1] : tensor<1x1xf32> into tensor<1x32xf32>
+# CHECK-NEXT:          scf.yield %inserted_slice_13 : tensor<1x32xf32>
+# CHECK-NEXT:        } {"./j"}
+# CHECK-NEXT:        %inserted_slice = tensor.insert_slice %6 into %arg5[%arg4, 0] [1, 32] [1, 1] : tensor<1x32xf32> into tensor<4x32xf32>
+# CHECK-NEXT:        scf.yield %inserted_slice : tensor<4x32xf32>
+# CHECK-NEXT:      } {"./i"}
+# CHECK-NEXT:      %3 = tensor.empty() : tensor<32x32xf32>
+# CHECK-NEXT:      %cst_0 = arith.constant 0.000000e+00 : f32
+# CHECK-NEXT:      %4 = linalg.fill {__xtc_id_E_0_} ins(%cst_0 : f32) outs(%3 : tensor<32x32xf32>) -> tensor<32x32xf32>
+# CHECK-NEXT:      %c0_1 = arith.constant 0 : index
+# CHECK-NEXT:      %c32 = arith.constant 32 : index
+# CHECK-NEXT:      %c1_2 = arith.constant 1 : index
+# CHECK-NEXT:      %5 = scf.for %arg4 = %c0_1 to %c32 step %c1_2 iter_args(%arg5 = %4) -> (tensor<32x32xf32>) {
+# CHECK-NEXT:        %extracted_slice = tensor.extract_slice %arg2[%arg4, 0] [1, 4] [1, 1] : tensor<32x4xf32> to tensor<1x4xf32>
+# CHECK-NEXT:        %extracted_slice_3 = tensor.extract_slice %2[0, 0] [4, 32] [1, 1] : tensor<4x32xf32> to tensor<4x32xf32>
+# CHECK-NEXT:        %extracted_slice_4 = tensor.extract_slice %arg5[%arg4, 0] [1, 32] [1, 1] : tensor<32x32xf32> to tensor<1x32xf32>
+# CHECK-NEXT:        %c0_5 = arith.constant 0 : index
+# CHECK-NEXT:        %c32_6 = arith.constant 32 : index
+# CHECK-NEXT:        %c1_7 = arith.constant 1 : index
+# CHECK-NEXT:        %6 = scf.for %arg6 = %c0_5 to %c32_6 step %c1_7 iter_args(%arg7 = %extracted_slice_4) -> (tensor<1x32xf32>) {
+# CHECK-NEXT:          %extracted_slice_8 = tensor.extract_slice %extracted_slice[0, 0] [1, 4] [1, 1] : tensor<1x4xf32> to tensor<1x4xf32>
+# CHECK-NEXT:          %extracted_slice_9 = tensor.extract_slice %extracted_slice_3[0, %arg6] [4, 1] [1, 1] : tensor<4x32xf32> to tensor<4x1xf32>
+# CHECK-NEXT:          %extracted_slice_10 = tensor.extract_slice %arg7[0, %arg6] [1, 1] [1, 1] : tensor<1x32xf32> to tensor<1x1xf32>
+# CHECK-NEXT:          %c0_11 = arith.constant 0 : index
+# CHECK-NEXT:          %c4_12 = arith.constant 4 : index
+# CHECK-NEXT:          %c1_13 = arith.constant 1 : index
+# CHECK-NEXT:          %7 = scf.for %arg8 = %c0_11 to %c4_12 step %c1_13 iter_args(%arg9 = %extracted_slice_10) -> (tensor<1x1xf32>) {
+# CHECK-NEXT:            %extracted_slice_15 = tensor.extract_slice %extracted_slice_8[0, %arg8] [1, 1] [1, 1] : tensor<1x4xf32> to tensor<1x1xf32>
+# CHECK-NEXT:            %extracted_slice_16 = tensor.extract_slice %extracted_slice_9[%arg8, 0] [1, 1] [1, 1] : tensor<4x1xf32> to tensor<1x1xf32>
+# CHECK-NEXT:            %extracted_slice_17 = tensor.extract_slice %arg9[0, 0] [1, 1] [1, 1] : tensor<1x1xf32> to tensor<1x1xf32>
+# CHECK-NEXT:            %8 = linalg.matmul {__xtc_id_E_} ins(%extracted_slice_15, %extracted_slice_16 : tensor<1x1xf32>, tensor<1x1xf32>) outs(%extracted_slice_17 : tensor<1x1xf32>) -> tensor<1x1xf32>
+# CHECK-NEXT:            %inserted_slice_18 = tensor.insert_slice %8 into %arg9[0, 0] [1, 1] [1, 1] : tensor<1x1xf32> into tensor<1x1xf32>
+# CHECK-NEXT:            scf.yield %inserted_slice_18 : tensor<1x1xf32>
+# CHECK-NEXT:          } {"./k"}
+# CHECK-NEXT:          %inserted_slice_14 = tensor.insert_slice %7 into %arg7[0, %arg6] [1, 1] [1, 1] : tensor<1x1xf32> into tensor<1x32xf32>
+# CHECK-NEXT:          scf.yield %inserted_slice_14 : tensor<1x32xf32>
+# CHECK-NEXT:        } {"./j"}
+# CHECK-NEXT:        %inserted_slice = tensor.insert_slice %6 into %arg5[%arg4, 0] [1, 32] [1, 1] : tensor<1x32xf32> into tensor<32x32xf32>
+# CHECK-NEXT:        scf.yield %inserted_slice : tensor<32x32xf32>
+# CHECK-NEXT:      } {"./i"}
+# CHECK-NEXT:      bufferization.materialize_in_destination %5 in restrict writable %arg3 : (tensor<32x32xf32>, memref<32x32xf32>) -> ()
+# CHECK-NEXT:      return
+# CHECK-NEXT:    }
+# CHECK-NEXT:    transform.named_sequence @_vecto(%arg0: !transform.any_op {transform.consumed}) {
+# CHECK-NEXT:      transform.structured.vectorize %arg0 : !transform.any_op
+# CHECK-NEXT:      transform.yield 
+# CHECK-NEXT:    }
+# CHECK-NEXT:    transform.named_sequence @_post_bufferize(%arg0: !transform.any_op {transform.readonly}) {
+# CHECK-NEXT:      transform.yield 
+# CHECK-NEXT:    }
+# CHECK-NEXT:  }
 # CHECK-NEXT:  
-# CHECK-NEXT: // -----// IR Dump After Tensor Lowering //----- //
-# CHECK-NEXT: module attributes {transform.with_named_sequence} {
-# CHECK-NEXT:   func.func @matmul(%arg0: memref<4x512xf32> {llvm.noalias}, %arg1: memref<512x32xf32> {llvm.noalias}, %arg2: memref<32x4xf32> {llvm.noalias}, %arg3: memref<32x32xf32> {llvm.noalias}) {
-# CHECK-NEXT:     %c512 = arith.constant 512 : index
-# CHECK-NEXT:     %c32 = arith.constant 32 : index
-# CHECK-NEXT:     %c1 = arith.constant 1 : index
-# CHECK-NEXT:     %c4 = arith.constant 4 : index
-# CHECK-NEXT:     %c0 = arith.constant 0 : index
-# CHECK-NEXT:     %cst = arith.constant 0.000000e+00 : f32
-# CHECK-NEXT:     %alloca = memref.alloca() {alignment = 256 : i64} : memref<4x32xf32>
-# CHECK-NEXT:     %0 = scf.for %arg4 = %c0 to %c4 step %c1 iter_args(%arg5 = %alloca) -> (memref<4x32xf32>) {
-# CHECK-NEXT:       %subview = memref.subview %arg5[%arg4, 0] [1, 32] [1, 1] : memref<4x32xf32> to memref<1x32xf32, strided<[32, 1], offset: ?>>
-# CHECK-NEXT:       %4 = scf.for %arg6 = %c0 to %c32 step %c1 iter_args(%arg7 = %subview) -> (memref<1x32xf32, strided<[32, 1], offset: ?>>) {
-# CHECK-NEXT:         %subview_1 = memref.subview %arg7[0, %arg6] [1, 1] [1, 1] : memref<1x32xf32, strided<[32, 1], offset: ?>> to memref<1x1xf32, strided<[32, 1], offset: ?>>
-# CHECK-NEXT:         linalg.fill {__xtc_id_D_0_} ins(%cst : f32) outs(%subview_1 : memref<1x1xf32, strided<[32, 1], offset: ?>>)
-# CHECK-NEXT:         %subview_2 = memref.subview %arg7[0, %arg6] [1, 1] [1, 1] : memref<1x32xf32, strided<[32, 1], offset: ?>> to memref<1x1xf32, strided<[32, 1], offset: ?>>
-# CHECK-NEXT:         memref.copy %subview_1, %subview_2 : memref<1x1xf32, strided<[32, 1], offset: ?>> to memref<1x1xf32, strided<[32, 1], offset: ?>>
-# CHECK-NEXT:         scf.yield %arg7 : memref<1x32xf32, strided<[32, 1], offset: ?>>
-# CHECK-NEXT:       } {"./j"}
-# CHECK-NEXT:       %subview_0 = memref.subview %arg5[%arg4, 0] [1, 32] [1, 1] : memref<4x32xf32> to memref<1x32xf32, strided<[32, 1], offset: ?>>
-# CHECK-NEXT:       memref.copy %4, %subview_0 : memref<1x32xf32, strided<[32, 1], offset: ?>> to memref<1x32xf32, strided<[32, 1], offset: ?>>
-# CHECK-NEXT:       scf.yield %arg5 : memref<4x32xf32>
-# CHECK-NEXT:     } {"./i"}
-# CHECK-NEXT:     %1 = scf.for %arg4 = %c0 to %c4 step %c1 iter_args(%arg5 = %0) -> (memref<4x32xf32>) {
-# CHECK-NEXT:       %subview = memref.subview %arg0[%arg4, 0] [1, 512] [1, 1] : memref<4x512xf32> to memref<1x512xf32, strided<[512, 1], offset: ?>>
-# CHECK-NEXT:       %subview_0 = memref.subview %arg5[%arg4, 0] [1, 32] [1, 1] : memref<4x32xf32> to memref<1x32xf32, strided<[32, 1], offset: ?>>
-# CHECK-NEXT:       %4 = scf.for %arg6 = %c0 to %c32 step %c1 iter_args(%arg7 = %subview_0) -> (memref<1x32xf32, strided<[32, 1], offset: ?>>) {
-# CHECK-NEXT:         %subview_2 = memref.subview %arg1[0, %arg6] [512, 1] [1, 1] : memref<512x32xf32> to memref<512x1xf32, strided<[32, 1], offset: ?>>
-# CHECK-NEXT:         %subview_3 = memref.subview %arg7[0, %arg6] [1, 1] [1, 1] : memref<1x32xf32, strided<[32, 1], offset: ?>> to memref<1x1xf32, strided<[32, 1], offset: ?>>
-# CHECK-NEXT:         %5 = scf.for %arg8 = %c0 to %c512 step %c1 iter_args(%arg9 = %subview_3) -> (memref<1x1xf32, strided<[32, 1], offset: ?>>) {
-# CHECK-NEXT:           %subview_5 = memref.subview %subview[0, %arg8] [1, 1] [1, 1] : memref<1x512xf32, strided<[512, 1], offset: ?>> to memref<1x1xf32, strided<[512, 1], offset: ?>>
-# CHECK-NEXT:           %subview_6 = memref.subview %subview_2[%arg8, 0] [1, 1] [1, 1] : memref<512x1xf32, strided<[32, 1], offset: ?>> to memref<1x1xf32, strided<[32, 1], offset: ?>>
-# CHECK-NEXT:           linalg.matmul {__xtc_id_D_} ins(%subview_5, %subview_6 : memref<1x1xf32, strided<[512, 1], offset: ?>>, memref<1x1xf32, strided<[32, 1], offset: ?>>) outs(%arg9 : memref<1x1xf32, strided<[32, 1], offset: ?>>)
-# CHECK-NEXT:           scf.yield %arg9 : memref<1x1xf32, strided<[32, 1], offset: ?>>
-# CHECK-NEXT:         } {"./k"}
-# CHECK-NEXT:         %subview_4 = memref.subview %arg7[0, %arg6] [1, 1] [1, 1] : memref<1x32xf32, strided<[32, 1], offset: ?>> to memref<1x1xf32, strided<[32, 1], offset: ?>>
-# CHECK-NEXT:         memref.copy %5, %subview_4 : memref<1x1xf32, strided<[32, 1], offset: ?>> to memref<1x1xf32, strided<[32, 1], offset: ?>>
-# CHECK-NEXT:         scf.yield %arg7 : memref<1x32xf32, strided<[32, 1], offset: ?>>
-# CHECK-NEXT:       } {"./j"}
-# CHECK-NEXT:       %subview_1 = memref.subview %arg5[%arg4, 0] [1, 32] [1, 1] : memref<4x32xf32> to memref<1x32xf32, strided<[32, 1], offset: ?>>
-# CHECK-NEXT:       memref.copy %4, %subview_1 : memref<1x32xf32, strided<[32, 1], offset: ?>> to memref<1x32xf32, strided<[32, 1], offset: ?>>
-# CHECK-NEXT:       scf.yield %arg5 : memref<4x32xf32>
-# CHECK-NEXT:     } {"./i"}
-# CHECK-NEXT:     %2 = scf.for %arg4 = %c0 to %c32 step %c1 iter_args(%arg5 = %arg3) -> (memref<32x32xf32>) {
-# CHECK-NEXT:       %subview = memref.subview %arg5[%arg4, 0] [1, 32] [1, 1] : memref<32x32xf32> to memref<1x32xf32, strided<[32, 1], offset: ?>>
-# CHECK-NEXT:       %4 = scf.for %arg6 = %c0 to %c32 step %c1 iter_args(%arg7 = %subview) -> (memref<1x32xf32, strided<[32, 1], offset: ?>>) {
-# CHECK-NEXT:         %subview_1 = memref.subview %arg7[0, %arg6] [1, 1] [1, 1] : memref<1x32xf32, strided<[32, 1], offset: ?>> to memref<1x1xf32, strided<[32, 1], offset: ?>>
-# CHECK-NEXT:         linalg.fill {__xtc_id_E_0_} ins(%cst : f32) outs(%subview_1 : memref<1x1xf32, strided<[32, 1], offset: ?>>)
-# CHECK-NEXT:         %subview_2 = memref.subview %arg7[0, %arg6] [1, 1] [1, 1] : memref<1x32xf32, strided<[32, 1], offset: ?>> to memref<1x1xf32, strided<[32, 1], offset: ?>>
-# CHECK-NEXT:         memref.copy %subview_1, %subview_2 : memref<1x1xf32, strided<[32, 1], offset: ?>> to memref<1x1xf32, strided<[32, 1], offset: ?>>
-# CHECK-NEXT:         scf.yield %arg7 : memref<1x32xf32, strided<[32, 1], offset: ?>>
-# CHECK-NEXT:       } {"./j"}
-# CHECK-NEXT:       %subview_0 = memref.subview %arg5[%arg4, 0] [1, 32] [1, 1] : memref<32x32xf32> to memref<1x32xf32, strided<[32, 1], offset: ?>>
-# CHECK-NEXT:       memref.copy %4, %subview_0 : memref<1x32xf32, strided<[32, 1], offset: ?>> to memref<1x32xf32, strided<[32, 1], offset: ?>>
-# CHECK-NEXT:       scf.yield %arg5 : memref<32x32xf32>
-# CHECK-NEXT:     } {"./i"}
-# CHECK-NEXT:     %3 = scf.for %arg4 = %c0 to %c32 step %c1 iter_args(%arg5 = %2) -> (memref<32x32xf32>) {
-# CHECK-NEXT:       %subview = memref.subview %arg2[%arg4, 0] [1, 4] [1, 1] : memref<32x4xf32> to memref<1x4xf32, strided<[4, 1], offset: ?>>
-# CHECK-NEXT:       %subview_0 = memref.subview %arg5[%arg4, 0] [1, 32] [1, 1] : memref<32x32xf32> to memref<1x32xf32, strided<[32, 1], offset: ?>>
-# CHECK-NEXT:       %4 = scf.for %arg6 = %c0 to %c32 step %c1 iter_args(%arg7 = %subview_0) -> (memref<1x32xf32, strided<[32, 1], offset: ?>>) {
-# CHECK-NEXT:         %subview_2 = memref.subview %1[0, %arg6] [4, 1] [1, 1] : memref<4x32xf32> to memref<4x1xf32, strided<[32, 1], offset: ?>>
-# CHECK-NEXT:         %subview_3 = memref.subview %arg7[0, %arg6] [1, 1] [1, 1] : memref<1x32xf32, strided<[32, 1], offset: ?>> to memref<1x1xf32, strided<[32, 1], offset: ?>>
-# CHECK-NEXT:         %5 = scf.for %arg8 = %c0 to %c4 step %c1 iter_args(%arg9 = %subview_3) -> (memref<1x1xf32, strided<[32, 1], offset: ?>>) {
-# CHECK-NEXT:           %subview_5 = memref.subview %subview[0, %arg8] [1, 1] [1, 1] : memref<1x4xf32, strided<[4, 1], offset: ?>> to memref<1x1xf32, strided<[4, 1], offset: ?>>
-# CHECK-NEXT:           %subview_6 = memref.subview %subview_2[%arg8, 0] [1, 1] [1, 1] : memref<4x1xf32, strided<[32, 1], offset: ?>> to memref<1x1xf32, strided<[32, 1], offset: ?>>
-# CHECK-NEXT:           linalg.matmul {__xtc_id_E_} ins(%subview_5, %subview_6 : memref<1x1xf32, strided<[4, 1], offset: ?>>, memref<1x1xf32, strided<[32, 1], offset: ?>>) outs(%arg9 : memref<1x1xf32, strided<[32, 1], offset: ?>>)
-# CHECK-NEXT:           scf.yield %arg9 : memref<1x1xf32, strided<[32, 1], offset: ?>>
-# CHECK-NEXT:         } {"./k"}
-# CHECK-NEXT:         %subview_4 = memref.subview %arg7[0, %arg6] [1, 1] [1, 1] : memref<1x32xf32, strided<[32, 1], offset: ?>> to memref<1x1xf32, strided<[32, 1], offset: ?>>
-# CHECK-NEXT:         memref.copy %5, %subview_4 : memref<1x1xf32, strided<[32, 1], offset: ?>> to memref<1x1xf32, strided<[32, 1], offset: ?>>
-# CHECK-NEXT:         scf.yield %arg7 : memref<1x32xf32, strided<[32, 1], offset: ?>>
-# CHECK-NEXT:       } {"./j"}
-# CHECK-NEXT:       %subview_1 = memref.subview %arg5[%arg4, 0] [1, 32] [1, 1] : memref<32x32xf32> to memref<1x32xf32, strided<[32, 1], offset: ?>>
-# CHECK-NEXT:       memref.copy %4, %subview_1 : memref<1x32xf32, strided<[32, 1], offset: ?>> to memref<1x32xf32, strided<[32, 1], offset: ?>>
-# CHECK-NEXT:       scf.yield %arg5 : memref<32x32xf32>
-# CHECK-NEXT:     } {"./i"}
-# CHECK-NEXT:     memref.copy %3, %arg3 : memref<32x32xf32> to memref<32x32xf32>
-# CHECK-NEXT:     return
-# CHECK-NEXT:   }
-# CHECK-NEXT: }
+# CHECK-NEXT:  // -----// IR Dump After Tensor Lowering //----- //
+# CHECK-NEXT:  module attributes {transform.with_named_sequence} {
+# CHECK-NEXT:    func.func @matmul(%arg0: memref<4x512xf32> {llvm.noalias}, %arg1: memref<512x32xf32> {llvm.noalias}, %arg2: memref<32x4xf32> {llvm.noalias}, %arg3: memref<32x32xf32> {llvm.noalias}) {
+# CHECK-NEXT:      %c512 = arith.constant 512 : index
+# CHECK-NEXT:      %c32 = arith.constant 32 : index
+# CHECK-NEXT:      %c1 = arith.constant 1 : index
+# CHECK-NEXT:      %c4 = arith.constant 4 : index
+# CHECK-NEXT:      %c0 = arith.constant 0 : index
+# CHECK-NEXT:      %cst = arith.constant 0.000000e+00 : f32
+# CHECK-NEXT:      %alloca = memref.alloca() {alignment = 256 : i64} : memref<4x32xf32>
+# CHECK-NEXT:      linalg.fill {__xtc_id_D_0_} ins(%cst : f32) outs(%alloca : memref<4x32xf32>)
+# CHECK-NEXT:      %0 = scf.for %arg4 = %c0 to %c4 step %c1 iter_args(%arg5 = %alloca) -> (memref<4x32xf32>) {
+# CHECK-NEXT:        %subview = memref.subview %arg0[%arg4, 0] [1, 512] [1, 1] : memref<4x512xf32> to memref<1x512xf32, strided<[512, 1], offset: ?>>
+# CHECK-NEXT:        %subview_0 = memref.subview %arg5[%arg4, 0] [1, 32] [1, 1] : memref<4x32xf32> to memref<1x32xf32, strided<[32, 1], offset: ?>>
+# CHECK-NEXT:        %2 = scf.for %arg6 = %c0 to %c32 step %c1 iter_args(%arg7 = %subview_0) -> (memref<1x32xf32, strided<[32, 1], offset: ?>>) {
+# CHECK-NEXT:          %subview_2 = memref.subview %arg1[0, %arg6] [512, 1] [1, 1] : memref<512x32xf32> to memref<512x1xf32, strided<[32, 1], offset: ?>>
+# CHECK-NEXT:          %subview_3 = memref.subview %arg7[0, %arg6] [1, 1] [1, 1] : memref<1x32xf32, strided<[32, 1], offset: ?>> to memref<1x1xf32, strided<[32, 1], offset: ?>>
+# CHECK-NEXT:          %3 = scf.for %arg8 = %c0 to %c512 step %c1 iter_args(%arg9 = %subview_3) -> (memref<1x1xf32, strided<[32, 1], offset: ?>>) {
+# CHECK-NEXT:            %subview_5 = memref.subview %subview[0, %arg8] [1, 1] [1, 1] : memref<1x512xf32, strided<[512, 1], offset: ?>> to memref<1x1xf32, strided<[512, 1], offset: ?>>
+# CHECK-NEXT:            %subview_6 = memref.subview %subview_2[%arg8, 0] [1, 1] [1, 1] : memref<512x1xf32, strided<[32, 1], offset: ?>> to memref<1x1xf32, strided<[32, 1], offset: ?>>
+# CHECK-NEXT:            linalg.matmul {__xtc_id_D_} ins(%subview_5, %subview_6 : memref<1x1xf32, strided<[512, 1], offset: ?>>, memref<1x1xf32, strided<[32, 1], offset: ?>>) outs(%arg9 : memref<1x1xf32, strided<[32, 1], offset: ?>>)
+# CHECK-NEXT:            scf.yield %arg9 : memref<1x1xf32, strided<[32, 1], offset: ?>>
+# CHECK-NEXT:          } {"./k"}
+# CHECK-NEXT:          %subview_4 = memref.subview %arg7[0, %arg6] [1, 1] [1, 1] : memref<1x32xf32, strided<[32, 1], offset: ?>> to memref<1x1xf32, strided<[32, 1], offset: ?>>
+# CHECK-NEXT:          memref.copy %3, %subview_4 : memref<1x1xf32, strided<[32, 1], offset: ?>> to memref<1x1xf32, strided<[32, 1], offset: ?>>
+# CHECK-NEXT:          scf.yield %arg7 : memref<1x32xf32, strided<[32, 1], offset: ?>>
+# CHECK-NEXT:        } {"./j"}
+# CHECK-NEXT:        %subview_1 = memref.subview %arg5[%arg4, 0] [1, 32] [1, 1] : memref<4x32xf32> to memref<1x32xf32, strided<[32, 1], offset: ?>>
+# CHECK-NEXT:        memref.copy %2, %subview_1 : memref<1x32xf32, strided<[32, 1], offset: ?>> to memref<1x32xf32, strided<[32, 1], offset: ?>>
+# CHECK-NEXT:        scf.yield %arg5 : memref<4x32xf32>
+# CHECK-NEXT:      } {"./i"}
+# CHECK-NEXT:      linalg.fill {__xtc_id_E_0_} ins(%cst : f32) outs(%arg3 : memref<32x32xf32>)
+# CHECK-NEXT:      %1 = scf.for %arg4 = %c0 to %c32 step %c1 iter_args(%arg5 = %arg3) -> (memref<32x32xf32>) {
+# CHECK-NEXT:        %subview = memref.subview %arg2[%arg4, 0] [1, 4] [1, 1] : memref<32x4xf32> to memref<1x4xf32, strided<[4, 1], offset: ?>>
+# CHECK-NEXT:        %subview_0 = memref.subview %arg5[%arg4, 0] [1, 32] [1, 1] : memref<32x32xf32> to memref<1x32xf32, strided<[32, 1], offset: ?>>
+# CHECK-NEXT:        %2 = scf.for %arg6 = %c0 to %c32 step %c1 iter_args(%arg7 = %subview_0) -> (memref<1x32xf32, strided<[32, 1], offset: ?>>) {
+# CHECK-NEXT:          %subview_2 = memref.subview %0[0, %arg6] [4, 1] [1, 1] : memref<4x32xf32> to memref<4x1xf32, strided<[32, 1], offset: ?>>
+# CHECK-NEXT:          %subview_3 = memref.subview %arg7[0, %arg6] [1, 1] [1, 1] : memref<1x32xf32, strided<[32, 1], offset: ?>> to memref<1x1xf32, strided<[32, 1], offset: ?>>
+# CHECK-NEXT:          %3 = scf.for %arg8 = %c0 to %c4 step %c1 iter_args(%arg9 = %subview_3) -> (memref<1x1xf32, strided<[32, 1], offset: ?>>) {
+# CHECK-NEXT:            %subview_5 = memref.subview %subview[0, %arg8] [1, 1] [1, 1] : memref<1x4xf32, strided<[4, 1], offset: ?>> to memref<1x1xf32, strided<[4, 1], offset: ?>>
+# CHECK-NEXT:            %subview_6 = memref.subview %subview_2[%arg8, 0] [1, 1] [1, 1] : memref<4x1xf32, strided<[32, 1], offset: ?>> to memref<1x1xf32, strided<[32, 1], offset: ?>>
+# CHECK-NEXT:            linalg.matmul {__xtc_id_E_} ins(%subview_5, %subview_6 : memref<1x1xf32, strided<[4, 1], offset: ?>>, memref<1x1xf32, strided<[32, 1], offset: ?>>) outs(%arg9 : memref<1x1xf32, strided<[32, 1], offset: ?>>)
+# CHECK-NEXT:            scf.yield %arg9 : memref<1x1xf32, strided<[32, 1], offset: ?>>
+# CHECK-NEXT:          } {"./k"}
+# CHECK-NEXT:          %subview_4 = memref.subview %arg7[0, %arg6] [1, 1] [1, 1] : memref<1x32xf32, strided<[32, 1], offset: ?>> to memref<1x1xf32, strided<[32, 1], offset: ?>>
+# CHECK-NEXT:          memref.copy %3, %subview_4 : memref<1x1xf32, strided<[32, 1], offset: ?>> to memref<1x1xf32, strided<[32, 1], offset: ?>>
+# CHECK-NEXT:          scf.yield %arg7 : memref<1x32xf32, strided<[32, 1], offset: ?>>
+# CHECK-NEXT:        } {"./j"}
+# CHECK-NEXT:        %subview_1 = memref.subview %arg5[%arg4, 0] [1, 32] [1, 1] : memref<32x32xf32> to memref<1x32xf32, strided<[32, 1], offset: ?>>
+# CHECK-NEXT:        memref.copy %2, %subview_1 : memref<1x32xf32, strided<[32, 1], offset: ?>> to memref<1x32xf32, strided<[32, 1], offset: ?>>
+# CHECK-NEXT:        scf.yield %arg5 : memref<32x32xf32>
+# CHECK-NEXT:      } {"./i"}
+# CHECK-NEXT:      memref.copy %1, %arg3 : memref<32x32xf32> to memref<32x32xf32>
+# CHECK-NEXT:      return
+# CHECK-NEXT:    }
+# CHECK-NEXT:  }
 # CHECK-NEXT:  
-# CHECK-NEXT: graph:
-# CHECK-NEXT:   name: matmul
-# CHECK-NEXT:   inputs:
-# CHECK-NEXT:   - %0 : 4x512xfloat32
-# CHECK-NEXT:   - %1 : 512x32xfloat32
-# CHECK-NEXT:   - %2 : 32x4xfloat32
-# CHECK-NEXT:   outputs:
-# CHECK-NEXT:   - %4 : 32x32xfloat32
-# CHECK-NEXT:   nodes:
-# CHECK-NEXT:   - %3: matmul(%0, %1) {name = 'D'} : [4x512xfloat32, 512x32xfloat32] -> [4x32xfloat32]
-# CHECK-NEXT:   - %4: matmul(%2, %3) {name = 'E'} : [32x4xfloat32, 4x32xfloat32] -> [32x32xfloat32]
+# CHECK-NEXT:  graph:
+# CHECK-NEXT:    name: matmul
+# CHECK-NEXT:    inputs:
+# CHECK-NEXT:    - %0 : 4x512xfloat32
+# CHECK-NEXT:    - %1 : 512x32xfloat32
+# CHECK-NEXT:    - %2 : 32x4xfloat32
+# CHECK-NEXT:    outputs:
+# CHECK-NEXT:    - %4 : 32x32xfloat32
+# CHECK-NEXT:    nodes:
+# CHECK-NEXT:    - %3: matmul(%0, %1) {name = 'D'} : [4x512xfloat32, 512x32xfloat32] -> [4x32xfloat32]
+# CHECK-NEXT:    - %4: matmul(%2, %3) {name = 'E'} : [32x4xfloat32, 4x32xfloat32] -> [32x32xfloat32]
 # CHECK-NEXT:  
-# CHECK-NEXT: CODE: 0
+# CHECK-NEXT:  CODE: 0

--- a/tests/filecheck/backends/test_conv2d_mini_mlir.py
+++ b/tests/filecheck/backends/test_conv2d_mini_mlir.py
@@ -51,30 +51,21 @@ print(f"CODE: {res}")
 # CHECK-NEXT:      transform.yield 
 # CHECK-NEXT:    }
 # CHECK-NEXT:    transform.named_sequence @__transform_main(%arg0: !transform.any_op {transform.readonly}) {
-# CHECK-NEXT:      %0 = transform.structured.match attributes {__xtc_id_O_0_} in %arg0 : (!transform.any_op) -> !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op, %loops = transform.structured.tile_using_for %0 tile_sizes [1, 0, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      %0 = transform.structured.match attributes {__xtc_id_O_} in %arg0 : (!transform.any_op) -> !transform.any_op
+# CHECK-NEXT:      %tiled_linalg_op, %loops = transform.structured.tile_using_for %0 tile_sizes [1, 0, 0, 0, 0, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
 # CHECK-NEXT:      transform.annotate %loops "./b" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_0, %loops_1 = transform.structured.tile_using_for %tiled_linalg_op tile_sizes [0, 1, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      %tiled_linalg_op_0, %loops_1 = transform.structured.tile_using_for %tiled_linalg_op tile_sizes [0, 1, 0, 0, 0, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
 # CHECK-NEXT:      transform.annotate %loops_1 "./h" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_2, %loops_3 = transform.structured.tile_using_for %tiled_linalg_op_0 tile_sizes [0, 0, 1, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      %tiled_linalg_op_2, %loops_3 = transform.structured.tile_using_for %tiled_linalg_op_0 tile_sizes [0, 0, 1, 0, 0, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
 # CHECK-NEXT:      transform.annotate %loops_3 "./w" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_4, %loops_5 = transform.structured.tile_using_for %tiled_linalg_op_2 tile_sizes [0, 0, 0, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      %tiled_linalg_op_4, %loops_5 = transform.structured.tile_using_for %tiled_linalg_op_2 tile_sizes [0, 0, 0, 1, 0, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
 # CHECK-NEXT:      transform.annotate %loops_5 "./f" : !transform.any_op
-# CHECK-NEXT:      %1 = transform.structured.match attributes {__xtc_id_O_} in %arg0 : (!transform.any_op) -> !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_6, %loops_7 = transform.structured.tile_using_for %1 tile_sizes [1, 0, 0, 0, 0, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_7 "./b" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_8, %loops_9 = transform.structured.tile_using_for %tiled_linalg_op_6 tile_sizes [0, 1, 0, 0, 0, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_9 "./h" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_10, %loops_11 = transform.structured.tile_using_for %tiled_linalg_op_8 tile_sizes [0, 0, 1, 0, 0, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_11 "./w" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_12, %loops_13 = transform.structured.tile_using_for %tiled_linalg_op_10 tile_sizes [0, 0, 0, 1, 0, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_13 "./f" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_14, %loops_15 = transform.structured.tile_using_for %tiled_linalg_op_12 tile_sizes [0, 0, 0, 0, 1, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_15 "./r" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_16, %loops_17 = transform.structured.tile_using_for %tiled_linalg_op_14 tile_sizes [0, 0, 0, 0, 0, 1, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_17 "./s" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_18, %loops_19 = transform.structured.tile_using_for %tiled_linalg_op_16 tile_sizes [0, 0, 0, 0, 0, 0, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_19 "./c" : !transform.any_op
+# CHECK-NEXT:      %tiled_linalg_op_6, %loops_7 = transform.structured.tile_using_for %tiled_linalg_op_4 tile_sizes [0, 0, 0, 0, 1, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      transform.annotate %loops_7 "./r" : !transform.any_op
+# CHECK-NEXT:      %tiled_linalg_op_8, %loops_9 = transform.structured.tile_using_for %tiled_linalg_op_6 tile_sizes [0, 0, 0, 0, 0, 1, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      transform.annotate %loops_9 "./s" : !transform.any_op
+# CHECK-NEXT:      %tiled_linalg_op_10, %loops_11 = transform.structured.tile_using_for %tiled_linalg_op_8 tile_sizes [0, 0, 0, 0, 0, 0, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      transform.annotate %loops_11 "./c" : !transform.any_op
 # CHECK-NEXT:      transform.yield 
 # CHECK-NEXT:    }
 # CHECK-NEXT:  }
@@ -86,83 +77,59 @@ print(f"CODE: {res}")
 # CHECK-NEXT:  module attributes {transform.with_named_sequence} {
 # CHECK-NEXT:    func.func @conv2d_nhwc_mini(%arg0: memref<1x10x10x3xf32> {llvm.noalias}, %arg1: memref<3x3x3x16xf32> {llvm.noalias}, %arg2: memref<1x8x8x16xf32> {llvm.noalias}) {
 # CHECK-NEXT:      %cst = arith.constant 0.000000e+00 : f32
+# CHECK-NEXT:      linalg.fill {__xtc_id_O_0_} ins(%cst : f32) outs(%arg2 : memref<1x8x8x16xf32>)
 # CHECK-NEXT:      %c0 = arith.constant 0 : index
 # CHECK-NEXT:      %c1 = arith.constant 1 : index
 # CHECK-NEXT:      %c1_0 = arith.constant 1 : index
 # CHECK-NEXT:      scf.for %arg3 = %c0 to %c1 step %c1_0 {
-# CHECK-NEXT:        %subview = memref.subview %arg2[%arg3, 0, 0, 0] [1, 8, 8, 16] [1, 1, 1, 1] : memref<1x8x8x16xf32> to memref<1x8x8x16xf32, strided<[1024, 128, 16, 1], offset: ?>>
-# CHECK-NEXT:        %c0_4 = arith.constant 0 : index
-# CHECK-NEXT:        %c8 = arith.constant 8 : index
-# CHECK-NEXT:        %c1_5 = arith.constant 1 : index
-# CHECK-NEXT:        scf.for %arg4 = %c0_4 to %c8 step %c1_5 {
-# CHECK-NEXT:          %subview_6 = memref.subview %subview[0, %arg4, 0, 0] [1, 1, 8, 16] [1, 1, 1, 1] : memref<1x8x8x16xf32, strided<[1024, 128, 16, 1], offset: ?>> to memref<1x1x8x16xf32, strided<[1024, 128, 16, 1], offset: ?>>
-# CHECK-NEXT:          %c0_7 = arith.constant 0 : index
-# CHECK-NEXT:          %c8_8 = arith.constant 8 : index
-# CHECK-NEXT:          %c1_9 = arith.constant 1 : index
-# CHECK-NEXT:          scf.for %arg5 = %c0_7 to %c8_8 step %c1_9 {
-# CHECK-NEXT:            %subview_10 = memref.subview %subview_6[0, 0, %arg5, 0] [1, 1, 1, 16] [1, 1, 1, 1] : memref<1x1x8x16xf32, strided<[1024, 128, 16, 1], offset: ?>> to memref<1x1x1x16xf32, strided<[1024, 128, 16, 1], offset: ?>>
-# CHECK-NEXT:            %c0_11 = arith.constant 0 : index
-# CHECK-NEXT:            %c16 = arith.constant 16 : index
-# CHECK-NEXT:            %c1_12 = arith.constant 1 : index
-# CHECK-NEXT:            scf.for %arg6 = %c0_11 to %c16 step %c1_12 {
-# CHECK-NEXT:              %subview_13 = memref.subview %subview_10[0, 0, 0, %arg6] [1, 1, 1, 1] [1, 1, 1, 1] : memref<1x1x1x16xf32, strided<[1024, 128, 16, 1], offset: ?>> to memref<1x1x1x1xf32, strided<[1024, 128, 16, 1], offset: ?>>
-# CHECK-NEXT:              linalg.fill {__xtc_id_O_0_} ins(%cst : f32) outs(%subview_13 : memref<1x1x1x1xf32, strided<[1024, 128, 16, 1], offset: ?>>)
-# CHECK-NEXT:            } {"./f"}
-# CHECK-NEXT:          } {"./w"}
-# CHECK-NEXT:        } {"./h"}
-# CHECK-NEXT:      } {"./b"}
-# CHECK-NEXT:      %c0_1 = arith.constant 0 : index
-# CHECK-NEXT:      %c1_2 = arith.constant 1 : index
-# CHECK-NEXT:      %c1_3 = arith.constant 1 : index
-# CHECK-NEXT:      scf.for %arg3 = %c0_1 to %c1_2 step %c1_3 {
 # CHECK-NEXT:        %subview = memref.subview %arg0[%arg3, 0, 0, 0] [1, 10, 10, 3] [1, 1, 1, 1] : memref<1x10x10x3xf32> to memref<1x10x10x3xf32, strided<[300, 30, 3, 1], offset: ?>>
-# CHECK-NEXT:        %subview_4 = memref.subview %arg1[0, 0, 0, 0] [3, 3, 3, 16] [1, 1, 1, 1] : memref<3x3x3x16xf32> to memref<3x3x3x16xf32, strided<[144, 48, 16, 1]>>
-# CHECK-NEXT:        %subview_5 = memref.subview %arg2[%arg3, 0, 0, 0] [1, 8, 8, 16] [1, 1, 1, 1] : memref<1x8x8x16xf32> to memref<1x8x8x16xf32, strided<[1024, 128, 16, 1], offset: ?>>
-# CHECK-NEXT:        %c0_6 = arith.constant 0 : index
+# CHECK-NEXT:        %subview_1 = memref.subview %arg1[0, 0, 0, 0] [3, 3, 3, 16] [1, 1, 1, 1] : memref<3x3x3x16xf32> to memref<3x3x3x16xf32, strided<[144, 48, 16, 1]>>
+# CHECK-NEXT:        %subview_2 = memref.subview %arg2[%arg3, 0, 0, 0] [1, 8, 8, 16] [1, 1, 1, 1] : memref<1x8x8x16xf32> to memref<1x8x8x16xf32, strided<[1024, 128, 16, 1], offset: ?>>
+# CHECK-NEXT:        %c0_3 = arith.constant 0 : index
 # CHECK-NEXT:        %c8 = arith.constant 8 : index
-# CHECK-NEXT:        %c1_7 = arith.constant 1 : index
-# CHECK-NEXT:        scf.for %arg4 = %c0_6 to %c8 step %c1_7 {
-# CHECK-NEXT:          %subview_8 = memref.subview %subview[0, %arg4, 0, 0] [1, 3, 10, 3] [1, 1, 1, 1] : memref<1x10x10x3xf32, strided<[300, 30, 3, 1], offset: ?>> to memref<1x3x10x3xf32, strided<[300, 30, 3, 1], offset: ?>>
-# CHECK-NEXT:          %subview_9 = memref.subview %subview_4[0, 0, 0, 0] [3, 3, 3, 16] [1, 1, 1, 1] : memref<3x3x3x16xf32, strided<[144, 48, 16, 1]>> to memref<3x3x3x16xf32, strided<[144, 48, 16, 1]>>
-# CHECK-NEXT:          %subview_10 = memref.subview %subview_5[0, %arg4, 0, 0] [1, 1, 8, 16] [1, 1, 1, 1] : memref<1x8x8x16xf32, strided<[1024, 128, 16, 1], offset: ?>> to memref<1x1x8x16xf32, strided<[1024, 128, 16, 1], offset: ?>>
-# CHECK-NEXT:          %c0_11 = arith.constant 0 : index
-# CHECK-NEXT:          %c8_12 = arith.constant 8 : index
-# CHECK-NEXT:          %c1_13 = arith.constant 1 : index
-# CHECK-NEXT:          scf.for %arg5 = %c0_11 to %c8_12 step %c1_13 {
-# CHECK-NEXT:            %subview_14 = memref.subview %subview_8[0, 0, %arg5, 0] [1, 3, 3, 3] [1, 1, 1, 1] : memref<1x3x10x3xf32, strided<[300, 30, 3, 1], offset: ?>> to memref<1x3x3x3xf32, strided<[300, 30, 3, 1], offset: ?>>
-# CHECK-NEXT:            %subview_15 = memref.subview %subview_9[0, 0, 0, 0] [3, 3, 3, 16] [1, 1, 1, 1] : memref<3x3x3x16xf32, strided<[144, 48, 16, 1]>> to memref<3x3x3x16xf32, strided<[144, 48, 16, 1]>>
-# CHECK-NEXT:            %subview_16 = memref.subview %subview_10[0, 0, %arg5, 0] [1, 1, 1, 16] [1, 1, 1, 1] : memref<1x1x8x16xf32, strided<[1024, 128, 16, 1], offset: ?>> to memref<1x1x1x16xf32, strided<[1024, 128, 16, 1], offset: ?>>
-# CHECK-NEXT:            %c0_17 = arith.constant 0 : index
+# CHECK-NEXT:        %c1_4 = arith.constant 1 : index
+# CHECK-NEXT:        scf.for %arg4 = %c0_3 to %c8 step %c1_4 {
+# CHECK-NEXT:          %subview_5 = memref.subview %subview[0, %arg4, 0, 0] [1, 3, 10, 3] [1, 1, 1, 1] : memref<1x10x10x3xf32, strided<[300, 30, 3, 1], offset: ?>> to memref<1x3x10x3xf32, strided<[300, 30, 3, 1], offset: ?>>
+# CHECK-NEXT:          %subview_6 = memref.subview %subview_1[0, 0, 0, 0] [3, 3, 3, 16] [1, 1, 1, 1] : memref<3x3x3x16xf32, strided<[144, 48, 16, 1]>> to memref<3x3x3x16xf32, strided<[144, 48, 16, 1]>>
+# CHECK-NEXT:          %subview_7 = memref.subview %subview_2[0, %arg4, 0, 0] [1, 1, 8, 16] [1, 1, 1, 1] : memref<1x8x8x16xf32, strided<[1024, 128, 16, 1], offset: ?>> to memref<1x1x8x16xf32, strided<[1024, 128, 16, 1], offset: ?>>
+# CHECK-NEXT:          %c0_8 = arith.constant 0 : index
+# CHECK-NEXT:          %c8_9 = arith.constant 8 : index
+# CHECK-NEXT:          %c1_10 = arith.constant 1 : index
+# CHECK-NEXT:          scf.for %arg5 = %c0_8 to %c8_9 step %c1_10 {
+# CHECK-NEXT:            %subview_11 = memref.subview %subview_5[0, 0, %arg5, 0] [1, 3, 3, 3] [1, 1, 1, 1] : memref<1x3x10x3xf32, strided<[300, 30, 3, 1], offset: ?>> to memref<1x3x3x3xf32, strided<[300, 30, 3, 1], offset: ?>>
+# CHECK-NEXT:            %subview_12 = memref.subview %subview_6[0, 0, 0, 0] [3, 3, 3, 16] [1, 1, 1, 1] : memref<3x3x3x16xf32, strided<[144, 48, 16, 1]>> to memref<3x3x3x16xf32, strided<[144, 48, 16, 1]>>
+# CHECK-NEXT:            %subview_13 = memref.subview %subview_7[0, 0, %arg5, 0] [1, 1, 1, 16] [1, 1, 1, 1] : memref<1x1x8x16xf32, strided<[1024, 128, 16, 1], offset: ?>> to memref<1x1x1x16xf32, strided<[1024, 128, 16, 1], offset: ?>>
+# CHECK-NEXT:            %c0_14 = arith.constant 0 : index
 # CHECK-NEXT:            %c16 = arith.constant 16 : index
-# CHECK-NEXT:            %c1_18 = arith.constant 1 : index
-# CHECK-NEXT:            scf.for %arg6 = %c0_17 to %c16 step %c1_18 {
-# CHECK-NEXT:              %subview_19 = memref.subview %subview_14[0, 0, 0, 0] [1, 3, 3, 3] [1, 1, 1, 1] : memref<1x3x3x3xf32, strided<[300, 30, 3, 1], offset: ?>> to memref<1x3x3x3xf32, strided<[300, 30, 3, 1], offset: ?>>
-# CHECK-NEXT:              %subview_20 = memref.subview %subview_15[0, 0, 0, %arg6] [3, 3, 3, 1] [1, 1, 1, 1] : memref<3x3x3x16xf32, strided<[144, 48, 16, 1]>> to memref<3x3x3x1xf32, strided<[144, 48, 16, 1], offset: ?>>
-# CHECK-NEXT:              %subview_21 = memref.subview %subview_16[0, 0, 0, %arg6] [1, 1, 1, 1] [1, 1, 1, 1] : memref<1x1x1x16xf32, strided<[1024, 128, 16, 1], offset: ?>> to memref<1x1x1x1xf32, strided<[1024, 128, 16, 1], offset: ?>>
-# CHECK-NEXT:              %c0_22 = arith.constant 0 : index
+# CHECK-NEXT:            %c1_15 = arith.constant 1 : index
+# CHECK-NEXT:            scf.for %arg6 = %c0_14 to %c16 step %c1_15 {
+# CHECK-NEXT:              %subview_16 = memref.subview %subview_11[0, 0, 0, 0] [1, 3, 3, 3] [1, 1, 1, 1] : memref<1x3x3x3xf32, strided<[300, 30, 3, 1], offset: ?>> to memref<1x3x3x3xf32, strided<[300, 30, 3, 1], offset: ?>>
+# CHECK-NEXT:              %subview_17 = memref.subview %subview_12[0, 0, 0, %arg6] [3, 3, 3, 1] [1, 1, 1, 1] : memref<3x3x3x16xf32, strided<[144, 48, 16, 1]>> to memref<3x3x3x1xf32, strided<[144, 48, 16, 1], offset: ?>>
+# CHECK-NEXT:              %subview_18 = memref.subview %subview_13[0, 0, 0, %arg6] [1, 1, 1, 1] [1, 1, 1, 1] : memref<1x1x1x16xf32, strided<[1024, 128, 16, 1], offset: ?>> to memref<1x1x1x1xf32, strided<[1024, 128, 16, 1], offset: ?>>
+# CHECK-NEXT:              %c0_19 = arith.constant 0 : index
 # CHECK-NEXT:              %c3 = arith.constant 3 : index
-# CHECK-NEXT:              %c1_23 = arith.constant 1 : index
-# CHECK-NEXT:              scf.for %arg7 = %c0_22 to %c3 step %c1_23 {
-# CHECK-NEXT:                %subview_24 = memref.subview %subview_19[0, %arg7, 0, 0] [1, 1, 3, 3] [1, 1, 1, 1] : memref<1x3x3x3xf32, strided<[300, 30, 3, 1], offset: ?>> to memref<1x1x3x3xf32, strided<[300, 30, 3, 1], offset: ?>>
-# CHECK-NEXT:                %subview_25 = memref.subview %subview_20[%arg7, 0, 0, 0] [1, 3, 3, 1] [1, 1, 1, 1] : memref<3x3x3x1xf32, strided<[144, 48, 16, 1], offset: ?>> to memref<1x3x3x1xf32, strided<[144, 48, 16, 1], offset: ?>>
-# CHECK-NEXT:                %subview_26 = memref.subview %subview_21[0, 0, 0, 0] [1, 1, 1, 1] [1, 1, 1, 1] : memref<1x1x1x1xf32, strided<[1024, 128, 16, 1], offset: ?>> to memref<1x1x1x1xf32, strided<[1024, 128, 16, 1], offset: ?>>
-# CHECK-NEXT:                %c0_27 = arith.constant 0 : index
-# CHECK-NEXT:                %c3_28 = arith.constant 3 : index
-# CHECK-NEXT:                %c1_29 = arith.constant 1 : index
-# CHECK-NEXT:                scf.for %arg8 = %c0_27 to %c3_28 step %c1_29 {
-# CHECK-NEXT:                  %subview_30 = memref.subview %subview_24[0, 0, %arg8, 0] [1, 1, 1, 3] [1, 1, 1, 1] : memref<1x1x3x3xf32, strided<[300, 30, 3, 1], offset: ?>> to memref<1x1x1x3xf32, strided<[300, 30, 3, 1], offset: ?>>
-# CHECK-NEXT:                  %subview_31 = memref.subview %subview_25[0, %arg8, 0, 0] [1, 1, 3, 1] [1, 1, 1, 1] : memref<1x3x3x1xf32, strided<[144, 48, 16, 1], offset: ?>> to memref<1x1x3x1xf32, strided<[144, 48, 16, 1], offset: ?>>
-# CHECK-NEXT:                  %subview_32 = memref.subview %subview_26[0, 0, 0, 0] [1, 1, 1, 1] [1, 1, 1, 1] : memref<1x1x1x1xf32, strided<[1024, 128, 16, 1], offset: ?>> to memref<1x1x1x1xf32, strided<[1024, 128, 16, 1], offset: ?>>
-# CHECK-NEXT:                  %c0_33 = arith.constant 0 : index
-# CHECK-NEXT:                  %c3_34 = arith.constant 3 : index
-# CHECK-NEXT:                  %c1_35 = arith.constant 1 : index
-# CHECK-NEXT:                  scf.for %arg9 = %c0_33 to %c3_34 step %c1_35 {
-# CHECK-NEXT:                    %subview_36 = memref.subview %subview_30[0, 0, 0, %arg9] [1, 1, 1, 1] [1, 1, 1, 1] : memref<1x1x1x3xf32, strided<[300, 30, 3, 1], offset: ?>> to memref<1x1x1x1xf32, strided<[300, 30, 3, 1], offset: ?>>
-# CHECK-NEXT:                    %subview_37 = memref.subview %subview_31[0, 0, %arg9, 0] [1, 1, 1, 1] [1, 1, 1, 1] : memref<1x1x3x1xf32, strided<[144, 48, 16, 1], offset: ?>> to memref<1x1x1x1xf32, strided<[144, 48, 16, 1], offset: ?>>
-# CHECK-NEXT:                    %subview_38 = memref.subview %subview_32[0, 0, 0, 0] [1, 1, 1, 1] [1, 1, 1, 1] : memref<1x1x1x1xf32, strided<[1024, 128, 16, 1], offset: ?>> to memref<1x1x1x1xf32, strided<[1024, 128, 16, 1], offset: ?>>
-# CHECK-NEXT:                    linalg.generic {indexing_maps = [#map, #map1, #map2], iterator_types = ["parallel", "parallel", "parallel", "parallel", "reduction", "reduction", "reduction"]} ins(%subview_36, %subview_37 : memref<1x1x1x1xf32, strided<[300, 30, 3, 1], offset: ?>>, memref<1x1x1x1xf32, strided<[144, 48, 16, 1], offset: ?>>) outs(%subview_38 : memref<1x1x1x1xf32, strided<[1024, 128, 16, 1], offset: ?>>) attrs =  {__xtc_id_O_} {
-# CHECK-NEXT:                    ^bb0(%in: f32, %in_39: f32, %out: f32):
-# CHECK-NEXT:                      %0 = arith.mulf %in, %in_39 : f32
+# CHECK-NEXT:              %c1_20 = arith.constant 1 : index
+# CHECK-NEXT:              scf.for %arg7 = %c0_19 to %c3 step %c1_20 {
+# CHECK-NEXT:                %subview_21 = memref.subview %subview_16[0, %arg7, 0, 0] [1, 1, 3, 3] [1, 1, 1, 1] : memref<1x3x3x3xf32, strided<[300, 30, 3, 1], offset: ?>> to memref<1x1x3x3xf32, strided<[300, 30, 3, 1], offset: ?>>
+# CHECK-NEXT:                %subview_22 = memref.subview %subview_17[%arg7, 0, 0, 0] [1, 3, 3, 1] [1, 1, 1, 1] : memref<3x3x3x1xf32, strided<[144, 48, 16, 1], offset: ?>> to memref<1x3x3x1xf32, strided<[144, 48, 16, 1], offset: ?>>
+# CHECK-NEXT:                %subview_23 = memref.subview %subview_18[0, 0, 0, 0] [1, 1, 1, 1] [1, 1, 1, 1] : memref<1x1x1x1xf32, strided<[1024, 128, 16, 1], offset: ?>> to memref<1x1x1x1xf32, strided<[1024, 128, 16, 1], offset: ?>>
+# CHECK-NEXT:                %c0_24 = arith.constant 0 : index
+# CHECK-NEXT:                %c3_25 = arith.constant 3 : index
+# CHECK-NEXT:                %c1_26 = arith.constant 1 : index
+# CHECK-NEXT:                scf.for %arg8 = %c0_24 to %c3_25 step %c1_26 {
+# CHECK-NEXT:                  %subview_27 = memref.subview %subview_21[0, 0, %arg8, 0] [1, 1, 1, 3] [1, 1, 1, 1] : memref<1x1x3x3xf32, strided<[300, 30, 3, 1], offset: ?>> to memref<1x1x1x3xf32, strided<[300, 30, 3, 1], offset: ?>>
+# CHECK-NEXT:                  %subview_28 = memref.subview %subview_22[0, %arg8, 0, 0] [1, 1, 3, 1] [1, 1, 1, 1] : memref<1x3x3x1xf32, strided<[144, 48, 16, 1], offset: ?>> to memref<1x1x3x1xf32, strided<[144, 48, 16, 1], offset: ?>>
+# CHECK-NEXT:                  %subview_29 = memref.subview %subview_23[0, 0, 0, 0] [1, 1, 1, 1] [1, 1, 1, 1] : memref<1x1x1x1xf32, strided<[1024, 128, 16, 1], offset: ?>> to memref<1x1x1x1xf32, strided<[1024, 128, 16, 1], offset: ?>>
+# CHECK-NEXT:                  %c0_30 = arith.constant 0 : index
+# CHECK-NEXT:                  %c3_31 = arith.constant 3 : index
+# CHECK-NEXT:                  %c1_32 = arith.constant 1 : index
+# CHECK-NEXT:                  scf.for %arg9 = %c0_30 to %c3_31 step %c1_32 {
+# CHECK-NEXT:                    %subview_33 = memref.subview %subview_27[0, 0, 0, %arg9] [1, 1, 1, 1] [1, 1, 1, 1] : memref<1x1x1x3xf32, strided<[300, 30, 3, 1], offset: ?>> to memref<1x1x1x1xf32, strided<[300, 30, 3, 1], offset: ?>>
+# CHECK-NEXT:                    %subview_34 = memref.subview %subview_28[0, 0, %arg9, 0] [1, 1, 1, 1] [1, 1, 1, 1] : memref<1x1x3x1xf32, strided<[144, 48, 16, 1], offset: ?>> to memref<1x1x1x1xf32, strided<[144, 48, 16, 1], offset: ?>>
+# CHECK-NEXT:                    %subview_35 = memref.subview %subview_29[0, 0, 0, 0] [1, 1, 1, 1] [1, 1, 1, 1] : memref<1x1x1x1xf32, strided<[1024, 128, 16, 1], offset: ?>> to memref<1x1x1x1xf32, strided<[1024, 128, 16, 1], offset: ?>>
+# CHECK-NEXT:                    linalg.generic {indexing_maps = [#map, #map1, #map2], iterator_types = ["parallel", "parallel", "parallel", "parallel", "reduction", "reduction", "reduction"]} ins(%subview_33, %subview_34 : memref<1x1x1x1xf32, strided<[300, 30, 3, 1], offset: ?>>, memref<1x1x1x1xf32, strided<[144, 48, 16, 1], offset: ?>>) outs(%subview_35 : memref<1x1x1x1xf32, strided<[1024, 128, 16, 1], offset: ?>>) attrs =  {__xtc_id_O_} {
+# CHECK-NEXT:                    ^bb0(%in: f32, %in_36: f32, %out: f32):
+# CHECK-NEXT:                      %0 = arith.mulf %in, %in_36 : f32
 # CHECK-NEXT:                      %1 = arith.addf %out, %0 : f32
 # CHECK-NEXT:                      linalg.yield %1 : f32
 # CHECK-NEXT:                    }

--- a/tests/filecheck/backends/test_conv2d_mini_mlir.py
+++ b/tests/filecheck/backends/test_conv2d_mini_mlir.py
@@ -51,30 +51,21 @@ print(f"CODE: {res}")
 # CHECK-NEXT:      transform.yield 
 # CHECK-NEXT:    }
 # CHECK-NEXT:    transform.named_sequence @__transform_main(%arg0: !transform.any_op {transform.readonly}) {
-# CHECK-NEXT:      %0 = transform.structured.match attributes {__xtc_id_O_0_} in %arg0 : (!transform.any_op) -> !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op, %loops = transform.structured.tile_using_for %0 tile_sizes [1, 0, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      %0 = transform.structured.match attributes {__xtc_id_O_} in %arg0 : (!transform.any_op) -> !transform.any_op
+# CHECK-NEXT:      %tiled_linalg_op, %loops = transform.structured.tile_using_for %0 tile_sizes [1, 0, 0, 0, 0, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
 # CHECK-NEXT:      transform.annotate %loops "./b" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_0, %loops_1 = transform.structured.tile_using_for %tiled_linalg_op tile_sizes [0, 1, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      %tiled_linalg_op_0, %loops_1 = transform.structured.tile_using_for %tiled_linalg_op tile_sizes [0, 1, 0, 0, 0, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
 # CHECK-NEXT:      transform.annotate %loops_1 "./h" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_2, %loops_3 = transform.structured.tile_using_for %tiled_linalg_op_0 tile_sizes [0, 0, 1, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      %tiled_linalg_op_2, %loops_3 = transform.structured.tile_using_for %tiled_linalg_op_0 tile_sizes [0, 0, 1, 0, 0, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
 # CHECK-NEXT:      transform.annotate %loops_3 "./w" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_4, %loops_5 = transform.structured.tile_using_for %tiled_linalg_op_2 tile_sizes [0, 0, 0, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      %tiled_linalg_op_4, %loops_5 = transform.structured.tile_using_for %tiled_linalg_op_2 tile_sizes [0, 0, 0, 1, 0, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
 # CHECK-NEXT:      transform.annotate %loops_5 "./f" : !transform.any_op
-# CHECK-NEXT:      %1 = transform.structured.match attributes {__xtc_id_O_} in %arg0 : (!transform.any_op) -> !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_6, %loops_7 = transform.structured.tile_using_for %1 tile_sizes [1, 0, 0, 0, 0, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_7 "./b" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_8, %loops_9 = transform.structured.tile_using_for %tiled_linalg_op_6 tile_sizes [0, 1, 0, 0, 0, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_9 "./h" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_10, %loops_11 = transform.structured.tile_using_for %tiled_linalg_op_8 tile_sizes [0, 0, 1, 0, 0, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_11 "./w" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_12, %loops_13 = transform.structured.tile_using_for %tiled_linalg_op_10 tile_sizes [0, 0, 0, 1, 0, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_13 "./f" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_14, %loops_15 = transform.structured.tile_using_for %tiled_linalg_op_12 tile_sizes [0, 0, 0, 0, 1, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_15 "./r" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_16, %loops_17 = transform.structured.tile_using_for %tiled_linalg_op_14 tile_sizes [0, 0, 0, 0, 0, 1, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_17 "./s" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_18, %loops_19 = transform.structured.tile_using_for %tiled_linalg_op_16 tile_sizes [0, 0, 0, 0, 0, 0, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_19 "./c" : !transform.any_op
+# CHECK-NEXT:      %tiled_linalg_op_6, %loops_7 = transform.structured.tile_using_for %tiled_linalg_op_4 tile_sizes [0, 0, 0, 0, 1, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      transform.annotate %loops_7 "./r" : !transform.any_op
+# CHECK-NEXT:      %tiled_linalg_op_8, %loops_9 = transform.structured.tile_using_for %tiled_linalg_op_6 tile_sizes [0, 0, 0, 0, 0, 1, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      transform.annotate %loops_9 "./s" : !transform.any_op
+# CHECK-NEXT:      %tiled_linalg_op_10, %loops_11 = transform.structured.tile_using_for %tiled_linalg_op_8 tile_sizes [0, 0, 0, 0, 0, 0, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      transform.annotate %loops_11 "./c" : !transform.any_op
 # CHECK-NEXT:      transform.yield 
 # CHECK-NEXT:    }
 # CHECK-NEXT:  }
@@ -86,83 +77,59 @@ print(f"CODE: {res}")
 # CHECK-NEXT:  module attributes {transform.with_named_sequence} {
 # CHECK-NEXT:    func.func @conv2d_nhwc_mini(%arg0: memref<1x10x10x3xf32> {llvm.noalias}, %arg1: memref<3x3x3x16xf32> {llvm.noalias}, %arg2: memref<1x8x8x16xf32> {llvm.noalias}) {
 # CHECK-NEXT:      %cst = arith.constant 0.000000e+00 : f32
+# CHECK-NEXT:      linalg.fill {__xtc_id_O_0_} ins(%cst : f32) outs(%arg2 : memref<1x8x8x16xf32>)
 # CHECK-NEXT:      %c0 = arith.constant 0 : index
 # CHECK-NEXT:      %c1 = arith.constant 1 : index
 # CHECK-NEXT:      %c1_0 = arith.constant 1 : index
 # CHECK-NEXT:      scf.for %arg3 = %c0 to %c1 step %c1_0 {
-# CHECK-NEXT:        %subview = memref.subview %arg2[%arg3, 0, 0, 0] [1, 8, 8, 16] [1, 1, 1, 1] : memref<1x8x8x16xf32> to memref<1x8x8x16xf32, strided<[1024, 128, 16, 1], offset: ?>>
-# CHECK-NEXT:        %c0_4 = arith.constant 0 : index
-# CHECK-NEXT:        %c8 = arith.constant 8 : index
-# CHECK-NEXT:        %c1_5 = arith.constant 1 : index
-# CHECK-NEXT:        scf.for %arg4 = %c0_4 to %c8 step %c1_5 {
-# CHECK-NEXT:          %subview_6 = memref.subview %subview[0, %arg4, 0, 0] [1, 1, 8, 16] [1, 1, 1, 1] : memref<1x8x8x16xf32, strided<[1024, 128, 16, 1], offset: ?>> to memref<1x1x8x16xf32, strided<[1024, 128, 16, 1], offset: ?>>
-# CHECK-NEXT:          %c0_7 = arith.constant 0 : index
-# CHECK-NEXT:          %c8_8 = arith.constant 8 : index
-# CHECK-NEXT:          %c1_9 = arith.constant 1 : index
-# CHECK-NEXT:          scf.for %arg5 = %c0_7 to %c8_8 step %c1_9 {
-# CHECK-NEXT:            %subview_10 = memref.subview %subview_6[0, 0, %arg5, 0] [1, 1, 1, 16] [1, 1, 1, 1] : memref<1x1x8x16xf32, strided<[1024, 128, 16, 1], offset: ?>> to memref<1x1x1x16xf32, strided<[1024, 128, 16, 1], offset: ?>>
-# CHECK-NEXT:            %c0_11 = arith.constant 0 : index
-# CHECK-NEXT:            %c16 = arith.constant 16 : index
-# CHECK-NEXT:            %c1_12 = arith.constant 1 : index
-# CHECK-NEXT:            scf.for %arg6 = %c0_11 to %c16 step %c1_12 {
-# CHECK-NEXT:              %subview_13 = memref.subview %subview_10[0, 0, 0, %arg6] [1, 1, 1, 1] [1, 1, 1, 1] : memref<1x1x1x16xf32, strided<[1024, 128, 16, 1], offset: ?>> to memref<1x1x1x1xf32, strided<[1024, 128, 16, 1], offset: ?>>
-# CHECK-NEXT:              linalg.fill {__xtc_id_O_0_} ins(%cst : f32) outs(%subview_13 : memref<1x1x1x1xf32, strided<[1024, 128, 16, 1], offset: ?>>)
-# CHECK-NEXT:            } {"./f"}
-# CHECK-NEXT:          } {"./w"}
-# CHECK-NEXT:        } {"./h"}
-# CHECK-NEXT:      } {"./b"}
-# CHECK-NEXT:      %c0_1 = arith.constant 0 : index
-# CHECK-NEXT:      %c1_2 = arith.constant 1 : index
-# CHECK-NEXT:      %c1_3 = arith.constant 1 : index
-# CHECK-NEXT:      scf.for %arg3 = %c0_1 to %c1_2 step %c1_3 {
 # CHECK-NEXT:        %subview = memref.subview %arg0[%arg3, 0, 0, 0] [1, 10, 10, 3] [1, 1, 1, 1] : memref<1x10x10x3xf32> to memref<1x10x10x3xf32, strided<[300, 30, 3, 1], offset: ?>>
-# CHECK-NEXT:        %subview_4 = memref.subview %arg1[0, 0, 0, 0] [3, 3, 3, 16] [1, 1, 1, 1] : memref<3x3x3x16xf32> to memref<3x3x3x16xf32, strided<[144, 48, 16, 1]>>
-# CHECK-NEXT:        %subview_5 = memref.subview %arg2[%arg3, 0, 0, 0] [1, 8, 8, 16] [1, 1, 1, 1] : memref<1x8x8x16xf32> to memref<1x8x8x16xf32, strided<[1024, 128, 16, 1], offset: ?>>
-# CHECK-NEXT:        %c0_6 = arith.constant 0 : index
+# CHECK-NEXT:        %subview_1 = memref.subview %arg1[0, 0, 0, 0] [3, 3, 3, 16] [1, 1, 1, 1] : memref<3x3x3x16xf32> to memref<3x3x3x16xf32, strided<[144, 48, 16, 1]>>
+# CHECK-NEXT:        %subview_2 = memref.subview %arg2[%arg3, 0, 0, 0] [1, 8, 8, 16] [1, 1, 1, 1] : memref<1x8x8x16xf32> to memref<1x8x8x16xf32, strided<[1024, 128, 16, 1], offset: ?>>
+# CHECK-NEXT:        %c0_3 = arith.constant 0 : index
 # CHECK-NEXT:        %c8 = arith.constant 8 : index
-# CHECK-NEXT:        %c1_7 = arith.constant 1 : index
-# CHECK-NEXT:        scf.for %arg4 = %c0_6 to %c8 step %c1_7 {
-# CHECK-NEXT:          %subview_8 = memref.subview %subview[0, %arg4, 0, 0] [1, 3, 10, 3] [1, 1, 1, 1] : memref<1x10x10x3xf32, strided<[300, 30, 3, 1], offset: ?>> to memref<1x3x10x3xf32, strided<[300, 30, 3, 1], offset: ?>>
-# CHECK-NEXT:          %subview_9 = memref.subview %subview_4[0, 0, 0, 0] [3, 3, 3, 16] [1, 1, 1, 1] : memref<3x3x3x16xf32, strided<[144, 48, 16, 1]>> to memref<3x3x3x16xf32, strided<[144, 48, 16, 1]>>
-# CHECK-NEXT:          %subview_10 = memref.subview %subview_5[0, %arg4, 0, 0] [1, 1, 8, 16] [1, 1, 1, 1] : memref<1x8x8x16xf32, strided<[1024, 128, 16, 1], offset: ?>> to memref<1x1x8x16xf32, strided<[1024, 128, 16, 1], offset: ?>>
-# CHECK-NEXT:          %c0_11 = arith.constant 0 : index
-# CHECK-NEXT:          %c8_12 = arith.constant 8 : index
-# CHECK-NEXT:          %c1_13 = arith.constant 1 : index
-# CHECK-NEXT:          scf.for %arg5 = %c0_11 to %c8_12 step %c1_13 {
-# CHECK-NEXT:            %subview_14 = memref.subview %subview_8[0, 0, %arg5, 0] [1, 3, 3, 3] [1, 1, 1, 1] : memref<1x3x10x3xf32, strided<[300, 30, 3, 1], offset: ?>> to memref<1x3x3x3xf32, strided<[300, 30, 3, 1], offset: ?>>
-# CHECK-NEXT:            %subview_15 = memref.subview %subview_9[0, 0, 0, 0] [3, 3, 3, 16] [1, 1, 1, 1] : memref<3x3x3x16xf32, strided<[144, 48, 16, 1]>> to memref<3x3x3x16xf32, strided<[144, 48, 16, 1]>>
-# CHECK-NEXT:            %subview_16 = memref.subview %subview_10[0, 0, %arg5, 0] [1, 1, 1, 16] [1, 1, 1, 1] : memref<1x1x8x16xf32, strided<[1024, 128, 16, 1], offset: ?>> to memref<1x1x1x16xf32, strided<[1024, 128, 16, 1], offset: ?>>
-# CHECK-NEXT:            %c0_17 = arith.constant 0 : index
+# CHECK-NEXT:        %c1_4 = arith.constant 1 : index
+# CHECK-NEXT:        scf.for %arg4 = %c0_3 to %c8 step %c1_4 {
+# CHECK-NEXT:          %subview_5 = memref.subview %subview[0, %arg4, 0, 0] [1, 3, 10, 3] [1, 1, 1, 1] : memref<1x10x10x3xf32, strided<[300, 30, 3, 1], offset: ?>> to memref<1x3x10x3xf32, strided<[300, 30, 3, 1], offset: ?>>
+# CHECK-NEXT:          %subview_6 = memref.subview %subview_1[0, 0, 0, 0] [3, 3, 3, 16] [1, 1, 1, 1] : memref<3x3x3x16xf32, strided<[144, 48, 16, 1]>> to memref<3x3x3x16xf32, strided<[144, 48, 16, 1]>>
+# CHECK-NEXT:          %subview_7 = memref.subview %subview_2[0, %arg4, 0, 0] [1, 1, 8, 16] [1, 1, 1, 1] : memref<1x8x8x16xf32, strided<[1024, 128, 16, 1], offset: ?>> to memref<1x1x8x16xf32, strided<[1024, 128, 16, 1], offset: ?>>
+# CHECK-NEXT:          %c0_8 = arith.constant 0 : index
+# CHECK-NEXT:          %c8_9 = arith.constant 8 : index
+# CHECK-NEXT:          %c1_10 = arith.constant 1 : index
+# CHECK-NEXT:          scf.for %arg5 = %c0_8 to %c8_9 step %c1_10 {
+# CHECK-NEXT:            %subview_11 = memref.subview %subview_5[0, 0, %arg5, 0] [1, 3, 3, 3] [1, 1, 1, 1] : memref<1x3x10x3xf32, strided<[300, 30, 3, 1], offset: ?>> to memref<1x3x3x3xf32, strided<[300, 30, 3, 1], offset: ?>>
+# CHECK-NEXT:            %subview_12 = memref.subview %subview_6[0, 0, 0, 0] [3, 3, 3, 16] [1, 1, 1, 1] : memref<3x3x3x16xf32, strided<[144, 48, 16, 1]>> to memref<3x3x3x16xf32, strided<[144, 48, 16, 1]>>
+# CHECK-NEXT:            %subview_13 = memref.subview %subview_7[0, 0, %arg5, 0] [1, 1, 1, 16] [1, 1, 1, 1] : memref<1x1x8x16xf32, strided<[1024, 128, 16, 1], offset: ?>> to memref<1x1x1x16xf32, strided<[1024, 128, 16, 1], offset: ?>>
+# CHECK-NEXT:            %c0_14 = arith.constant 0 : index
 # CHECK-NEXT:            %c16 = arith.constant 16 : index
-# CHECK-NEXT:            %c1_18 = arith.constant 1 : index
-# CHECK-NEXT:            scf.for %arg6 = %c0_17 to %c16 step %c1_18 {
-# CHECK-NEXT:              %subview_19 = memref.subview %subview_14[0, 0, 0, 0] [1, 3, 3, 3] [1, 1, 1, 1] : memref<1x3x3x3xf32, strided<[300, 30, 3, 1], offset: ?>> to memref<1x3x3x3xf32, strided<[300, 30, 3, 1], offset: ?>>
-# CHECK-NEXT:              %subview_20 = memref.subview %subview_15[0, 0, 0, %arg6] [3, 3, 3, 1] [1, 1, 1, 1] : memref<3x3x3x16xf32, strided<[144, 48, 16, 1]>> to memref<3x3x3x1xf32, strided<[144, 48, 16, 1], offset: ?>>
-# CHECK-NEXT:              %subview_21 = memref.subview %subview_16[0, 0, 0, %arg6] [1, 1, 1, 1] [1, 1, 1, 1] : memref<1x1x1x16xf32, strided<[1024, 128, 16, 1], offset: ?>> to memref<1x1x1x1xf32, strided<[1024, 128, 16, 1], offset: ?>>
-# CHECK-NEXT:              %c0_22 = arith.constant 0 : index
+# CHECK-NEXT:            %c1_15 = arith.constant 1 : index
+# CHECK-NEXT:            scf.for %arg6 = %c0_14 to %c16 step %c1_15 {
+# CHECK-NEXT:              %subview_16 = memref.subview %subview_11[0, 0, 0, 0] [1, 3, 3, 3] [1, 1, 1, 1] : memref<1x3x3x3xf32, strided<[300, 30, 3, 1], offset: ?>> to memref<1x3x3x3xf32, strided<[300, 30, 3, 1], offset: ?>>
+# CHECK-NEXT:              %subview_17 = memref.subview %subview_12[0, 0, 0, %arg6] [3, 3, 3, 1] [1, 1, 1, 1] : memref<3x3x3x16xf32, strided<[144, 48, 16, 1]>> to memref<3x3x3x1xf32, strided<[144, 48, 16, 1], offset: ?>>
+# CHECK-NEXT:              %subview_18 = memref.subview %subview_13[0, 0, 0, %arg6] [1, 1, 1, 1] [1, 1, 1, 1] : memref<1x1x1x16xf32, strided<[1024, 128, 16, 1], offset: ?>> to memref<1x1x1x1xf32, strided<[1024, 128, 16, 1], offset: ?>>
+# CHECK-NEXT:              %c0_19 = arith.constant 0 : index
 # CHECK-NEXT:              %c3 = arith.constant 3 : index
-# CHECK-NEXT:              %c1_23 = arith.constant 1 : index
-# CHECK-NEXT:              scf.for %arg7 = %c0_22 to %c3 step %c1_23 {
-# CHECK-NEXT:                %subview_24 = memref.subview %subview_19[0, %arg7, 0, 0] [1, 1, 3, 3] [1, 1, 1, 1] : memref<1x3x3x3xf32, strided<[300, 30, 3, 1], offset: ?>> to memref<1x1x3x3xf32, strided<[300, 30, 3, 1], offset: ?>>
-# CHECK-NEXT:                %subview_25 = memref.subview %subview_20[%arg7, 0, 0, 0] [1, 3, 3, 1] [1, 1, 1, 1] : memref<3x3x3x1xf32, strided<[144, 48, 16, 1], offset: ?>> to memref<1x3x3x1xf32, strided<[144, 48, 16, 1], offset: ?>>
-# CHECK-NEXT:                %subview_26 = memref.subview %subview_21[0, 0, 0, 0] [1, 1, 1, 1] [1, 1, 1, 1] : memref<1x1x1x1xf32, strided<[1024, 128, 16, 1], offset: ?>> to memref<1x1x1x1xf32, strided<[1024, 128, 16, 1], offset: ?>>
-# CHECK-NEXT:                %c0_27 = arith.constant 0 : index
-# CHECK-NEXT:                %c3_28 = arith.constant 3 : index
-# CHECK-NEXT:                %c1_29 = arith.constant 1 : index
-# CHECK-NEXT:                scf.for %arg8 = %c0_27 to %c3_28 step %c1_29 {
-# CHECK-NEXT:                  %subview_30 = memref.subview %subview_24[0, 0, %arg8, 0] [1, 1, 1, 3] [1, 1, 1, 1] : memref<1x1x3x3xf32, strided<[300, 30, 3, 1], offset: ?>> to memref<1x1x1x3xf32, strided<[300, 30, 3, 1], offset: ?>>
-# CHECK-NEXT:                  %subview_31 = memref.subview %subview_25[0, %arg8, 0, 0] [1, 1, 3, 1] [1, 1, 1, 1] : memref<1x3x3x1xf32, strided<[144, 48, 16, 1], offset: ?>> to memref<1x1x3x1xf32, strided<[144, 48, 16, 1], offset: ?>>
-# CHECK-NEXT:                  %subview_32 = memref.subview %subview_26[0, 0, 0, 0] [1, 1, 1, 1] [1, 1, 1, 1] : memref<1x1x1x1xf32, strided<[1024, 128, 16, 1], offset: ?>> to memref<1x1x1x1xf32, strided<[1024, 128, 16, 1], offset: ?>>
-# CHECK-NEXT:                  %c0_33 = arith.constant 0 : index
-# CHECK-NEXT:                  %c3_34 = arith.constant 3 : index
-# CHECK-NEXT:                  %c1_35 = arith.constant 1 : index
-# CHECK-NEXT:                  scf.for %arg9 = %c0_33 to %c3_34 step %c1_35 {
-# CHECK-NEXT:                    %subview_36 = memref.subview %subview_30[0, 0, 0, %arg9] [1, 1, 1, 1] [1, 1, 1, 1] : memref<1x1x1x3xf32, strided<[300, 30, 3, 1], offset: ?>> to memref<1x1x1x1xf32, strided<[300, 30, 3, 1], offset: ?>>
-# CHECK-NEXT:                    %subview_37 = memref.subview %subview_31[0, 0, %arg9, 0] [1, 1, 1, 1] [1, 1, 1, 1] : memref<1x1x3x1xf32, strided<[144, 48, 16, 1], offset: ?>> to memref<1x1x1x1xf32, strided<[144, 48, 16, 1], offset: ?>>
-# CHECK-NEXT:                    %subview_38 = memref.subview %subview_32[0, 0, 0, 0] [1, 1, 1, 1] [1, 1, 1, 1] : memref<1x1x1x1xf32, strided<[1024, 128, 16, 1], offset: ?>> to memref<1x1x1x1xf32, strided<[1024, 128, 16, 1], offset: ?>>
-# CHECK-NEXT:                    linalg.generic {indexing_maps = [#map, #map1, #map2], iterator_types = ["parallel", "parallel", "parallel", "parallel", "reduction", "reduction", "reduction"]} ins(%subview_36, %subview_37 : memref<1x1x1x1xf32, strided<[300, 30, 3, 1], offset: ?>>, memref<1x1x1x1xf32, strided<[144, 48, 16, 1], offset: ?>>) outs(%subview_38 : memref<1x1x1x1xf32, strided<[1024, 128, 16, 1], offset: ?>>) attrs =  {__xtc_id_O_} {
-# CHECK-NEXT:                    ^bb0(%in: f32, %in_39: f32, %out: f32):
-# CHECK-NEXT:                      %0 = arith.mulf %in, %in_39 fastmath<fast> : f32
+# CHECK-NEXT:              %c1_20 = arith.constant 1 : index
+# CHECK-NEXT:              scf.for %arg7 = %c0_19 to %c3 step %c1_20 {
+# CHECK-NEXT:                %subview_21 = memref.subview %subview_16[0, %arg7, 0, 0] [1, 1, 3, 3] [1, 1, 1, 1] : memref<1x3x3x3xf32, strided<[300, 30, 3, 1], offset: ?>> to memref<1x1x3x3xf32, strided<[300, 30, 3, 1], offset: ?>>
+# CHECK-NEXT:                %subview_22 = memref.subview %subview_17[%arg7, 0, 0, 0] [1, 3, 3, 1] [1, 1, 1, 1] : memref<3x3x3x1xf32, strided<[144, 48, 16, 1], offset: ?>> to memref<1x3x3x1xf32, strided<[144, 48, 16, 1], offset: ?>>
+# CHECK-NEXT:                %subview_23 = memref.subview %subview_18[0, 0, 0, 0] [1, 1, 1, 1] [1, 1, 1, 1] : memref<1x1x1x1xf32, strided<[1024, 128, 16, 1], offset: ?>> to memref<1x1x1x1xf32, strided<[1024, 128, 16, 1], offset: ?>>
+# CHECK-NEXT:                %c0_24 = arith.constant 0 : index
+# CHECK-NEXT:                %c3_25 = arith.constant 3 : index
+# CHECK-NEXT:                %c1_26 = arith.constant 1 : index
+# CHECK-NEXT:                scf.for %arg8 = %c0_24 to %c3_25 step %c1_26 {
+# CHECK-NEXT:                  %subview_27 = memref.subview %subview_21[0, 0, %arg8, 0] [1, 1, 1, 3] [1, 1, 1, 1] : memref<1x1x3x3xf32, strided<[300, 30, 3, 1], offset: ?>> to memref<1x1x1x3xf32, strided<[300, 30, 3, 1], offset: ?>>
+# CHECK-NEXT:                  %subview_28 = memref.subview %subview_22[0, %arg8, 0, 0] [1, 1, 3, 1] [1, 1, 1, 1] : memref<1x3x3x1xf32, strided<[144, 48, 16, 1], offset: ?>> to memref<1x1x3x1xf32, strided<[144, 48, 16, 1], offset: ?>>
+# CHECK-NEXT:                  %subview_29 = memref.subview %subview_23[0, 0, 0, 0] [1, 1, 1, 1] [1, 1, 1, 1] : memref<1x1x1x1xf32, strided<[1024, 128, 16, 1], offset: ?>> to memref<1x1x1x1xf32, strided<[1024, 128, 16, 1], offset: ?>>
+# CHECK-NEXT:                  %c0_30 = arith.constant 0 : index
+# CHECK-NEXT:                  %c3_31 = arith.constant 3 : index
+# CHECK-NEXT:                  %c1_32 = arith.constant 1 : index
+# CHECK-NEXT:                  scf.for %arg9 = %c0_30 to %c3_31 step %c1_32 {
+# CHECK-NEXT:                    %subview_33 = memref.subview %subview_27[0, 0, 0, %arg9] [1, 1, 1, 1] [1, 1, 1, 1] : memref<1x1x1x3xf32, strided<[300, 30, 3, 1], offset: ?>> to memref<1x1x1x1xf32, strided<[300, 30, 3, 1], offset: ?>>
+# CHECK-NEXT:                    %subview_34 = memref.subview %subview_28[0, 0, %arg9, 0] [1, 1, 1, 1] [1, 1, 1, 1] : memref<1x1x3x1xf32, strided<[144, 48, 16, 1], offset: ?>> to memref<1x1x1x1xf32, strided<[144, 48, 16, 1], offset: ?>>
+# CHECK-NEXT:                    %subview_35 = memref.subview %subview_29[0, 0, 0, 0] [1, 1, 1, 1] [1, 1, 1, 1] : memref<1x1x1x1xf32, strided<[1024, 128, 16, 1], offset: ?>> to memref<1x1x1x1xf32, strided<[1024, 128, 16, 1], offset: ?>>
+# CHECK-NEXT:                    linalg.generic {indexing_maps = [#map, #map1, #map2], iterator_types = ["parallel", "parallel", "parallel", "parallel", "reduction", "reduction", "reduction"]} ins(%subview_33, %subview_34 : memref<1x1x1x1xf32, strided<[300, 30, 3, 1], offset: ?>>, memref<1x1x1x1xf32, strided<[144, 48, 16, 1], offset: ?>>) outs(%subview_35 : memref<1x1x1x1xf32, strided<[1024, 128, 16, 1], offset: ?>>) attrs =  {__xtc_id_O_} {
+# CHECK-NEXT:                    ^bb0(%in: f32, %in_36: f32, %out: f32):
+# CHECK-NEXT:                      %0 = arith.mulf %in, %in_36 fastmath<fast> : f32
 # CHECK-NEXT:                      %1 = arith.addf %out, %0 fastmath<fast> : f32
 # CHECK-NEXT:                      linalg.yield %1 : f32
 # CHECK-NEXT:                    }

--- a/tests/filecheck/backends/test_conv2d_r181_mlir.py
+++ b/tests/filecheck/backends/test_conv2d_r181_mlir.py
@@ -60,41 +60,32 @@ print(f"CODE: {res}")
 # CHECK-NEXT:      transform.yield 
 # CHECK-NEXT:    }
 # CHECK-NEXT:    transform.named_sequence @__transform_main(%arg0: !transform.any_op {transform.readonly}) {
-# CHECK-NEXT:      %0 = transform.structured.match attributes {__xtc_id_O_0_} in %arg0 : (!transform.any_op) -> !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op, %loops = transform.structured.tile_using_for %0 tile_sizes [1, 0, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      %0 = transform.structured.match attributes {__xtc_id_O_} in %arg0 : (!transform.any_op) -> !transform.any_op
+# CHECK-NEXT:      %tiled_linalg_op, %loops = transform.structured.tile_using_for %0 tile_sizes [1, 0, 0, 0, 0, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
 # CHECK-NEXT:      transform.annotate %loops "./b" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_0, %loops_1 = transform.structured.tile_using_for %tiled_linalg_op tile_sizes [0, 1, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      %tiled_linalg_op_0, %loops_1 = transform.structured.tile_using_for %tiled_linalg_op tile_sizes [0, 1, 0, 0, 0, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
 # CHECK-NEXT:      transform.annotate %loops_1 "./h" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_2, %loops_3 = transform.structured.tile_using_for %tiled_linalg_op_0 tile_sizes [0, 0, 1, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      %tiled_linalg_op_2, %loops_3 = transform.structured.tile_using_for %tiled_linalg_op_0 tile_sizes [0, 0, 4, 0, 0, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
 # CHECK-NEXT:      transform.annotate %loops_3 "./w" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_4, %loops_5 = transform.structured.tile_using_for %tiled_linalg_op_2 tile_sizes [0, 0, 0, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      %tiled_linalg_op_4, %loops_5 = transform.structured.tile_using_for %tiled_linalg_op_2 tile_sizes [0, 0, 0, 16, 0, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
 # CHECK-NEXT:      transform.annotate %loops_5 "./f" : !transform.any_op
-# CHECK-NEXT:      %1 = transform.structured.match attributes {__xtc_id_O_} in %arg0 : (!transform.any_op) -> !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_6, %loops_7 = transform.structured.tile_using_for %1 tile_sizes [1, 0, 0, 0, 0, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_7 "./b" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_8, %loops_9 = transform.structured.tile_using_for %tiled_linalg_op_6 tile_sizes [0, 1, 0, 0, 0, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_9 "./h" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_10, %loops_11 = transform.structured.tile_using_for %tiled_linalg_op_8 tile_sizes [0, 0, 4, 0, 0, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_11 "./w" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_12, %loops_13 = transform.structured.tile_using_for %tiled_linalg_op_10 tile_sizes [0, 0, 0, 16, 0, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_13 "./f" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_14, %loops_15 = transform.structured.tile_using_for %tiled_linalg_op_12 tile_sizes [0, 0, 0, 0, 1, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_15 "./r" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_16, %loops_17 = transform.structured.tile_using_for %tiled_linalg_op_14 tile_sizes [0, 0, 0, 0, 0, 1, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_17 "./s" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_18, %loops_19 = transform.structured.tile_using_for %tiled_linalg_op_16 tile_sizes [0, 0, 0, 0, 0, 0, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_19 "./c" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_20, %loops_21 = transform.structured.tile_using_for %tiled_linalg_op_18 tile_sizes [0, 0, 1, 0, 0, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_21 "./w1" : !transform.any_op
-# CHECK-NEXT:      transform.include @_vecto failures(suppress) (%tiled_linalg_op_20) : (!transform.any_op) -> ()
-# CHECK-NEXT:      transform.loop.unroll %loops_21 {factor = 4 : i64} : !transform.any_op
-# CHECK-NEXT:      transform.loop.unroll %loops_19 {factor = 3 : i64} : !transform.any_op
-# CHECK-NEXT:      %2 = transform.get_parent_op %loops_7 {isolated_from_above} : (!transform.any_op) -> !transform.any_op
-# CHECK-NEXT:      transform.apply_patterns to %2 {
+# CHECK-NEXT:      %tiled_linalg_op_6, %loops_7 = transform.structured.tile_using_for %tiled_linalg_op_4 tile_sizes [0, 0, 0, 0, 1, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      transform.annotate %loops_7 "./r" : !transform.any_op
+# CHECK-NEXT:      %tiled_linalg_op_8, %loops_9 = transform.structured.tile_using_for %tiled_linalg_op_6 tile_sizes [0, 0, 0, 0, 0, 1, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      transform.annotate %loops_9 "./s" : !transform.any_op
+# CHECK-NEXT:      %tiled_linalg_op_10, %loops_11 = transform.structured.tile_using_for %tiled_linalg_op_8 tile_sizes [0, 0, 0, 0, 0, 0, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      transform.annotate %loops_11 "./c" : !transform.any_op
+# CHECK-NEXT:      %tiled_linalg_op_12, %loops_13 = transform.structured.tile_using_for %tiled_linalg_op_10 tile_sizes [0, 0, 1, 0, 0, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      transform.annotate %loops_13 "./w1" : !transform.any_op
+# CHECK-NEXT:      transform.include @_vecto failures(suppress) (%tiled_linalg_op_12) : (!transform.any_op) -> ()
+# CHECK-NEXT:      transform.loop.unroll %loops_13 {factor = 4 : i64} : !transform.any_op
+# CHECK-NEXT:      transform.loop.unroll %loops_11 {factor = 3 : i64} : !transform.any_op
+# CHECK-NEXT:      %1 = transform.get_parent_op %loops {isolated_from_above} : (!transform.any_op) -> !transform.any_op
+# CHECK-NEXT:      transform.apply_patterns to %1 {
 # CHECK-NEXT:        transform.apply_patterns.vector.reduction_to_contract
 # CHECK-NEXT:        transform.apply_patterns.vector.transfer_permutation_patterns
 # CHECK-NEXT:      } : !transform.any_op
-# CHECK-NEXT:      transform.apply_patterns to %2 {
+# CHECK-NEXT:      transform.apply_patterns to %1 {
 # CHECK-NEXT:        transform.apply_patterns.vector.lower_outerproduct
 # CHECK-NEXT:        transform.apply_patterns.vector.lower_contraction
 # CHECK-NEXT:      } : !transform.any_op
@@ -114,25 +105,13 @@ print(f"CODE: {res}")
 # CHECK-NEXT:      %c2 = arith.constant 2 : index
 # CHECK-NEXT:      %c7 = arith.constant 7 : index
 # CHECK-NEXT:      %c16 = arith.constant 16 : index
-# CHECK-NEXT:      %c4 = arith.constant 4 : index
 # CHECK-NEXT:      %c64 = arith.constant 64 : index
+# CHECK-NEXT:      %c4 = arith.constant 4 : index
 # CHECK-NEXT:      %c112 = arith.constant 112 : index
-# CHECK-NEXT:      %cst = arith.constant 0.000000e+00 : f32
-# CHECK-NEXT:      %c0 = arith.constant 0 : index
 # CHECK-NEXT:      %c1 = arith.constant 1 : index
-# CHECK-NEXT:      scf.for %arg3 = %c0 to %c1 step %c1 {
-# CHECK-NEXT:        %subview = memref.subview %arg2[%arg3, 0, 0, 0] [1, 112, 112, 64] [1, 1, 1, 1] : memref<1x112x112x64xf32> to memref<1x112x112x64xf32, strided<[802816, 7168, 64, 1], offset: ?>>
-# CHECK-NEXT:        scf.for %arg4 = %c0 to %c112 step %c1 {
-# CHECK-NEXT:          %subview_0 = memref.subview %subview[0, %arg4, 0, 0] [1, 1, 112, 64] [1, 1, 1, 1] : memref<1x112x112x64xf32, strided<[802816, 7168, 64, 1], offset: ?>> to memref<1x1x112x64xf32, strided<[802816, 7168, 64, 1], offset: ?>>
-# CHECK-NEXT:          scf.for %arg5 = %c0 to %c112 step %c1 {
-# CHECK-NEXT:            %subview_1 = memref.subview %subview_0[0, 0, %arg5, 0] [1, 1, 1, 64] [1, 1, 1, 1] : memref<1x1x112x64xf32, strided<[802816, 7168, 64, 1], offset: ?>> to memref<1x1x1x64xf32, strided<[802816, 7168, 64, 1], offset: ?>>
-# CHECK-NEXT:            scf.for %arg6 = %c0 to %c64 step %c1 {
-# CHECK-NEXT:              %subview_2 = memref.subview %subview_1[0, 0, 0, %arg6] [1, 1, 1, 1] [1, 1, 1, 1] : memref<1x1x1x64xf32, strided<[802816, 7168, 64, 1], offset: ?>> to memref<1x1x1x1xf32, strided<[802816, 7168, 64, 1], offset: ?>>
-# CHECK-NEXT:              linalg.fill {__xtc_id_O_0_} ins(%cst : f32) outs(%subview_2 : memref<1x1x1x1xf32, strided<[802816, 7168, 64, 1], offset: ?>>)
-# CHECK-NEXT:            } {"./f"}
-# CHECK-NEXT:          } {"./w"}
-# CHECK-NEXT:        } {"./h"}
-# CHECK-NEXT:      } {"./b"}
+# CHECK-NEXT:      %c0 = arith.constant 0 : index
+# CHECK-NEXT:      %cst = arith.constant 0.000000e+00 : f32
+# CHECK-NEXT:      linalg.fill {__xtc_id_O_0_} ins(%cst : f32) outs(%arg2 : memref<1x112x112x64xf32>)
 # CHECK-NEXT:      scf.for %arg3 = %c0 to %c1 step %c1 {
 # CHECK-NEXT:        %subview = memref.subview %arg0[%arg3, 0, 0, 0] [1, 229, 229, 3] [1, 1, 1, 1] : memref<1x230x230x3xf32> to memref<1x229x229x3xf32, strided<[158700, 690, 3, 1], offset: ?>>
 # CHECK-NEXT:        %subview_0 = memref.subview %arg1[0, 0, 0, 0] [7, 7, 3, 64] [1, 1, 1, 1] : memref<7x7x3x64xf32> to memref<7x7x3x64xf32, strided<[1344, 192, 64, 1]>>

--- a/tests/filecheck/backends/test_conv2d_r181_mlir_sv.py
+++ b/tests/filecheck/backends/test_conv2d_r181_mlir_sv.py
@@ -1,5 +1,6 @@
 # RUN: python %s 2>&1 | filecheck %s
 # UNSUPPORTED: mlir-target=nvgpu
+# UNSUPPORTED: mlir-target=c
 
 import xtc.graphs.xtc.op as O
 from xtc.backends.mlir.MlirGraphBackend import MlirGraphBackend as Backend
@@ -67,44 +68,35 @@ print(f"CODE: {res}")
 # CHECK-NEXT:      transform.yield %0 : !transform.any_op
 # CHECK-NEXT:    }
 # CHECK-NEXT:    transform.named_sequence @__transform_main(%arg0: !transform.any_op {transform.readonly}) {
-# CHECK-NEXT:      %0 = transform.structured.match attributes {__xtc_id_O_0_} in %arg0 : (!transform.any_op) -> !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op, %loops = transform.structured.tile_using_for %0 tile_sizes [1, 0, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      %0 = transform.structured.match attributes {__xtc_id_O_} in %arg0 : (!transform.any_op) -> !transform.any_op
+# CHECK-NEXT:      %tiled_linalg_op, %loops = transform.structured.tile_using_for %0 tile_sizes [1, 0, 0, 0, 0, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
 # CHECK-NEXT:      transform.annotate %loops "./b" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_0, %loops_1 = transform.structured.tile_using_for %tiled_linalg_op tile_sizes [0, 1, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      %tiled_linalg_op_0, %loops_1 = transform.structured.tile_using_for %tiled_linalg_op tile_sizes [0, 1, 0, 0, 0, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
 # CHECK-NEXT:      transform.annotate %loops_1 "./h" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_2, %loops_3 = transform.structured.tile_using_for %tiled_linalg_op_0 tile_sizes [0, 0, 1, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      %tiled_linalg_op_2, %loops_3 = transform.structured.tile_using_for %tiled_linalg_op_0 tile_sizes [0, 0, 4, 0, 0, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
 # CHECK-NEXT:      transform.annotate %loops_3 "./w" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_4, %loops_5 = transform.structured.tile_using_for %tiled_linalg_op_2 tile_sizes [0, 0, 0, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      %tiled_linalg_op_4, %loops_5 = transform.structured.tile_using_for %tiled_linalg_op_2 tile_sizes [0, 0, 0, 16, 0, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
 # CHECK-NEXT:      transform.annotate %loops_5 "./f" : !transform.any_op
-# CHECK-NEXT:      %1 = transform.structured.match attributes {__xtc_id_O_} in %arg0 : (!transform.any_op) -> !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_6, %loops_7 = transform.structured.tile_using_for %1 tile_sizes [1, 0, 0, 0, 0, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_7 "./b" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_8, %loops_9 = transform.structured.tile_using_for %tiled_linalg_op_6 tile_sizes [0, 1, 0, 0, 0, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_9 "./h" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_10, %loops_11 = transform.structured.tile_using_for %tiled_linalg_op_8 tile_sizes [0, 0, 4, 0, 0, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_11 "./w" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_12, %loops_13 = transform.structured.tile_using_for %tiled_linalg_op_10 tile_sizes [0, 0, 0, 16, 0, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_13 "./f" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_14, %loops_15 = transform.structured.tile_using_for %tiled_linalg_op_12 tile_sizes [0, 0, 0, 0, 1, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_15 "./r" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_16, %loops_17 = transform.structured.tile_using_for %tiled_linalg_op_14 tile_sizes [0, 0, 0, 0, 0, 1, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_17 "./s" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_18, %loops_19 = transform.structured.tile_using_for %tiled_linalg_op_16 tile_sizes [0, 0, 0, 0, 0, 0, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_19 "./c" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_20, %loops_21 = transform.structured.tile_using_for %tiled_linalg_op_18 tile_sizes [0, 0, 1, 0, 0, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_21 "./w1" : !transform.any_op
-# CHECK-NEXT:      transform.loop.unroll %loops_21 {factor = 4 : i64} : !transform.any_op
-# CHECK-NEXT:      transform.loop.unroll %loops_19 {factor = 3 : i64} : !transform.any_op
-# CHECK-NEXT:      %2 = transform.get_parent_op %loops_7 {isolated_from_above} : (!transform.any_op) -> !transform.any_op
-# CHECK-NEXT:      %3 = transform.apply_registered_pass "convert-linalg-to-affine-loops" to %2 : (!transform.any_op) -> !transform.any_op
-# CHECK-NEXT:      %4 = transform.include @_super_vectorize failures(suppress) (%3) : (!transform.any_op) -> !transform.any_op
-# CHECK-NEXT:      transform.yield 
+# CHECK-NEXT:      %tiled_linalg_op_6, %loops_7 = transform.structured.tile_using_for %tiled_linalg_op_4 tile_sizes [0, 0, 0, 0, 1, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      transform.annotate %loops_7 "./r" : !transform.any_op
+# CHECK-NEXT:      %tiled_linalg_op_8, %loops_9 = transform.structured.tile_using_for %tiled_linalg_op_6 tile_sizes [0, 0, 0, 0, 0, 1, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      transform.annotate %loops_9 "./s" : !transform.any_op
+# CHECK-NEXT:      %tiled_linalg_op_10, %loops_11 = transform.structured.tile_using_for %tiled_linalg_op_8 tile_sizes [0, 0, 0, 0, 0, 0, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      transform.annotate %loops_11 "./c" : !transform.any_op
+# CHECK-NEXT:      %tiled_linalg_op_12, %loops_13 = transform.structured.tile_using_for %tiled_linalg_op_10 tile_sizes [0, 0, 1, 0, 0, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      transform.annotate %loops_13 "./w1" : !transform.any_op
+# CHECK-NEXT:      transform.loop.unroll %loops_13 {factor = 4 : i64} : !transform.any_op
+# CHECK-NEXT:      transform.loop.unroll %loops_11 {factor = 3 : i64} : !transform.any_op
+# CHECK-NEXT:      %1 = transform.get_parent_op %loops {isolated_from_above} : (!transform.any_op) -> !transform.any_op
+# CHECK-NEXT:      %2 = transform.apply_registered_pass "convert-linalg-to-affine-loops" to %1 : (!transform.any_op) -> !transform.any_op
+# CHECK-NEXT:      %3 = transform.include @_super_vectorize failures(suppress) (%2) : (!transform.any_op) -> !transform.any_op
+# CHECK-NEXT:      transform.yield
 # CHECK-NEXT:    }
 # CHECK-NEXT:  }
 
 # CHECK: MLIR Error: NYI: non-trivial layout map
 
-# CHECK:  // -----// IR Dump After transform //----- //
+# CHECK:       // -----// IR Dump After transform //----- //
 # CHECK-NEXT:  #map = affine_map<(d0) -> (d0 * 2)>
 # CHECK-NEXT:  #map1 = affine_map<(d0, d1) -> (d0 * 2 + d1)>
 # CHECK-NEXT:  module attributes {transform.with_named_sequence} {
@@ -114,33 +106,22 @@ print(f"CODE: {res}")
 # CHECK-NEXT:      %c2 = arith.constant 2 : index
 # CHECK-NEXT:      %c7 = arith.constant 7 : index
 # CHECK-NEXT:      %c16 = arith.constant 16 : index
-# CHECK-NEXT:      %c4 = arith.constant 4 : index
 # CHECK-NEXT:      %c64 = arith.constant 64 : index
+# CHECK-NEXT:      %c4 = arith.constant 4 : index
 # CHECK-NEXT:      %c112 = arith.constant 112 : index
-# CHECK-NEXT:      %cst = arith.constant 0.000000e+00 : f32
-# CHECK-NEXT:      %c0 = arith.constant 0 : index
 # CHECK-NEXT:      %c1 = arith.constant 1 : index
-# CHECK-NEXT:      scf.for %arg3 = %c0 to %c1 step %c1 {
-# CHECK-NEXT:        %subview = memref.subview %arg2[%arg3, 0, 0, 0] [1, 112, 112, 64] [1, 1, 1, 1] : memref<1x112x112x64xf32> to memref<1x112x112x64xf32, strided<[802816, 7168, 64, 1], offset: ?>>
-# CHECK-NEXT:        scf.for %arg4 = %c0 to %c112 step %c1 {
-# CHECK-NEXT:          %subview_0 = memref.subview %subview[0, %arg4, 0, 0] [1, 1, 112, 64] [1, 1, 1, 1] : memref<1x112x112x64xf32, strided<[802816, 7168, 64, 1], offset: ?>> to memref<1x1x112x64xf32, strided<[802816, 7168, 64, 1], offset: ?>>
-# CHECK-NEXT:          scf.for %arg5 = %c0 to %c112 step %c1 {
-# CHECK-NEXT:            %subview_1 = memref.subview %subview_0[0, 0, %arg5, 0] [1, 1, 1, 64] [1, 1, 1, 1] : memref<1x1x112x64xf32, strided<[802816, 7168, 64, 1], offset: ?>> to memref<1x1x1x64xf32, strided<[802816, 7168, 64, 1], offset: ?>>
-# CHECK-NEXT:            scf.for %arg6 = %c0 to %c64 step %c1 {
-# CHECK-NEXT:              %subview_2 = memref.subview %subview_1[0, 0, 0, %arg6] [1, 1, 1, 1] [1, 1, 1, 1] : memref<1x1x1x64xf32, strided<[802816, 7168, 64, 1], offset: ?>> to memref<1x1x1x1xf32, strided<[802816, 7168, 64, 1], offset: ?>>
-# CHECK-NEXT:              affine.for %arg7 = 0 to 1 {
-# CHECK-NEXT:                affine.for %arg8 = 0 to 1 {
-# CHECK-NEXT:                  affine.for %arg9 = 0 to 1 {
-# CHECK-NEXT:                    affine.for %arg10 = 0 to 1 {
-# CHECK-NEXT:                      affine.store %cst, %subview_2[%arg7, %arg8, %arg9, %arg10] : memref<1x1x1x1xf32, strided<[802816, 7168, 64, 1], offset: ?>>
-# CHECK-NEXT:                    }
-# CHECK-NEXT:                  }
-# CHECK-NEXT:                }
-# CHECK-NEXT:              }
-# CHECK-NEXT:            } {"./f"}
-# CHECK-NEXT:          } {"./w"}
-# CHECK-NEXT:        } {"./h"}
-# CHECK-NEXT:      } {"./b"}
+# CHECK-NEXT:      %c0 = arith.constant 0 : index
+# CHECK-NEXT:      %cst = arith.constant 0.000000e+00 : f32
+# CHECK-NEXT:      affine.for %arg3 = 0 to 1 {
+# CHECK-NEXT:        affine.for %arg4 = 0 to 112 {
+# CHECK-NEXT:          affine.for %arg5 = 0 to 112 {
+# CHECK-NEXT:            affine.for %arg6 = 0 to 64 step 16 {
+# CHECK-NEXT:              %cst_0 = arith.constant dense<0.000000e+00> : vector<16xf32>
+# CHECK-NEXT:              vector.transfer_write %cst_0, %arg2[%arg3, %arg4, %arg5, %arg6] : vector<16xf32>, memref<1x112x112x64xf32>
+# CHECK-NEXT:            }
+# CHECK-NEXT:          }
+# CHECK-NEXT:        }
+# CHECK-NEXT:      }
 # CHECK-NEXT:      scf.for %arg3 = %c0 to %c1 step %c1 {
 # CHECK-NEXT:        %subview = memref.subview %arg0[%arg3, 0, 0, 0] [1, 229, 229, 3] [1, 1, 1, 1] : memref<1x230x230x3xf32> to memref<1x229x229x3xf32, strided<[158700, 690, 3, 1], offset: ?>>
 # CHECK-NEXT:        %subview_0 = memref.subview %arg1[0, 0, 0, 0] [7, 7, 3, 64] [1, 1, 1, 1] : memref<7x7x3x64xf32> to memref<7x7x3x64xf32, strided<[1344, 192, 64, 1]>>

--- a/tests/filecheck/backends/test_conv2d_r181_mlir_sv.py
+++ b/tests/filecheck/backends/test_conv2d_r181_mlir_sv.py
@@ -1,5 +1,6 @@
 # RUN: python %s 2>&1 | filecheck %s
 # UNSUPPORTED: mlir-target=nvgpu
+# UNSUPPORTED: mlir-target=c
 
 import xtc.graphs.xtc.op as O
 from xtc.backends.mlir.MlirGraphBackend import MlirGraphBackend as Backend
@@ -69,44 +70,35 @@ print(f"CODE: {res}")
 # CHECK-NEXT:      transform.yield %0 : !transform.any_op
 # CHECK-NEXT:    }
 # CHECK-NEXT:    transform.named_sequence @__transform_main(%arg0: !transform.any_op {transform.readonly}) {
-# CHECK-NEXT:      %0 = transform.structured.match attributes {__xtc_id_O_0_} in %arg0 : (!transform.any_op) -> !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op, %loops = transform.structured.tile_using_for %0 tile_sizes [1, 0, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      %0 = transform.structured.match attributes {__xtc_id_O_} in %arg0 : (!transform.any_op) -> !transform.any_op
+# CHECK-NEXT:      %tiled_linalg_op, %loops = transform.structured.tile_using_for %0 tile_sizes [1, 0, 0, 0, 0, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
 # CHECK-NEXT:      transform.annotate %loops "./b" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_0, %loops_1 = transform.structured.tile_using_for %tiled_linalg_op tile_sizes [0, 1, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      %tiled_linalg_op_0, %loops_1 = transform.structured.tile_using_for %tiled_linalg_op tile_sizes [0, 1, 0, 0, 0, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
 # CHECK-NEXT:      transform.annotate %loops_1 "./h" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_2, %loops_3 = transform.structured.tile_using_for %tiled_linalg_op_0 tile_sizes [0, 0, 1, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      %tiled_linalg_op_2, %loops_3 = transform.structured.tile_using_for %tiled_linalg_op_0 tile_sizes [0, 0, 4, 0, 0, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
 # CHECK-NEXT:      transform.annotate %loops_3 "./w" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_4, %loops_5 = transform.structured.tile_using_for %tiled_linalg_op_2 tile_sizes [0, 0, 0, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      %tiled_linalg_op_4, %loops_5 = transform.structured.tile_using_for %tiled_linalg_op_2 tile_sizes [0, 0, 0, 16, 0, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
 # CHECK-NEXT:      transform.annotate %loops_5 "./f" : !transform.any_op
-# CHECK-NEXT:      %1 = transform.structured.match attributes {__xtc_id_O_} in %arg0 : (!transform.any_op) -> !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_6, %loops_7 = transform.structured.tile_using_for %1 tile_sizes [1, 0, 0, 0, 0, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_7 "./b" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_8, %loops_9 = transform.structured.tile_using_for %tiled_linalg_op_6 tile_sizes [0, 1, 0, 0, 0, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_9 "./h" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_10, %loops_11 = transform.structured.tile_using_for %tiled_linalg_op_8 tile_sizes [0, 0, 4, 0, 0, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_11 "./w" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_12, %loops_13 = transform.structured.tile_using_for %tiled_linalg_op_10 tile_sizes [0, 0, 0, 16, 0, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_13 "./f" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_14, %loops_15 = transform.structured.tile_using_for %tiled_linalg_op_12 tile_sizes [0, 0, 0, 0, 1, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_15 "./r" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_16, %loops_17 = transform.structured.tile_using_for %tiled_linalg_op_14 tile_sizes [0, 0, 0, 0, 0, 1, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_17 "./s" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_18, %loops_19 = transform.structured.tile_using_for %tiled_linalg_op_16 tile_sizes [0, 0, 0, 0, 0, 0, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_19 "./c" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_20, %loops_21 = transform.structured.tile_using_for %tiled_linalg_op_18 tile_sizes [0, 0, 1, 0, 0, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_21 "./w1" : !transform.any_op
-# CHECK-NEXT:      transform.loop.unroll %loops_21 {factor = 4 : i64} : !transform.any_op
-# CHECK-NEXT:      transform.loop.unroll %loops_19 {factor = 3 : i64} : !transform.any_op
-# CHECK-NEXT:      %2 = transform.get_parent_op %loops_7 {isolated_from_above} : (!transform.any_op) -> !transform.any_op
-# CHECK-NEXT:      %3 = transform.apply_registered_pass "convert-linalg-to-affine-loops" to %2 : (!transform.any_op) -> !transform.any_op
-# CHECK-NEXT:      %4 = transform.include @_super_vectorize failures(suppress) (%3) : (!transform.any_op) -> !transform.any_op
-# CHECK-NEXT:      transform.yield 
+# CHECK-NEXT:      %tiled_linalg_op_6, %loops_7 = transform.structured.tile_using_for %tiled_linalg_op_4 tile_sizes [0, 0, 0, 0, 1, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      transform.annotate %loops_7 "./r" : !transform.any_op
+# CHECK-NEXT:      %tiled_linalg_op_8, %loops_9 = transform.structured.tile_using_for %tiled_linalg_op_6 tile_sizes [0, 0, 0, 0, 0, 1, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      transform.annotate %loops_9 "./s" : !transform.any_op
+# CHECK-NEXT:      %tiled_linalg_op_10, %loops_11 = transform.structured.tile_using_for %tiled_linalg_op_8 tile_sizes [0, 0, 0, 0, 0, 0, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      transform.annotate %loops_11 "./c" : !transform.any_op
+# CHECK-NEXT:      %tiled_linalg_op_12, %loops_13 = transform.structured.tile_using_for %tiled_linalg_op_10 tile_sizes [0, 0, 1, 0, 0, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      transform.annotate %loops_13 "./w1" : !transform.any_op
+# CHECK-NEXT:      transform.loop.unroll %loops_13 {factor = 4 : i64} : !transform.any_op
+# CHECK-NEXT:      transform.loop.unroll %loops_11 {factor = 3 : i64} : !transform.any_op
+# CHECK-NEXT:      %1 = transform.get_parent_op %loops {isolated_from_above} : (!transform.any_op) -> !transform.any_op
+# CHECK-NEXT:      %2 = transform.apply_registered_pass "convert-linalg-to-affine-loops" to %1 : (!transform.any_op) -> !transform.any_op
+# CHECK-NEXT:      %3 = transform.include @_super_vectorize failures(suppress) (%2) : (!transform.any_op) -> !transform.any_op
+# CHECK-NEXT:      transform.yield
 # CHECK-NEXT:    }
 # CHECK-NEXT:  }
 
 # CHECK: MLIR Error: NYI: non-trivial layout map
 
-# CHECK:  // -----// IR Dump After transform //----- //
+# CHECK:       // -----// IR Dump After transform //----- //
 # CHECK-NEXT:  #map = affine_map<(d0) -> (d0 * 2)>
 # CHECK-NEXT:  #map1 = affine_map<(d0, d1) -> (d0 * 2 + d1)>
 # CHECK-NEXT:  module attributes {transform.with_named_sequence} {
@@ -116,33 +108,22 @@ print(f"CODE: {res}")
 # CHECK-NEXT:      %c2 = arith.constant 2 : index
 # CHECK-NEXT:      %c7 = arith.constant 7 : index
 # CHECK-NEXT:      %c16 = arith.constant 16 : index
-# CHECK-NEXT:      %c4 = arith.constant 4 : index
 # CHECK-NEXT:      %c64 = arith.constant 64 : index
+# CHECK-NEXT:      %c4 = arith.constant 4 : index
 # CHECK-NEXT:      %c112 = arith.constant 112 : index
-# CHECK-NEXT:      %cst = arith.constant 0.000000e+00 : f32
-# CHECK-NEXT:      %c0 = arith.constant 0 : index
 # CHECK-NEXT:      %c1 = arith.constant 1 : index
-# CHECK-NEXT:      scf.for %arg3 = %c0 to %c1 step %c1 {
-# CHECK-NEXT:        %subview = memref.subview %arg2[%arg3, 0, 0, 0] [1, 112, 112, 64] [1, 1, 1, 1] : memref<1x112x112x64xf32> to memref<1x112x112x64xf32, strided<[802816, 7168, 64, 1], offset: ?>>
-# CHECK-NEXT:        scf.for %arg4 = %c0 to %c112 step %c1 {
-# CHECK-NEXT:          %subview_0 = memref.subview %subview[0, %arg4, 0, 0] [1, 1, 112, 64] [1, 1, 1, 1] : memref<1x112x112x64xf32, strided<[802816, 7168, 64, 1], offset: ?>> to memref<1x1x112x64xf32, strided<[802816, 7168, 64, 1], offset: ?>>
-# CHECK-NEXT:          scf.for %arg5 = %c0 to %c112 step %c1 {
-# CHECK-NEXT:            %subview_1 = memref.subview %subview_0[0, 0, %arg5, 0] [1, 1, 1, 64] [1, 1, 1, 1] : memref<1x1x112x64xf32, strided<[802816, 7168, 64, 1], offset: ?>> to memref<1x1x1x64xf32, strided<[802816, 7168, 64, 1], offset: ?>>
-# CHECK-NEXT:            scf.for %arg6 = %c0 to %c64 step %c1 {
-# CHECK-NEXT:              %subview_2 = memref.subview %subview_1[0, 0, 0, %arg6] [1, 1, 1, 1] [1, 1, 1, 1] : memref<1x1x1x64xf32, strided<[802816, 7168, 64, 1], offset: ?>> to memref<1x1x1x1xf32, strided<[802816, 7168, 64, 1], offset: ?>>
-# CHECK-NEXT:              affine.for %arg7 = 0 to 1 {
-# CHECK-NEXT:                affine.for %arg8 = 0 to 1 {
-# CHECK-NEXT:                  affine.for %arg9 = 0 to 1 {
-# CHECK-NEXT:                    affine.for %arg10 = 0 to 1 {
-# CHECK-NEXT:                      affine.store %cst, %subview_2[%arg7, %arg8, %arg9, %arg10] : memref<1x1x1x1xf32, strided<[802816, 7168, 64, 1], offset: ?>>
-# CHECK-NEXT:                    }
-# CHECK-NEXT:                  }
-# CHECK-NEXT:                }
-# CHECK-NEXT:              }
-# CHECK-NEXT:            } {"./f"}
-# CHECK-NEXT:          } {"./w"}
-# CHECK-NEXT:        } {"./h"}
-# CHECK-NEXT:      } {"./b"}
+# CHECK-NEXT:      %c0 = arith.constant 0 : index
+# CHECK-NEXT:      %cst = arith.constant 0.000000e+00 : f32
+# CHECK-NEXT:      affine.for %arg3 = 0 to 1 {
+# CHECK-NEXT:        affine.for %arg4 = 0 to 112 {
+# CHECK-NEXT:          affine.for %arg5 = 0 to 112 {
+# CHECK-NEXT:            affine.for %arg6 = 0 to 64 step 16 {
+# CHECK-NEXT:              %cst_0 = arith.constant dense<0.000000e+00> : vector<16xf32>
+# CHECK-NEXT:              vector.transfer_write %cst_0, %arg2[%arg3, %arg4, %arg5, %arg6] : vector<16xf32>, memref<1x112x112x64xf32>
+# CHECK-NEXT:            }
+# CHECK-NEXT:          }
+# CHECK-NEXT:        }
+# CHECK-NEXT:      }
 # CHECK-NEXT:      scf.for %arg3 = %c0 to %c1 step %c1 {
 # CHECK-NEXT:        %subview = memref.subview %arg0[%arg3, 0, 0, 0] [1, 229, 229, 3] [1, 1, 1, 1] : memref<1x230x230x3xf32> to memref<1x229x229x3xf32, strided<[158700, 690, 3, 1], offset: ?>>
 # CHECK-NEXT:        %subview_0 = memref.subview %arg1[0, 0, 0, 0] [7, 7, 3, 64] [1, 1, 1, 1] : memref<7x7x3x64xf32> to memref<7x7x3x64xf32, strided<[1344, 192, 64, 1]>>

--- a/tests/filecheck/backends/test_conv2d_relu_mlir.py
+++ b/tests/filecheck/backends/test_conv2d_relu_mlir.py
@@ -66,40 +66,31 @@ print(f"CODE: {res}")
 # CHECK-NEXT:      transform.yield 
 # CHECK-NEXT:    }
 # CHECK-NEXT:    transform.named_sequence @__transform_main(%arg0: !transform.any_op {transform.readonly}) {
-# CHECK-NEXT:      %0 = transform.structured.match attributes {__xtc_id_O_0_} in %arg0 : (!transform.any_op) -> !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op, %loops = transform.structured.tile_using_for %0 tile_sizes [1, 0, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      %0 = transform.structured.match attributes {__xtc_id_O_} in %arg0 : (!transform.any_op) -> !transform.any_op
+# CHECK-NEXT:      %tiled_linalg_op, %loops = transform.structured.tile_using_for %0 tile_sizes [1, 0, 0, 0, 0, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
 # CHECK-NEXT:      transform.annotate %loops "./b" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_0, %loops_1 = transform.structured.tile_using_for %tiled_linalg_op tile_sizes [0, 1, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      %tiled_linalg_op_0, %loops_1 = transform.structured.tile_using_for %tiled_linalg_op tile_sizes [0, 1, 0, 0, 0, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
 # CHECK-NEXT:      transform.annotate %loops_1 "./h" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_2, %loops_3 = transform.structured.tile_using_for %tiled_linalg_op_0 tile_sizes [0, 0, 1, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      %tiled_linalg_op_2, %loops_3 = transform.structured.tile_using_for %tiled_linalg_op_0 tile_sizes [0, 0, 1, 0, 0, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
 # CHECK-NEXT:      transform.annotate %loops_3 "./w" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_4, %loops_5 = transform.structured.tile_using_for %tiled_linalg_op_2 tile_sizes [0, 0, 0, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      %tiled_linalg_op_4, %loops_5 = transform.structured.tile_using_for %tiled_linalg_op_2 tile_sizes [0, 0, 0, 1, 0, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
 # CHECK-NEXT:      transform.annotate %loops_5 "./f" : !transform.any_op
-# CHECK-NEXT:      %1 = transform.structured.match attributes {__xtc_id_O_} in %arg0 : (!transform.any_op) -> !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_6, %loops_7 = transform.structured.tile_using_for %1 tile_sizes [1, 0, 0, 0, 0, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_7 "./b" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_8, %loops_9 = transform.structured.tile_using_for %tiled_linalg_op_6 tile_sizes [0, 1, 0, 0, 0, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_9 "./h" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_10, %loops_11 = transform.structured.tile_using_for %tiled_linalg_op_8 tile_sizes [0, 0, 1, 0, 0, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_11 "./w" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_12, %loops_13 = transform.structured.tile_using_for %tiled_linalg_op_10 tile_sizes [0, 0, 0, 1, 0, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_13 "./f" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_14, %loops_15 = transform.structured.tile_using_for %tiled_linalg_op_12 tile_sizes [0, 0, 0, 0, 1, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_15 "./r" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_16, %loops_17 = transform.structured.tile_using_for %tiled_linalg_op_14 tile_sizes [0, 0, 0, 0, 0, 1, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_17 "./s" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_18, %loops_19 = transform.structured.tile_using_for %tiled_linalg_op_16 tile_sizes [0, 0, 0, 0, 0, 0, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_19 "./c" : !transform.any_op
-# CHECK-NEXT:      %2 = transform.structured.match attributes {__xtc_id_relu_} in %arg0 : (!transform.any_op) -> !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_20, %loops_21 = transform.structured.tile_using_for %2 tile_sizes [16] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_21 "./i" : !transform.any_op
-# CHECK-NEXT:      transform.include @_vecto failures(suppress) (%tiled_linalg_op_20) : (!transform.any_op) -> ()
-# CHECK-NEXT:      %3 = transform.get_parent_op %loops_21 {isolated_from_above} : (!transform.any_op) -> !transform.any_op
-# CHECK-NEXT:      transform.apply_patterns to %3 {
+# CHECK-NEXT:      %tiled_linalg_op_6, %loops_7 = transform.structured.tile_using_for %tiled_linalg_op_4 tile_sizes [0, 0, 0, 0, 1, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      transform.annotate %loops_7 "./r" : !transform.any_op
+# CHECK-NEXT:      %tiled_linalg_op_8, %loops_9 = transform.structured.tile_using_for %tiled_linalg_op_6 tile_sizes [0, 0, 0, 0, 0, 1, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      transform.annotate %loops_9 "./s" : !transform.any_op
+# CHECK-NEXT:      %tiled_linalg_op_10, %loops_11 = transform.structured.tile_using_for %tiled_linalg_op_8 tile_sizes [0, 0, 0, 0, 0, 0, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      transform.annotate %loops_11 "./c" : !transform.any_op
+# CHECK-NEXT:      %1 = transform.structured.match attributes {__xtc_id_relu_} in %arg0 : (!transform.any_op) -> !transform.any_op
+# CHECK-NEXT:      %tiled_linalg_op_12, %loops_13 = transform.structured.tile_using_for %1 tile_sizes [16] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      transform.annotate %loops_13 "./i" : !transform.any_op
+# CHECK-NEXT:      transform.include @_vecto failures(suppress) (%tiled_linalg_op_12) : (!transform.any_op) -> ()
+# CHECK-NEXT:      %2 = transform.get_parent_op %loops_13 {isolated_from_above} : (!transform.any_op) -> !transform.any_op
+# CHECK-NEXT:      transform.apply_patterns to %2 {
 # CHECK-NEXT:        transform.apply_patterns.vector.reduction_to_contract
 # CHECK-NEXT:        transform.apply_patterns.vector.transfer_permutation_patterns
 # CHECK-NEXT:      } : !transform.any_op
-# CHECK-NEXT:      transform.apply_patterns to %3 {
+# CHECK-NEXT:      transform.apply_patterns to %2 {
 # CHECK-NEXT:        transform.apply_patterns.vector.lower_outerproduct
 # CHECK-NEXT:        transform.apply_patterns.vector.lower_contraction
 # CHECK-NEXT:      } : !transform.any_op
@@ -123,19 +114,7 @@ print(f"CODE: {res}")
 # CHECK-NEXT:      %c0 = arith.constant 0 : index
 # CHECK-NEXT:      %cst_0 = arith.constant 0.000000e+00 : f32
 # CHECK-NEXT:      %alloca = memref.alloca() {alignment = 256 : i64} : memref<1x8x8x16xf32>
-# CHECK-NEXT:      scf.for %arg3 = %c0 to %c1 step %c1 {
-# CHECK-NEXT:        %subview = memref.subview %alloca[%arg3, 0, 0, 0] [1, 8, 8, 16] [1, 1, 1, 1] : memref<1x8x8x16xf32> to memref<1x8x8x16xf32, strided<[1024, 128, 16, 1], offset: ?>>
-# CHECK-NEXT:        scf.for %arg4 = %c0 to %c8 step %c1 {
-# CHECK-NEXT:          %subview_2 = memref.subview %subview[0, %arg4, 0, 0] [1, 1, 8, 16] [1, 1, 1, 1] : memref<1x8x8x16xf32, strided<[1024, 128, 16, 1], offset: ?>> to memref<1x1x8x16xf32, strided<[1024, 128, 16, 1], offset: ?>>
-# CHECK-NEXT:          scf.for %arg5 = %c0 to %c8 step %c1 {
-# CHECK-NEXT:            %subview_3 = memref.subview %subview_2[0, 0, %arg5, 0] [1, 1, 1, 16] [1, 1, 1, 1] : memref<1x1x8x16xf32, strided<[1024, 128, 16, 1], offset: ?>> to memref<1x1x1x16xf32, strided<[1024, 128, 16, 1], offset: ?>>
-# CHECK-NEXT:            scf.for %arg6 = %c0 to %c16 step %c1 {
-# CHECK-NEXT:              %subview_4 = memref.subview %subview_3[0, 0, 0, %arg6] [1, 1, 1, 1] [1, 1, 1, 1] : memref<1x1x1x16xf32, strided<[1024, 128, 16, 1], offset: ?>> to memref<1x1x1x1xf32, strided<[1024, 128, 16, 1], offset: ?>>
-# CHECK-NEXT:              linalg.fill {__xtc_id_O_0_} ins(%cst_0 : f32) outs(%subview_4 : memref<1x1x1x1xf32, strided<[1024, 128, 16, 1], offset: ?>>)
-# CHECK-NEXT:            } {"./f"}
-# CHECK-NEXT:          } {"./w"}
-# CHECK-NEXT:        } {"./h"}
-# CHECK-NEXT:      } {"./b"}
+# CHECK-NEXT:      linalg.fill {__xtc_id_O_0_} ins(%cst_0 : f32) outs(%alloca : memref<1x8x8x16xf32>)
 # CHECK-NEXT:      scf.for %arg3 = %c0 to %c1 step %c1 {
 # CHECK-NEXT:        %subview = memref.subview %arg0[%arg3, 0, 0, 0] [1, 10, 10, 3] [1, 1, 1, 1] : memref<1x10x10x3xf32> to memref<1x10x10x3xf32, strided<[300, 30, 3, 1], offset: ?>>
 # CHECK-NEXT:        %subview_2 = memref.subview %arg1[0, 0, 0, 0] [3, 3, 3, 16] [1, 1, 1, 1] : memref<3x3x3x16xf32> to memref<3x3x3x16xf32, strided<[144, 48, 16, 1]>>

--- a/tests/filecheck/backends/test_matmul_mlir.py
+++ b/tests/filecheck/backends/test_matmul_mlir.py
@@ -47,28 +47,23 @@ print(f"CODE: {res}")
 # CHECK-NEXT:      transform.yield 
 # CHECK-NEXT:    }
 # CHECK-NEXT:    transform.named_sequence @__transform_main(%arg0: !transform.any_op {transform.readonly}) {
-# CHECK-NEXT:      %0 = transform.structured.match attributes {__xtc_id_C_0_} in %arg0 : (!transform.any_op) -> !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op, %loops = transform.structured.tile_using_for %0 tile_sizes [1, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops "./i" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_0, %loops_1 = transform.structured.tile_using_for %tiled_linalg_op tile_sizes [0, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_1 "./j" : !transform.any_op
-# CHECK-NEXT:      %1 = transform.structured.match attributes {__xtc_id_C_} in %arg0 : (!transform.any_op) -> !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_2, %loops_3 = transform.structured.tile_using_for %1 tile_sizes [0, 0, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_3 "./k" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_4, %loops_5 = transform.structured.tile_using_for %tiled_linalg_op_2 tile_sizes [2, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_5 "./i" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_6, %loops_7 = transform.structured.tile_using_for %tiled_linalg_op_4 tile_sizes [0, 16, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_7 "./j" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_8, %loops_9 = transform.structured.tile_using_for %tiled_linalg_op_6 tile_sizes [1, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_9 "./i1" : !transform.any_op
-# CHECK-NEXT:      transform.include @_vecto failures(suppress) (%tiled_linalg_op_8) : (!transform.any_op) -> ()
-# CHECK-NEXT:      transform.loop.unroll %loops_9 {factor = 2 : i64} : !transform.any_op
-# CHECK-NEXT:      %2 = transform.get_parent_op %loops_3 {isolated_from_above} : (!transform.any_op) -> !transform.any_op
-# CHECK-NEXT:      transform.apply_patterns to %2 {
+# CHECK-NEXT:      %0 = transform.structured.match attributes {__xtc_id_C_} in %arg0 : (!transform.any_op) -> !transform.any_op
+# CHECK-NEXT:      %tiled_linalg_op, %loops = transform.structured.tile_using_for %0 tile_sizes [0, 0, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      transform.annotate %loops "./k" : !transform.any_op
+# CHECK-NEXT:      %tiled_linalg_op_0, %loops_1 = transform.structured.tile_using_for %tiled_linalg_op tile_sizes [2, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      transform.annotate %loops_1 "./i" : !transform.any_op
+# CHECK-NEXT:      %tiled_linalg_op_2, %loops_3 = transform.structured.tile_using_for %tiled_linalg_op_0 tile_sizes [0, 16, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      transform.annotate %loops_3 "./j" : !transform.any_op
+# CHECK-NEXT:      %tiled_linalg_op_4, %loops_5 = transform.structured.tile_using_for %tiled_linalg_op_2 tile_sizes [1, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      transform.annotate %loops_5 "./i1" : !transform.any_op
+# CHECK-NEXT:      transform.include @_vecto failures(suppress) (%tiled_linalg_op_4) : (!transform.any_op) -> ()
+# CHECK-NEXT:      transform.loop.unroll %loops_5 {factor = 2 : i64} : !transform.any_op
+# CHECK-NEXT:      %1 = transform.get_parent_op %loops {isolated_from_above} : (!transform.any_op) -> !transform.any_op
+# CHECK-NEXT:      transform.apply_patterns to %1 {
 # CHECK-NEXT:        transform.apply_patterns.vector.reduction_to_contract
 # CHECK-NEXT:        transform.apply_patterns.vector.transfer_permutation_patterns
 # CHECK-NEXT:      } : !transform.any_op
-# CHECK-NEXT:      transform.apply_patterns to %2 {
+# CHECK-NEXT:      transform.apply_patterns to %1 {
 # CHECK-NEXT:        transform.apply_patterns.vector.lower_outerproduct
 # CHECK-NEXT:        transform.apply_patterns.vector.lower_contraction
 # CHECK-NEXT:      } : !transform.any_op
@@ -82,20 +77,14 @@ print(f"CODE: {res}")
 # CHECK-NEXT:      %cst = arith.constant dense<0.000000e+00> : vector<1x16xf32>
 # CHECK-NEXT:      %0 = ub.poison : f32
 # CHECK-NEXT:      %c16 = arith.constant 16 : index
-# CHECK-NEXT:      %c2 = arith.constant 2 : index
-# CHECK-NEXT:      %c512 = arith.constant 512 : index
 # CHECK-NEXT:      %c32 = arith.constant 32 : index
-# CHECK-NEXT:      %cst_0 = arith.constant 0.000000e+00 : f32
-# CHECK-NEXT:      %c0 = arith.constant 0 : index
+# CHECK-NEXT:      %c2 = arith.constant 2 : index
 # CHECK-NEXT:      %c4 = arith.constant 4 : index
 # CHECK-NEXT:      %c1 = arith.constant 1 : index
-# CHECK-NEXT:      scf.for %arg3 = %c0 to %c4 step %c1 {
-# CHECK-NEXT:        %subview = memref.subview %arg2[%arg3, 0] [1, 32] [1, 1] : memref<4x32xf32> to memref<1x32xf32, strided<[32, 1], offset: ?>>
-# CHECK-NEXT:        scf.for %arg4 = %c0 to %c32 step %c1 {
-# CHECK-NEXT:          %subview_1 = memref.subview %subview[0, %arg4] [1, 1] [1, 1] : memref<1x32xf32, strided<[32, 1], offset: ?>> to memref<1x1xf32, strided<[32, 1], offset: ?>>
-# CHECK-NEXT:          linalg.fill {__xtc_id_C_0_} ins(%cst_0 : f32) outs(%subview_1 : memref<1x1xf32, strided<[32, 1], offset: ?>>)
-# CHECK-NEXT:        } {"./j"}
-# CHECK-NEXT:      } {"./i"}
+# CHECK-NEXT:      %c512 = arith.constant 512 : index
+# CHECK-NEXT:      %c0 = arith.constant 0 : index
+# CHECK-NEXT:      %cst_0 = arith.constant 0.000000e+00 : f32
+# CHECK-NEXT:      linalg.fill {__xtc_id_C_0_} ins(%cst_0 : f32) outs(%arg2 : memref<4x32xf32>)
 # CHECK-NEXT:      scf.for %arg3 = %c0 to %c512 step %c1 {
 # CHECK-NEXT:        %subview = memref.subview %arg0[0, %arg3] [4, 1] [1, 1] : memref<4x512xf32> to memref<4x1xf32, strided<[512, 1], offset: ?>>
 # CHECK-NEXT:        %subview_1 = memref.subview %arg1[%arg3, 0] [1, 32] [1, 1] : memref<512x32xf32> to memref<1x32xf32, strided<[32, 1], offset: ?>>

--- a/tests/filecheck/backends/test_matmul_mlir_const.py
+++ b/tests/filecheck/backends/test_matmul_mlir_const.py
@@ -38,22 +38,17 @@ print(f"CODE: {res}")
 # CHECK-NEXT:    }
 # CHECK-NEXT:    transform.named_sequence @_vecto(%arg0: !transform.any_op {transform.consumed}) {
 # CHECK-NEXT:      transform.structured.vectorize %arg0 : !transform.any_op
-# CHECK-NEXT:      transform.yield
+# CHECK-NEXT:      transform.yield 
 # CHECK-NEXT:    }
 # CHECK-NEXT:    transform.named_sequence @__transform_main(%arg0: !transform.any_op {transform.readonly}) {
-# CHECK-NEXT:      %0 = transform.structured.match attributes {__xtc_id_C_0_} in %arg0 : (!transform.any_op) -> !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op, %loops = transform.structured.tile_using_for %0 tile_sizes [1, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      %0 = transform.structured.match attributes {__xtc_id_C_} in %arg0 : (!transform.any_op) -> !transform.any_op
+# CHECK-NEXT:      %tiled_linalg_op, %loops = transform.structured.tile_using_for %0 tile_sizes [1, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
 # CHECK-NEXT:      transform.annotate %loops "./i" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_0, %loops_1 = transform.structured.tile_using_for %tiled_linalg_op tile_sizes [0, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      %tiled_linalg_op_0, %loops_1 = transform.structured.tile_using_for %tiled_linalg_op tile_sizes [0, 1, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
 # CHECK-NEXT:      transform.annotate %loops_1 "./j" : !transform.any_op
-# CHECK-NEXT:      %1 = transform.structured.match attributes {__xtc_id_C_} in %arg0 : (!transform.any_op) -> !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_2, %loops_3 = transform.structured.tile_using_for %1 tile_sizes [1, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_3 "./i" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_4, %loops_5 = transform.structured.tile_using_for %tiled_linalg_op_2 tile_sizes [0, 1, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_5 "./j" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_6, %loops_7 = transform.structured.tile_using_for %tiled_linalg_op_4 tile_sizes [0, 0, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_7 "./k" : !transform.any_op
-# CHECK-NEXT:      transform.yield
+# CHECK-NEXT:      %tiled_linalg_op_2, %loops_3 = transform.structured.tile_using_for %tiled_linalg_op_0 tile_sizes [0, 0, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      transform.annotate %loops_3 "./k" : !transform.any_op
+# CHECK-NEXT:      transform.yield 
 # CHECK-NEXT:    }
 # CHECK-NEXT:  }
 # CHECK-NEXT:  

--- a/tests/filecheck/backends/test_matmul_mlir_distributed.py
+++ b/tests/filecheck/backends/test_matmul_mlir_distributed.py
@@ -57,30 +57,25 @@ print(f"CODE: {res}")
 # CHECK-NEXT:    transform.named_sequence @__transform_main(%arg0: !transform.any_op {transform.readonly}) {
 # CHECK-NEXT:      %0 = transform.sdist.create_memory_mesh %arg0 "memory_mesh" = <["mx"=2, "my"=2]> : !transform.any_op -> !transform.any_op
 # CHECK-NEXT:      %1 = transform.sdist.create_processor_mesh %arg0 "processor_mesh" = <["px"=2, "py"=2, "psx"=2, "psy"=8]> from "memory_mesh" : !transform.any_op -> !transform.any_op
-# CHECK-NEXT:      %2 = transform.structured.match attributes {__xtc_id_C_0_} in %arg0 : (!transform.any_op) -> !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op, %loops = transform.structured.tile_using_for %2 tile_sizes [1, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops "./i" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_0, %loops_1 = transform.structured.tile_using_for %tiled_linalg_op tile_sizes [0, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_1 "./j" : !transform.any_op
-# CHECK-NEXT:      %3 = transform.structured.match attributes {__xtc_id_C_} in %arg0 : (!transform.any_op) -> !transform.any_op
-# CHECK-NEXT:      %4 = transform.sdist.distribute_buffer_at %3 tensor 1 with ["mx", "*"] on "memory_mesh" : !transform.any_op -> !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_2, %loops_3 = transform.structured.tile_using_for %3 tile_sizes [0, 0, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_3 "./k" : !transform.any_op
-# CHECK-NEXT:      transform.apply_patterns to %tiled_linalg_op_2 {
+# CHECK-NEXT:      %2 = transform.structured.match attributes {__xtc_id_C_} in %arg0 : (!transform.any_op) -> !transform.any_op
+# CHECK-NEXT:      %3 = transform.sdist.distribute_buffer_at %2 tensor 1 with ["mx", "*"] on "memory_mesh" : !transform.any_op -> !transform.any_op
+# CHECK-NEXT:      %tiled_linalg_op, %loops = transform.structured.tile_using_for %2 tile_sizes [0, 0, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      transform.annotate %loops "./k" : !transform.any_op
+# CHECK-NEXT:      transform.apply_patterns to %tiled_linalg_op {
 # CHECK-NEXT:        transform.apply_patterns.memref.fold_memref_alias_ops
 # CHECK-NEXT:      } : !transform.any_op
-# CHECK-NEXT:      %5 = transform.sdist.local_buffer_at %tiled_linalg_op_2 tensor 1 : !transform.any_op -> !transform.any_op
-# CHECK-NEXT:      %tiled_op, %forall_op = transform.structured.tile_using_forall %tiled_linalg_op_2 tile_sizes [2, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      %4 = transform.sdist.local_buffer_at %tiled_linalg_op tensor 1 : !transform.any_op -> !transform.any_op
+# CHECK-NEXT:      %tiled_op, %forall_op = transform.structured.tile_using_forall %tiled_linalg_op tile_sizes [2, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
 # CHECK-NEXT:      transform.annotate %forall_op "./i" : !transform.any_op
 # CHECK-NEXT:      %transformed, %tiledOp = transform.sdist.distribute_loop %forall_op {axis = "px", mesh = "processor_mesh"} : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
 # CHECK-NEXT:      transform.annotate %transformed "./i" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_4, %loops_5 = transform.structured.tile_using_for %tiledOp tile_sizes [0, 16, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_5 "./j" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_6, %loops_7 = transform.structured.tile_using_for %tiled_linalg_op_4 tile_sizes [1, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_7 "./i1" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_8, %loops_9 = transform.structured.tile_using_for %tiled_linalg_op_6 tile_sizes [0, 1, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_9 "./j1" : !transform.any_op
-# CHECK-NEXT:      transform.loop.unroll %loops_7 {factor = 2 : i64} : !transform.any_op
+# CHECK-NEXT:      %tiled_linalg_op_0, %loops_1 = transform.structured.tile_using_for %tiledOp tile_sizes [0, 16, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      transform.annotate %loops_1 "./j" : !transform.any_op
+# CHECK-NEXT:      %tiled_linalg_op_2, %loops_3 = transform.structured.tile_using_for %tiled_linalg_op_0 tile_sizes [1, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      transform.annotate %loops_3 "./i1" : !transform.any_op
+# CHECK-NEXT:      %tiled_linalg_op_4, %loops_5 = transform.structured.tile_using_for %tiled_linalg_op_2 tile_sizes [0, 1, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      transform.annotate %loops_5 "./j1" : !transform.any_op
+# CHECK-NEXT:      transform.loop.unroll %loops_3 {factor = 2 : i64} : !transform.any_op
 # CHECK-NEXT:      transform.yield 
 # CHECK-NEXT:    }
 # CHECK-NEXT:  }
@@ -92,75 +87,63 @@ print(f"CODE: {res}")
 # CHECK-NEXT:    sdist.memory_mesh @memory_mesh = <["mx"=2, "my"=2]>
 # CHECK-NEXT:    func.func @matmul(%arg0: memref<4x512xf32> {llvm.noalias}, %arg1: memref<512x32xf32> {llvm.noalias}, %arg2: memref<4x32xf32> {llvm.noalias}) {
 # CHECK-NEXT:      %cst = arith.constant 0.000000e+00 : f32
-# CHECK-NEXT:      %c0 = arith.constant 0 : index
-# CHECK-NEXT:      %c4 = arith.constant 4 : index
-# CHECK-NEXT:      %c1 = arith.constant 1 : index
-# CHECK-NEXT:      scf.for %arg3 = %c0 to %c4 step %c1 {
-# CHECK-NEXT:        %subview = memref.subview %arg2[%arg3, 0] [1, 32] [1, 1] : memref<4x32xf32> to memref<1x32xf32, strided<[32, 1], offset: ?>>
-# CHECK-NEXT:        %c0_2 = arith.constant 0 : index
-# CHECK-NEXT:        %c32 = arith.constant 32 : index
-# CHECK-NEXT:        %c1_3 = arith.constant 1 : index
-# CHECK-NEXT:        scf.for %arg4 = %c0_2 to %c32 step %c1_3 {
-# CHECK-NEXT:          %subview_4 = memref.subview %subview[0, %arg4] [1, 1] [1, 1] : memref<1x32xf32, strided<[32, 1], offset: ?>> to memref<1x1xf32, strided<[32, 1], offset: ?>>
-# CHECK-NEXT:          linalg.fill {__xtc_id_C_0_} ins(%cst : f32) outs(%subview_4 : memref<1x1xf32, strided<[32, 1], offset: ?>>)
-# CHECK-NEXT:        } {"./j"}
-# CHECK-NEXT:      } {"./i"}
+# CHECK-NEXT:      linalg.fill {__xtc_id_C_0_} ins(%cst : f32) outs(%arg2 : memref<4x32xf32>)
 # CHECK-NEXT:      %0 = sdist.distribute %arg1 ["mx", "*"] on @memory_mesh : memref<512x32xf32>, memref<512x32xf32, 1>
-# CHECK-NEXT:      %c0_0 = arith.constant 0 : index
+# CHECK-NEXT:      %c0 = arith.constant 0 : index
 # CHECK-NEXT:      %c512 = arith.constant 512 : index
-# CHECK-NEXT:      %c1_1 = arith.constant 1 : index
-# CHECK-NEXT:      scf.for %arg3 = %c0_0 to %c512 step %c1_1 {
+# CHECK-NEXT:      %c1 = arith.constant 1 : index
+# CHECK-NEXT:      scf.for %arg3 = %c0 to %c512 step %c1 {
 # CHECK-NEXT:        %subview = memref.subview %arg0[0, %arg3] [4, 1] [1, 1] : memref<4x512xf32> to memref<4x1xf32, strided<[512, 1], offset: ?>>
-# CHECK-NEXT:        %subview_2 = memref.subview %0[%arg3, 0] [1, 32] [1, 1] : memref<512x32xf32, 1> to memref<1x32xf32, strided<[32, 1], offset: ?>, 1>
-# CHECK-NEXT:        %subview_3 = memref.subview %arg2[0, 0] [4, 32] [1, 1] : memref<4x32xf32> to memref<4x32xf32, strided<[32, 1]>>
+# CHECK-NEXT:        %subview_0 = memref.subview %0[%arg3, 0] [1, 32] [1, 1] : memref<512x32xf32, 1> to memref<1x32xf32, strided<[32, 1], offset: ?>, 1>
+# CHECK-NEXT:        %subview_1 = memref.subview %arg2[0, 0] [4, 32] [1, 1] : memref<4x32xf32> to memref<4x32xf32, strided<[32, 1]>>
 # CHECK-NEXT:        %alloc = memref.alloc() : memref<1x32xf32, 2>
-# CHECK-NEXT:        %c0_4 = arith.constant 0 : index
-# CHECK-NEXT:        sdist.read %0[%arg3, %c0_4] to %alloc : memref<512x32xf32, 1>, memref<1x32xf32, 2>
-# CHECK-NEXT:        %c0_5 = arith.constant 0 : index
+# CHECK-NEXT:        %c0_2 = arith.constant 0 : index
+# CHECK-NEXT:        sdist.read %0[%arg3, %c0_2] to %alloc : memref<512x32xf32, 1>, memref<1x32xf32, 2>
+# CHECK-NEXT:        %c0_3 = arith.constant 0 : index
 # CHECK-NEXT:        %c2 = arith.constant 2 : index
-# CHECK-NEXT:        %c1_6 = arith.constant 1 : index
-# CHECK-NEXT:        sdist.for_distributed %arg4 = %c0_5 to %c2 step [%c1_6] on @processor_mesh("px") {
+# CHECK-NEXT:        %c1_4 = arith.constant 1 : index
+# CHECK-NEXT:        sdist.for_distributed %arg4 = %c0_3 to %c2 step [%c1_4] on @processor_mesh("px") {
 # CHECK-NEXT:          %1 = affine.apply #map(%arg4)
-# CHECK-NEXT:          %subview_7 = memref.subview %subview[%1, 0] [2, 1] [1, 1] : memref<4x1xf32, strided<[512, 1], offset: ?>> to memref<2x1xf32, strided<[512, 1], offset: ?>>
-# CHECK-NEXT:          %subview_8 = memref.subview %alloc[0, 0] [1, 32] [1, 1] : memref<1x32xf32, 2> to memref<1x32xf32, strided<[32, 1]>, 2>
-# CHECK-NEXT:          %subview_9 = memref.subview %subview_3[%1, 0] [2, 32] [1, 1] : memref<4x32xf32, strided<[32, 1]>> to memref<2x32xf32, strided<[32, 1], offset: ?>>
-# CHECK-NEXT:          %c0_10 = arith.constant 0 : index
+# CHECK-NEXT:          %subview_5 = memref.subview %subview[%1, 0] [2, 1] [1, 1] : memref<4x1xf32, strided<[512, 1], offset: ?>> to memref<2x1xf32, strided<[512, 1], offset: ?>>
+# CHECK-NEXT:          %subview_6 = memref.subview %alloc[0, 0] [1, 32] [1, 1] : memref<1x32xf32, 2> to memref<1x32xf32, strided<[32, 1]>, 2>
+# CHECK-NEXT:          %subview_7 = memref.subview %subview_1[%1, 0] [2, 32] [1, 1] : memref<4x32xf32, strided<[32, 1]>> to memref<2x32xf32, strided<[32, 1], offset: ?>>
+# CHECK-NEXT:          %c0_8 = arith.constant 0 : index
 # CHECK-NEXT:          %c32 = arith.constant 32 : index
 # CHECK-NEXT:          %c16 = arith.constant 16 : index
-# CHECK-NEXT:          scf.for %arg5 = %c0_10 to %c32 step %c16 {
-# CHECK-NEXT:            %subview_11 = memref.subview %subview_7[0, 0] [2, 1] [1, 1] : memref<2x1xf32, strided<[512, 1], offset: ?>> to memref<2x1xf32, strided<[512, 1], offset: ?>>
-# CHECK-NEXT:            %subview_12 = memref.subview %subview_8[0, %arg5] [1, 16] [1, 1] : memref<1x32xf32, strided<[32, 1]>, 2> to memref<1x16xf32, strided<[32, 1], offset: ?>, 2>
-# CHECK-NEXT:            %subview_13 = memref.subview %subview_9[0, %arg5] [2, 16] [1, 1] : memref<2x32xf32, strided<[32, 1], offset: ?>> to memref<2x16xf32, strided<[32, 1], offset: ?>>
-# CHECK-NEXT:            %c0_14 = arith.constant 0 : index
+# CHECK-NEXT:          scf.for %arg5 = %c0_8 to %c32 step %c16 {
+# CHECK-NEXT:            %subview_9 = memref.subview %subview_5[0, 0] [2, 1] [1, 1] : memref<2x1xf32, strided<[512, 1], offset: ?>> to memref<2x1xf32, strided<[512, 1], offset: ?>>
+# CHECK-NEXT:            %subview_10 = memref.subview %subview_6[0, %arg5] [1, 16] [1, 1] : memref<1x32xf32, strided<[32, 1]>, 2> to memref<1x16xf32, strided<[32, 1], offset: ?>, 2>
+# CHECK-NEXT:            %subview_11 = memref.subview %subview_7[0, %arg5] [2, 16] [1, 1] : memref<2x32xf32, strided<[32, 1], offset: ?>> to memref<2x16xf32, strided<[32, 1], offset: ?>>
+# CHECK-NEXT:            %c0_12 = arith.constant 0 : index
+# CHECK-NEXT:            %c2_13 = arith.constant 2 : index
+# CHECK-NEXT:            %c1_14 = arith.constant 1 : index
 # CHECK-NEXT:            %c2_15 = arith.constant 2 : index
-# CHECK-NEXT:            %c1_16 = arith.constant 1 : index
-# CHECK-NEXT:            %c2_17 = arith.constant 2 : index
-# CHECK-NEXT:            %subview_18 = memref.subview %subview_11[%c0_14, 0] [1, 1] [1, 1] : memref<2x1xf32, strided<[512, 1], offset: ?>> to memref<1x1xf32, strided<[512, 1], offset: ?>>
-# CHECK-NEXT:            %subview_19 = memref.subview %subview_12[0, 0] [1, 16] [1, 1] : memref<1x16xf32, strided<[32, 1], offset: ?>, 2> to memref<1x16xf32, strided<[32, 1], offset: ?>, 2>
-# CHECK-NEXT:            %subview_20 = memref.subview %subview_13[%c0_14, 0] [1, 16] [1, 1] : memref<2x16xf32, strided<[32, 1], offset: ?>> to memref<1x16xf32, strided<[32, 1], offset: ?>>
-# CHECK-NEXT:            %c0_21 = arith.constant 0 : index
-# CHECK-NEXT:            %c16_22 = arith.constant 16 : index
-# CHECK-NEXT:            %c1_23 = arith.constant 1 : index
-# CHECK-NEXT:            scf.for %arg6 = %c0_21 to %c16_22 step %c1_23 {
-# CHECK-NEXT:              %subview_31 = memref.subview %subview_18[0, 0] [1, 1] [1, 1] : memref<1x1xf32, strided<[512, 1], offset: ?>> to memref<1x1xf32, strided<[512, 1], offset: ?>>
-# CHECK-NEXT:              %subview_32 = memref.subview %subview_19[0, %arg6] [1, 1] [1, 1] : memref<1x16xf32, strided<[32, 1], offset: ?>, 2> to memref<1x1xf32, strided<[32, 1], offset: ?>, 2>
-# CHECK-NEXT:              %subview_33 = memref.subview %subview_20[0, %arg6] [1, 1] [1, 1] : memref<1x16xf32, strided<[32, 1], offset: ?>> to memref<1x1xf32, strided<[32, 1], offset: ?>>
-# CHECK-NEXT:              linalg.matmul {__xtc_id_C_} ins(%subview_31, %subview_32 : memref<1x1xf32, strided<[512, 1], offset: ?>>, memref<1x1xf32, strided<[32, 1], offset: ?>, 2>) outs(%subview_33 : memref<1x1xf32, strided<[32, 1], offset: ?>>)
+# CHECK-NEXT:            %subview_16 = memref.subview %subview_9[%c0_12, 0] [1, 1] [1, 1] : memref<2x1xf32, strided<[512, 1], offset: ?>> to memref<1x1xf32, strided<[512, 1], offset: ?>>
+# CHECK-NEXT:            %subview_17 = memref.subview %subview_10[0, 0] [1, 16] [1, 1] : memref<1x16xf32, strided<[32, 1], offset: ?>, 2> to memref<1x16xf32, strided<[32, 1], offset: ?>, 2>
+# CHECK-NEXT:            %subview_18 = memref.subview %subview_11[%c0_12, 0] [1, 16] [1, 1] : memref<2x16xf32, strided<[32, 1], offset: ?>> to memref<1x16xf32, strided<[32, 1], offset: ?>>
+# CHECK-NEXT:            %c0_19 = arith.constant 0 : index
+# CHECK-NEXT:            %c16_20 = arith.constant 16 : index
+# CHECK-NEXT:            %c1_21 = arith.constant 1 : index
+# CHECK-NEXT:            scf.for %arg6 = %c0_19 to %c16_20 step %c1_21 {
+# CHECK-NEXT:              %subview_29 = memref.subview %subview_16[0, 0] [1, 1] [1, 1] : memref<1x1xf32, strided<[512, 1], offset: ?>> to memref<1x1xf32, strided<[512, 1], offset: ?>>
+# CHECK-NEXT:              %subview_30 = memref.subview %subview_17[0, %arg6] [1, 1] [1, 1] : memref<1x16xf32, strided<[32, 1], offset: ?>, 2> to memref<1x1xf32, strided<[32, 1], offset: ?>, 2>
+# CHECK-NEXT:              %subview_31 = memref.subview %subview_18[0, %arg6] [1, 1] [1, 1] : memref<1x16xf32, strided<[32, 1], offset: ?>> to memref<1x1xf32, strided<[32, 1], offset: ?>>
+# CHECK-NEXT:              linalg.matmul {__xtc_id_C_} ins(%subview_29, %subview_30 : memref<1x1xf32, strided<[512, 1], offset: ?>>, memref<1x1xf32, strided<[32, 1], offset: ?>, 2>) outs(%subview_31 : memref<1x1xf32, strided<[32, 1], offset: ?>>)
 # CHECK-NEXT:            } {"./j1"}
-# CHECK-NEXT:            %c1_24 = arith.constant 1 : index
-# CHECK-NEXT:            %2 = arith.muli %c1_16, %c1_24 : index
-# CHECK-NEXT:            %3 = arith.addi %c0_14, %2 : index
-# CHECK-NEXT:            %subview_25 = memref.subview %subview_11[%3, 0] [1, 1] [1, 1] : memref<2x1xf32, strided<[512, 1], offset: ?>> to memref<1x1xf32, strided<[512, 1], offset: ?>>
-# CHECK-NEXT:            %subview_26 = memref.subview %subview_12[0, 0] [1, 16] [1, 1] : memref<1x16xf32, strided<[32, 1], offset: ?>, 2> to memref<1x16xf32, strided<[32, 1], offset: ?>, 2>
-# CHECK-NEXT:            %subview_27 = memref.subview %subview_13[%3, 0] [1, 16] [1, 1] : memref<2x16xf32, strided<[32, 1], offset: ?>> to memref<1x16xf32, strided<[32, 1], offset: ?>>
-# CHECK-NEXT:            %c0_28 = arith.constant 0 : index
-# CHECK-NEXT:            %c16_29 = arith.constant 16 : index
-# CHECK-NEXT:            %c1_30 = arith.constant 1 : index
-# CHECK-NEXT:            scf.for %arg6 = %c0_28 to %c16_29 step %c1_30 {
-# CHECK-NEXT:              %subview_31 = memref.subview %subview_25[0, 0] [1, 1] [1, 1] : memref<1x1xf32, strided<[512, 1], offset: ?>> to memref<1x1xf32, strided<[512, 1], offset: ?>>
-# CHECK-NEXT:              %subview_32 = memref.subview %subview_26[0, %arg6] [1, 1] [1, 1] : memref<1x16xf32, strided<[32, 1], offset: ?>, 2> to memref<1x1xf32, strided<[32, 1], offset: ?>, 2>
-# CHECK-NEXT:              %subview_33 = memref.subview %subview_27[0, %arg6] [1, 1] [1, 1] : memref<1x16xf32, strided<[32, 1], offset: ?>> to memref<1x1xf32, strided<[32, 1], offset: ?>>
-# CHECK-NEXT:              linalg.matmul {__xtc_id_C_} ins(%subview_31, %subview_32 : memref<1x1xf32, strided<[512, 1], offset: ?>>, memref<1x1xf32, strided<[32, 1], offset: ?>, 2>) outs(%subview_33 : memref<1x1xf32, strided<[32, 1], offset: ?>>)
+# CHECK-NEXT:            %c1_22 = arith.constant 1 : index
+# CHECK-NEXT:            %2 = arith.muli %c1_14, %c1_22 : index
+# CHECK-NEXT:            %3 = arith.addi %c0_12, %2 : index
+# CHECK-NEXT:            %subview_23 = memref.subview %subview_9[%3, 0] [1, 1] [1, 1] : memref<2x1xf32, strided<[512, 1], offset: ?>> to memref<1x1xf32, strided<[512, 1], offset: ?>>
+# CHECK-NEXT:            %subview_24 = memref.subview %subview_10[0, 0] [1, 16] [1, 1] : memref<1x16xf32, strided<[32, 1], offset: ?>, 2> to memref<1x16xf32, strided<[32, 1], offset: ?>, 2>
+# CHECK-NEXT:            %subview_25 = memref.subview %subview_11[%3, 0] [1, 16] [1, 1] : memref<2x16xf32, strided<[32, 1], offset: ?>> to memref<1x16xf32, strided<[32, 1], offset: ?>>
+# CHECK-NEXT:            %c0_26 = arith.constant 0 : index
+# CHECK-NEXT:            %c16_27 = arith.constant 16 : index
+# CHECK-NEXT:            %c1_28 = arith.constant 1 : index
+# CHECK-NEXT:            scf.for %arg6 = %c0_26 to %c16_27 step %c1_28 {
+# CHECK-NEXT:              %subview_29 = memref.subview %subview_23[0, 0] [1, 1] [1, 1] : memref<1x1xf32, strided<[512, 1], offset: ?>> to memref<1x1xf32, strided<[512, 1], offset: ?>>
+# CHECK-NEXT:              %subview_30 = memref.subview %subview_24[0, %arg6] [1, 1] [1, 1] : memref<1x16xf32, strided<[32, 1], offset: ?>, 2> to memref<1x1xf32, strided<[32, 1], offset: ?>, 2>
+# CHECK-NEXT:              %subview_31 = memref.subview %subview_25[0, %arg6] [1, 1] [1, 1] : memref<1x16xf32, strided<[32, 1], offset: ?>> to memref<1x1xf32, strided<[32, 1], offset: ?>>
+# CHECK-NEXT:              linalg.matmul {__xtc_id_C_} ins(%subview_29, %subview_30 : memref<1x1xf32, strided<[512, 1], offset: ?>>, memref<1x1xf32, strided<[32, 1], offset: ?>, 2>) outs(%subview_31 : memref<1x1xf32, strided<[32, 1], offset: ?>>)
 # CHECK-NEXT:            } {"./j1"}
 # CHECK-NEXT:          } {"./j"}
 # CHECK-NEXT:          sdist.terminator

--- a/tests/filecheck/backends/test_matmul_mlir_layout.py
+++ b/tests/filecheck/backends/test_matmul_mlir_layout.py
@@ -46,22 +46,17 @@ print(f"CODE: {res}")
 # CHECK-NEXT:    }
 # CHECK-NEXT:    transform.named_sequence @_vecto(%arg0: !transform.any_op {transform.consumed}) {
 # CHECK-NEXT:      transform.structured.vectorize %arg0 : !transform.any_op
-# CHECK-NEXT:      transform.yield
+# CHECK-NEXT:      transform.yield 
 # CHECK-NEXT:    }
 # CHECK-NEXT:    transform.named_sequence @__transform_main(%arg0: !transform.any_op {transform.readonly}) {
-# CHECK-NEXT:      %0 = transform.structured.match attributes {__xtc_id_C_0_} in %arg0 : (!transform.any_op) -> !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op, %loops = transform.structured.tile_using_for %0 tile_sizes [1, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      %0 = transform.structured.match attributes {__xtc_id_C_} in %arg0 : (!transform.any_op) -> !transform.any_op
+# CHECK-NEXT:      %tiled_linalg_op, %loops = transform.structured.tile_using_for %0 tile_sizes [1, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
 # CHECK-NEXT:      transform.annotate %loops "./i" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_0, %loops_1 = transform.structured.tile_using_for %tiled_linalg_op tile_sizes [0, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      %tiled_linalg_op_0, %loops_1 = transform.structured.tile_using_for %tiled_linalg_op tile_sizes [0, 1, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
 # CHECK-NEXT:      transform.annotate %loops_1 "./j" : !transform.any_op
-# CHECK-NEXT:      %1 = transform.structured.match attributes {__xtc_id_C_} in %arg0 : (!transform.any_op) -> !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_2, %loops_3 = transform.structured.tile_using_for %1 tile_sizes [1, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_3 "./i" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_4, %loops_5 = transform.structured.tile_using_for %tiled_linalg_op_2 tile_sizes [0, 1, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_5 "./j" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_6, %loops_7 = transform.structured.tile_using_for %tiled_linalg_op_4 tile_sizes [0, 0, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_7 "./k" : !transform.any_op
-# CHECK-NEXT:      transform.yield
+# CHECK-NEXT:      %tiled_linalg_op_2, %loops_3 = transform.structured.tile_using_for %tiled_linalg_op_0 tile_sizes [0, 0, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      transform.annotate %loops_3 "./k" : !transform.any_op
+# CHECK-NEXT:      transform.yield 
 # CHECK-NEXT:    }
 # CHECK-NEXT:  }
 # CHECK-NEXT:  

--- a/tests/filecheck/backends/test_matmul_mlir_parallel.py
+++ b/tests/filecheck/backends/test_matmul_mlir_parallel.py
@@ -43,27 +43,22 @@ print(f"CODE: {res}")
 # CHECK-NEXT:    }
 # CHECK-NEXT:    transform.named_sequence @_vecto(%arg0: !transform.any_op {transform.consumed}) {
 # CHECK-NEXT:      transform.structured.vectorize %arg0 : !transform.any_op
-# CHECK-NEXT:      transform.yield
+# CHECK-NEXT:      transform.yield 
 # CHECK-NEXT:    }
 # CHECK-NEXT:    transform.named_sequence @__transform_main(%arg0: !transform.any_op {transform.readonly}) {
-# CHECK-NEXT:      %0 = transform.structured.match attributes {__xtc_id_C_0_} in %arg0 : (!transform.any_op) -> !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op, %loops = transform.structured.tile_using_for %0 tile_sizes [1, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops "./i" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_0, %loops_1 = transform.structured.tile_using_for %tiled_linalg_op tile_sizes [0, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_1 "./j" : !transform.any_op
-# CHECK-NEXT:      %1 = transform.structured.match attributes {__xtc_id_C_} in %arg0 : (!transform.any_op) -> !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_2, %loops_3 = transform.structured.tile_using_for %1 tile_sizes [0, 0, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_3 "./k" : !transform.any_op
-# CHECK-NEXT:      %tiled_op, %forall_op = transform.structured.tile_using_forall %tiled_linalg_op_2 tile_sizes [2, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      %0 = transform.structured.match attributes {__xtc_id_C_} in %arg0 : (!transform.any_op) -> !transform.any_op
+# CHECK-NEXT:      %tiled_linalg_op, %loops = transform.structured.tile_using_for %0 tile_sizes [0, 0, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      transform.annotate %loops "./k" : !transform.any_op
+# CHECK-NEXT:      %tiled_op, %forall_op = transform.structured.tile_using_forall %tiled_linalg_op tile_sizes [2, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
 # CHECK-NEXT:      transform.annotate %forall_op "./i" : !transform.any_op
-# CHECK-NEXT:      %tiled_op_4, %forall_op_5 = transform.structured.tile_using_forall %tiled_op tile_sizes [0, 16, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %forall_op_5 "./j" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_6, %loops_7 = transform.structured.tile_using_for %tiled_op_4 tile_sizes [1, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_7 "./i1" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_8, %loops_9 = transform.structured.tile_using_for %tiled_linalg_op_6 tile_sizes [0, 1, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_9 "./j1" : !transform.any_op
-# CHECK-NEXT:      transform.loop.unroll %loops_7 {factor = 2 : i64} : !transform.any_op
-# CHECK-NEXT:      transform.yield
+# CHECK-NEXT:      %tiled_op_0, %forall_op_1 = transform.structured.tile_using_forall %tiled_op tile_sizes [0, 16, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      transform.annotate %forall_op_1 "./j" : !transform.any_op
+# CHECK-NEXT:      %tiled_linalg_op_2, %loops_3 = transform.structured.tile_using_for %tiled_op_0 tile_sizes [1, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      transform.annotate %loops_3 "./i1" : !transform.any_op
+# CHECK-NEXT:      %tiled_linalg_op_4, %loops_5 = transform.structured.tile_using_for %tiled_linalg_op_2 tile_sizes [0, 1, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      transform.annotate %loops_5 "./j1" : !transform.any_op
+# CHECK-NEXT:      transform.loop.unroll %loops_3 {factor = 2 : i64} : !transform.any_op
+# CHECK-NEXT:      transform.yield 
 # CHECK-NEXT:    }
 # CHECK-NEXT:  }
 # CHECK-NEXT:  
@@ -73,66 +68,54 @@ print(f"CODE: {res}")
 # CHECK-NEXT:  module attributes {transform.with_named_sequence} {
 # CHECK-NEXT:    func.func @matmul(%arg0: memref<4x512xf32> {llvm.noalias}, %arg1: memref<512x32xf32> {llvm.noalias}, %arg2: memref<4x32xf32> {llvm.noalias}) {
 # CHECK-NEXT:      %cst = arith.constant 0.000000e+00 : f32
+# CHECK-NEXT:      linalg.fill {__xtc_id_C_0_} ins(%cst : f32) outs(%arg2 : memref<4x32xf32>)
 # CHECK-NEXT:      %c0 = arith.constant 0 : index
-# CHECK-NEXT:      %c4 = arith.constant 4 : index
-# CHECK-NEXT:      %c1 = arith.constant 1 : index
-# CHECK-NEXT:      scf.for %arg3 = %c0 to %c4 step %c1 {
-# CHECK-NEXT:        %subview = memref.subview %arg2[%arg3, 0] [1, 32] [1, 1] : memref<4x32xf32> to memref<1x32xf32, strided<[32, 1], offset: ?>>
-# CHECK-NEXT:        %c0_2 = arith.constant 0 : index
-# CHECK-NEXT:        %c32 = arith.constant 32 : index
-# CHECK-NEXT:        %c1_3 = arith.constant 1 : index
-# CHECK-NEXT:        scf.for %arg4 = %c0_2 to %c32 step %c1_3 {
-# CHECK-NEXT:          %subview_4 = memref.subview %subview[0, %arg4] [1, 1] [1, 1] : memref<1x32xf32, strided<[32, 1], offset: ?>> to memref<1x1xf32, strided<[32, 1], offset: ?>>
-# CHECK-NEXT:          linalg.fill {__xtc_id_C_0_} ins(%cst : f32) outs(%subview_4 : memref<1x1xf32, strided<[32, 1], offset: ?>>)
-# CHECK-NEXT:        } {"./j"}
-# CHECK-NEXT:      } {"./i"}
-# CHECK-NEXT:      %c0_0 = arith.constant 0 : index
 # CHECK-NEXT:      %c512 = arith.constant 512 : index
-# CHECK-NEXT:      %c1_1 = arith.constant 1 : index
-# CHECK-NEXT:      scf.for %arg3 = %c0_0 to %c512 step %c1_1 {
+# CHECK-NEXT:      %c1 = arith.constant 1 : index
+# CHECK-NEXT:      scf.for %arg3 = %c0 to %c512 step %c1 {
 # CHECK-NEXT:        %subview = memref.subview %arg0[0, %arg3] [4, 1] [1, 1] : memref<4x512xf32> to memref<4x1xf32, strided<[512, 1], offset: ?>>
-# CHECK-NEXT:        %subview_2 = memref.subview %arg1[%arg3, 0] [1, 32] [1, 1] : memref<512x32xf32> to memref<1x32xf32, strided<[32, 1], offset: ?>>
-# CHECK-NEXT:        %subview_3 = memref.subview %arg2[0, 0] [4, 32] [1, 1] : memref<4x32xf32> to memref<4x32xf32, strided<[32, 1]>>
+# CHECK-NEXT:        %subview_0 = memref.subview %arg1[%arg3, 0] [1, 32] [1, 1] : memref<512x32xf32> to memref<1x32xf32, strided<[32, 1], offset: ?>>
+# CHECK-NEXT:        %subview_1 = memref.subview %arg2[0, 0] [4, 32] [1, 1] : memref<4x32xf32> to memref<4x32xf32, strided<[32, 1]>>
 # CHECK-NEXT:        scf.forall (%arg4) in (2) {
 # CHECK-NEXT:          %0 = affine.apply #map(%arg4)
-# CHECK-NEXT:          %subview_4 = memref.subview %subview[%0, 0] [2, 1] [1, 1] : memref<4x1xf32, strided<[512, 1], offset: ?>> to memref<2x1xf32, strided<[512, 1], offset: ?>>
-# CHECK-NEXT:          %subview_5 = memref.subview %subview_2[0, 0] [1, 32] [1, 1] : memref<1x32xf32, strided<[32, 1], offset: ?>> to memref<1x32xf32, strided<[32, 1], offset: ?>>
-# CHECK-NEXT:          %subview_6 = memref.subview %subview_3[%0, 0] [2, 32] [1, 1] : memref<4x32xf32, strided<[32, 1]>> to memref<2x32xf32, strided<[32, 1], offset: ?>>
+# CHECK-NEXT:          %subview_2 = memref.subview %subview[%0, 0] [2, 1] [1, 1] : memref<4x1xf32, strided<[512, 1], offset: ?>> to memref<2x1xf32, strided<[512, 1], offset: ?>>
+# CHECK-NEXT:          %subview_3 = memref.subview %subview_0[0, 0] [1, 32] [1, 1] : memref<1x32xf32, strided<[32, 1], offset: ?>> to memref<1x32xf32, strided<[32, 1], offset: ?>>
+# CHECK-NEXT:          %subview_4 = memref.subview %subview_1[%0, 0] [2, 32] [1, 1] : memref<4x32xf32, strided<[32, 1]>> to memref<2x32xf32, strided<[32, 1], offset: ?>>
 # CHECK-NEXT:          scf.forall (%arg5) in (2) {
 # CHECK-NEXT:            %1 = affine.apply #map1(%arg5)
-# CHECK-NEXT:            %subview_7 = memref.subview %subview_4[0, 0] [2, 1] [1, 1] : memref<2x1xf32, strided<[512, 1], offset: ?>> to memref<2x1xf32, strided<[512, 1], offset: ?>>
-# CHECK-NEXT:            %subview_8 = memref.subview %subview_5[0, %1] [1, 16] [1, 1] : memref<1x32xf32, strided<[32, 1], offset: ?>> to memref<1x16xf32, strided<[32, 1], offset: ?>>
-# CHECK-NEXT:            %subview_9 = memref.subview %subview_6[0, %1] [2, 16] [1, 1] : memref<2x32xf32, strided<[32, 1], offset: ?>> to memref<2x16xf32, strided<[32, 1], offset: ?>>
-# CHECK-NEXT:            %c0_10 = arith.constant 0 : index
+# CHECK-NEXT:            %subview_5 = memref.subview %subview_2[0, 0] [2, 1] [1, 1] : memref<2x1xf32, strided<[512, 1], offset: ?>> to memref<2x1xf32, strided<[512, 1], offset: ?>>
+# CHECK-NEXT:            %subview_6 = memref.subview %subview_3[0, %1] [1, 16] [1, 1] : memref<1x32xf32, strided<[32, 1], offset: ?>> to memref<1x16xf32, strided<[32, 1], offset: ?>>
+# CHECK-NEXT:            %subview_7 = memref.subview %subview_4[0, %1] [2, 16] [1, 1] : memref<2x32xf32, strided<[32, 1], offset: ?>> to memref<2x16xf32, strided<[32, 1], offset: ?>>
+# CHECK-NEXT:            %c0_8 = arith.constant 0 : index
 # CHECK-NEXT:            %c2 = arith.constant 2 : index
-# CHECK-NEXT:            %c1_11 = arith.constant 1 : index
-# CHECK-NEXT:            %c2_12 = arith.constant 2 : index
-# CHECK-NEXT:            %subview_13 = memref.subview %subview_7[%c0_10, 0] [1, 1] [1, 1] : memref<2x1xf32, strided<[512, 1], offset: ?>> to memref<1x1xf32, strided<[512, 1], offset: ?>>
-# CHECK-NEXT:            %subview_14 = memref.subview %subview_8[0, 0] [1, 16] [1, 1] : memref<1x16xf32, strided<[32, 1], offset: ?>> to memref<1x16xf32, strided<[32, 1], offset: ?>>
-# CHECK-NEXT:            %subview_15 = memref.subview %subview_9[%c0_10, 0] [1, 16] [1, 1] : memref<2x16xf32, strided<[32, 1], offset: ?>> to memref<1x16xf32, strided<[32, 1], offset: ?>>
-# CHECK-NEXT:            %c0_16 = arith.constant 0 : index
+# CHECK-NEXT:            %c1_9 = arith.constant 1 : index
+# CHECK-NEXT:            %c2_10 = arith.constant 2 : index
+# CHECK-NEXT:            %subview_11 = memref.subview %subview_5[%c0_8, 0] [1, 1] [1, 1] : memref<2x1xf32, strided<[512, 1], offset: ?>> to memref<1x1xf32, strided<[512, 1], offset: ?>>
+# CHECK-NEXT:            %subview_12 = memref.subview %subview_6[0, 0] [1, 16] [1, 1] : memref<1x16xf32, strided<[32, 1], offset: ?>> to memref<1x16xf32, strided<[32, 1], offset: ?>>
+# CHECK-NEXT:            %subview_13 = memref.subview %subview_7[%c0_8, 0] [1, 16] [1, 1] : memref<2x16xf32, strided<[32, 1], offset: ?>> to memref<1x16xf32, strided<[32, 1], offset: ?>>
+# CHECK-NEXT:            %c0_14 = arith.constant 0 : index
 # CHECK-NEXT:            %c16 = arith.constant 16 : index
-# CHECK-NEXT:            %c1_17 = arith.constant 1 : index
-# CHECK-NEXT:            scf.for %arg6 = %c0_16 to %c16 step %c1_17 {
-# CHECK-NEXT:              %subview_25 = memref.subview %subview_13[0, 0] [1, 1] [1, 1] : memref<1x1xf32, strided<[512, 1], offset: ?>> to memref<1x1xf32, strided<[512, 1], offset: ?>>
-# CHECK-NEXT:              %subview_26 = memref.subview %subview_14[0, %arg6] [1, 1] [1, 1] : memref<1x16xf32, strided<[32, 1], offset: ?>> to memref<1x1xf32, strided<[32, 1], offset: ?>>
-# CHECK-NEXT:              %subview_27 = memref.subview %subview_15[0, %arg6] [1, 1] [1, 1] : memref<1x16xf32, strided<[32, 1], offset: ?>> to memref<1x1xf32, strided<[32, 1], offset: ?>>
-# CHECK-NEXT:              linalg.matmul {__xtc_id_C_} ins(%subview_25, %subview_26 : memref<1x1xf32, strided<[512, 1], offset: ?>>, memref<1x1xf32, strided<[32, 1], offset: ?>>) outs(%subview_27 : memref<1x1xf32, strided<[32, 1], offset: ?>>)
+# CHECK-NEXT:            %c1_15 = arith.constant 1 : index
+# CHECK-NEXT:            scf.for %arg6 = %c0_14 to %c16 step %c1_15 {
+# CHECK-NEXT:              %subview_23 = memref.subview %subview_11[0, 0] [1, 1] [1, 1] : memref<1x1xf32, strided<[512, 1], offset: ?>> to memref<1x1xf32, strided<[512, 1], offset: ?>>
+# CHECK-NEXT:              %subview_24 = memref.subview %subview_12[0, %arg6] [1, 1] [1, 1] : memref<1x16xf32, strided<[32, 1], offset: ?>> to memref<1x1xf32, strided<[32, 1], offset: ?>>
+# CHECK-NEXT:              %subview_25 = memref.subview %subview_13[0, %arg6] [1, 1] [1, 1] : memref<1x16xf32, strided<[32, 1], offset: ?>> to memref<1x1xf32, strided<[32, 1], offset: ?>>
+# CHECK-NEXT:              linalg.matmul {__xtc_id_C_} ins(%subview_23, %subview_24 : memref<1x1xf32, strided<[512, 1], offset: ?>>, memref<1x1xf32, strided<[32, 1], offset: ?>>) outs(%subview_25 : memref<1x1xf32, strided<[32, 1], offset: ?>>)
 # CHECK-NEXT:            } {"./j1"}
-# CHECK-NEXT:            %c1_18 = arith.constant 1 : index
-# CHECK-NEXT:            %2 = arith.muli %c1_11, %c1_18 : index
-# CHECK-NEXT:            %3 = arith.addi %c0_10, %2 : index
-# CHECK-NEXT:            %subview_19 = memref.subview %subview_7[%3, 0] [1, 1] [1, 1] : memref<2x1xf32, strided<[512, 1], offset: ?>> to memref<1x1xf32, strided<[512, 1], offset: ?>>
-# CHECK-NEXT:            %subview_20 = memref.subview %subview_8[0, 0] [1, 16] [1, 1] : memref<1x16xf32, strided<[32, 1], offset: ?>> to memref<1x16xf32, strided<[32, 1], offset: ?>>
-# CHECK-NEXT:            %subview_21 = memref.subview %subview_9[%3, 0] [1, 16] [1, 1] : memref<2x16xf32, strided<[32, 1], offset: ?>> to memref<1x16xf32, strided<[32, 1], offset: ?>>
-# CHECK-NEXT:            %c0_22 = arith.constant 0 : index
-# CHECK-NEXT:            %c16_23 = arith.constant 16 : index
-# CHECK-NEXT:            %c1_24 = arith.constant 1 : index
-# CHECK-NEXT:            scf.for %arg6 = %c0_22 to %c16_23 step %c1_24 {
-# CHECK-NEXT:              %subview_25 = memref.subview %subview_19[0, 0] [1, 1] [1, 1] : memref<1x1xf32, strided<[512, 1], offset: ?>> to memref<1x1xf32, strided<[512, 1], offset: ?>>
-# CHECK-NEXT:              %subview_26 = memref.subview %subview_20[0, %arg6] [1, 1] [1, 1] : memref<1x16xf32, strided<[32, 1], offset: ?>> to memref<1x1xf32, strided<[32, 1], offset: ?>>
-# CHECK-NEXT:              %subview_27 = memref.subview %subview_21[0, %arg6] [1, 1] [1, 1] : memref<1x16xf32, strided<[32, 1], offset: ?>> to memref<1x1xf32, strided<[32, 1], offset: ?>>
-# CHECK-NEXT:              linalg.matmul {__xtc_id_C_} ins(%subview_25, %subview_26 : memref<1x1xf32, strided<[512, 1], offset: ?>>, memref<1x1xf32, strided<[32, 1], offset: ?>>) outs(%subview_27 : memref<1x1xf32, strided<[32, 1], offset: ?>>)
+# CHECK-NEXT:            %c1_16 = arith.constant 1 : index
+# CHECK-NEXT:            %2 = arith.muli %c1_9, %c1_16 : index
+# CHECK-NEXT:            %3 = arith.addi %c0_8, %2 : index
+# CHECK-NEXT:            %subview_17 = memref.subview %subview_5[%3, 0] [1, 1] [1, 1] : memref<2x1xf32, strided<[512, 1], offset: ?>> to memref<1x1xf32, strided<[512, 1], offset: ?>>
+# CHECK-NEXT:            %subview_18 = memref.subview %subview_6[0, 0] [1, 16] [1, 1] : memref<1x16xf32, strided<[32, 1], offset: ?>> to memref<1x16xf32, strided<[32, 1], offset: ?>>
+# CHECK-NEXT:            %subview_19 = memref.subview %subview_7[%3, 0] [1, 16] [1, 1] : memref<2x16xf32, strided<[32, 1], offset: ?>> to memref<1x16xf32, strided<[32, 1], offset: ?>>
+# CHECK-NEXT:            %c0_20 = arith.constant 0 : index
+# CHECK-NEXT:            %c16_21 = arith.constant 16 : index
+# CHECK-NEXT:            %c1_22 = arith.constant 1 : index
+# CHECK-NEXT:            scf.for %arg6 = %c0_20 to %c16_21 step %c1_22 {
+# CHECK-NEXT:              %subview_23 = memref.subview %subview_17[0, 0] [1, 1] [1, 1] : memref<1x1xf32, strided<[512, 1], offset: ?>> to memref<1x1xf32, strided<[512, 1], offset: ?>>
+# CHECK-NEXT:              %subview_24 = memref.subview %subview_18[0, %arg6] [1, 1] [1, 1] : memref<1x16xf32, strided<[32, 1], offset: ?>> to memref<1x1xf32, strided<[32, 1], offset: ?>>
+# CHECK-NEXT:              %subview_25 = memref.subview %subview_19[0, %arg6] [1, 1] [1, 1] : memref<1x16xf32, strided<[32, 1], offset: ?>> to memref<1x1xf32, strided<[32, 1], offset: ?>>
+# CHECK-NEXT:              linalg.matmul {__xtc_id_C_} ins(%subview_23, %subview_24 : memref<1x1xf32, strided<[512, 1], offset: ?>>, memref<1x1xf32, strided<[32, 1], offset: ?>>) outs(%subview_25 : memref<1x1xf32, strided<[32, 1], offset: ?>>)
 # CHECK-NEXT:            } {"./j1"}
 # CHECK-NEXT:          } {"./j"}
 # CHECK-NEXT:        } {"./i"}

--- a/tests/filecheck/backends/test_matmul_ndiv_mlir.py
+++ b/tests/filecheck/backends/test_matmul_ndiv_mlir.py
@@ -47,28 +47,23 @@ print(f"CODE: {res}")
 # CHECK-NEXT:      transform.yield 
 # CHECK-NEXT:    }
 # CHECK-NEXT:    transform.named_sequence @__transform_main(%arg0: !transform.any_op {transform.readonly}) {
-# CHECK-NEXT:      %0 = transform.structured.match attributes {__xtc_id_C_0_} in %arg0 : (!transform.any_op) -> !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op, %loops = transform.structured.tile_using_for %0 tile_sizes [1, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops "./i" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_0, %loops_1 = transform.structured.tile_using_for %tiled_linalg_op tile_sizes [0, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_1 "./j" : !transform.any_op
-# CHECK-NEXT:      %1 = transform.structured.match attributes {__xtc_id_C_} in %arg0 : (!transform.any_op) -> !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_2, %loops_3 = transform.structured.tile_using_for %1 tile_sizes [0, 0, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_3 "./k" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_4, %loops_5 = transform.structured.tile_using_for %tiled_linalg_op_2 tile_sizes [3, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_5 "./i" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_6, %loops_7 = transform.structured.tile_using_for %tiled_linalg_op_4 tile_sizes [0, 16, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_7 "./j" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_8, %loops_9 = transform.structured.tile_using_for %tiled_linalg_op_6 tile_sizes [1, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_9 "./i1" : !transform.any_op
-# CHECK-NEXT:      transform.include @_vecto failures(suppress) (%tiled_linalg_op_8) : (!transform.any_op) -> ()
-# CHECK-NEXT:      transform.loop.unroll %loops_9 {factor = 2 : i64} : !transform.any_op
-# CHECK-NEXT:      %2 = transform.get_parent_op %loops_3 {isolated_from_above} : (!transform.any_op) -> !transform.any_op
-# CHECK-NEXT:      transform.apply_patterns to %2 {
+# CHECK-NEXT:      %0 = transform.structured.match attributes {__xtc_id_C_} in %arg0 : (!transform.any_op) -> !transform.any_op
+# CHECK-NEXT:      %tiled_linalg_op, %loops = transform.structured.tile_using_for %0 tile_sizes [0, 0, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      transform.annotate %loops "./k" : !transform.any_op
+# CHECK-NEXT:      %tiled_linalg_op_0, %loops_1 = transform.structured.tile_using_for %tiled_linalg_op tile_sizes [3, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      transform.annotate %loops_1 "./i" : !transform.any_op
+# CHECK-NEXT:      %tiled_linalg_op_2, %loops_3 = transform.structured.tile_using_for %tiled_linalg_op_0 tile_sizes [0, 16, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      transform.annotate %loops_3 "./j" : !transform.any_op
+# CHECK-NEXT:      %tiled_linalg_op_4, %loops_5 = transform.structured.tile_using_for %tiled_linalg_op_2 tile_sizes [1, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      transform.annotate %loops_5 "./i1" : !transform.any_op
+# CHECK-NEXT:      transform.include @_vecto failures(suppress) (%tiled_linalg_op_4) : (!transform.any_op) -> ()
+# CHECK-NEXT:      transform.loop.unroll %loops_5 {factor = 2 : i64} : !transform.any_op
+# CHECK-NEXT:      %1 = transform.get_parent_op %loops {isolated_from_above} : (!transform.any_op) -> !transform.any_op
+# CHECK-NEXT:      transform.apply_patterns to %1 {
 # CHECK-NEXT:        transform.apply_patterns.vector.reduction_to_contract
 # CHECK-NEXT:        transform.apply_patterns.vector.transfer_permutation_patterns
 # CHECK-NEXT:      } : !transform.any_op
-# CHECK-NEXT:      transform.apply_patterns to %2 {
+# CHECK-NEXT:      transform.apply_patterns to %1 {
 # CHECK-NEXT:        transform.apply_patterns.vector.lower_outerproduct
 # CHECK-NEXT:        transform.apply_patterns.vector.lower_contraction
 # CHECK-NEXT:      } : !transform.any_op
@@ -84,20 +79,14 @@ print(f"CODE: {res}")
 # CHECK-NEXT:      %0 = ub.poison : f32
 # CHECK-NEXT:      %c2 = arith.constant 2 : index
 # CHECK-NEXT:      %c16 = arith.constant 16 : index
-# CHECK-NEXT:      %c3 = arith.constant 3 : index
-# CHECK-NEXT:      %c512 = arith.constant 512 : index
 # CHECK-NEXT:      %c32 = arith.constant 32 : index
-# CHECK-NEXT:      %cst_0 = arith.constant 0.000000e+00 : f32
-# CHECK-NEXT:      %c0 = arith.constant 0 : index
+# CHECK-NEXT:      %c3 = arith.constant 3 : index
 # CHECK-NEXT:      %c4 = arith.constant 4 : index
 # CHECK-NEXT:      %c1 = arith.constant 1 : index
-# CHECK-NEXT:      scf.for %arg3 = %c0 to %c4 step %c1 {
-# CHECK-NEXT:        %subview = memref.subview %arg2[%arg3, 0] [1, 32] [1, 1] : memref<4x32xf32> to memref<1x32xf32, strided<[32, 1], offset: ?>>
-# CHECK-NEXT:        scf.for %arg4 = %c0 to %c32 step %c1 {
-# CHECK-NEXT:          %subview_1 = memref.subview %subview[0, %arg4] [1, 1] [1, 1] : memref<1x32xf32, strided<[32, 1], offset: ?>> to memref<1x1xf32, strided<[32, 1], offset: ?>>
-# CHECK-NEXT:          linalg.fill {__xtc_id_C_0_} ins(%cst_0 : f32) outs(%subview_1 : memref<1x1xf32, strided<[32, 1], offset: ?>>)
-# CHECK-NEXT:        } {"./j"}
-# CHECK-NEXT:      } {"./i"}
+# CHECK-NEXT:      %c512 = arith.constant 512 : index
+# CHECK-NEXT:      %c0 = arith.constant 0 : index
+# CHECK-NEXT:      %cst_0 = arith.constant 0.000000e+00 : f32
+# CHECK-NEXT:      linalg.fill {__xtc_id_C_0_} ins(%cst_0 : f32) outs(%arg2 : memref<4x32xf32>)
 # CHECK-NEXT:      scf.for %arg3 = %c0 to %c512 step %c1 {
 # CHECK-NEXT:        %subview = memref.subview %arg0[0, %arg3] [4, 1] [1, 1] : memref<4x512xf32> to memref<4x1xf32, strided<[512, 1], offset: ?>>
 # CHECK-NEXT:        %subview_1 = memref.subview %arg1[%arg3, 0] [1, 32] [1, 1] : memref<512x32xf32> to memref<1x32xf32, strided<[32, 1], offset: ?>>

--- a/tests/filecheck/backends/test_matmul_relu_mlir.py
+++ b/tests/filecheck/backends/test_matmul_relu_mlir.py
@@ -59,34 +59,29 @@ print(f"CODE: {res}")
 # CHECK-NEXT:      transform.yield 
 # CHECK-NEXT:    }
 # CHECK-NEXT:    transform.named_sequence @__transform_main(%arg0: !transform.any_op {transform.readonly}) {
-# CHECK-NEXT:      %0 = transform.structured.match attributes {__xtc_id_matmul_0_} in %arg0 : (!transform.any_op) -> !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op, %loops = transform.structured.tile_using_for %0 tile_sizes [1, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops "./i" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_0, %loops_1 = transform.structured.tile_using_for %tiled_linalg_op tile_sizes [0, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_1 "./j" : !transform.any_op
-# CHECK-NEXT:      %1 = transform.structured.match attributes {__xtc_id_matmul_} in %arg0 : (!transform.any_op) -> !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_2, %loops_3 = transform.structured.tile_using_for %1 tile_sizes [0, 0, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_3 "./k" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_4, %loops_5 = transform.structured.tile_using_for %tiled_linalg_op_2 tile_sizes [2, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_5 "./i" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_6, %loops_7 = transform.structured.tile_using_for %tiled_linalg_op_4 tile_sizes [0, 16, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_7 "./j" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_8, %loops_9 = transform.structured.tile_using_for %tiled_linalg_op_6 tile_sizes [1, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_9 "./i1" : !transform.any_op
-# CHECK-NEXT:      transform.include @_vecto failures(suppress) (%tiled_linalg_op_8) : (!transform.any_op) -> ()
-# CHECK-NEXT:      transform.loop.unroll %loops_9 {factor = 2 : i64} : !transform.any_op
-# CHECK-NEXT:      %2 = transform.get_parent_op %loops_3 {isolated_from_above} : (!transform.any_op) -> !transform.any_op
-# CHECK-NEXT:      transform.apply_patterns to %2 {
+# CHECK-NEXT:      %0 = transform.structured.match attributes {__xtc_id_matmul_} in %arg0 : (!transform.any_op) -> !transform.any_op
+# CHECK-NEXT:      %tiled_linalg_op, %loops = transform.structured.tile_using_for %0 tile_sizes [0, 0, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      transform.annotate %loops "./k" : !transform.any_op
+# CHECK-NEXT:      %tiled_linalg_op_0, %loops_1 = transform.structured.tile_using_for %tiled_linalg_op tile_sizes [2, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      transform.annotate %loops_1 "./i" : !transform.any_op
+# CHECK-NEXT:      %tiled_linalg_op_2, %loops_3 = transform.structured.tile_using_for %tiled_linalg_op_0 tile_sizes [0, 16, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      transform.annotate %loops_3 "./j" : !transform.any_op
+# CHECK-NEXT:      %tiled_linalg_op_4, %loops_5 = transform.structured.tile_using_for %tiled_linalg_op_2 tile_sizes [1, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      transform.annotate %loops_5 "./i1" : !transform.any_op
+# CHECK-NEXT:      transform.include @_vecto failures(suppress) (%tiled_linalg_op_4) : (!transform.any_op) -> ()
+# CHECK-NEXT:      transform.loop.unroll %loops_5 {factor = 2 : i64} : !transform.any_op
+# CHECK-NEXT:      %1 = transform.get_parent_op %loops {isolated_from_above} : (!transform.any_op) -> !transform.any_op
+# CHECK-NEXT:      transform.apply_patterns to %1 {
 # CHECK-NEXT:        transform.apply_patterns.vector.reduction_to_contract
 # CHECK-NEXT:        transform.apply_patterns.vector.transfer_permutation_patterns
 # CHECK-NEXT:      } : !transform.any_op
-# CHECK-NEXT:      transform.apply_patterns to %2 {
+# CHECK-NEXT:      transform.apply_patterns to %1 {
 # CHECK-NEXT:        transform.apply_patterns.vector.lower_outerproduct
 # CHECK-NEXT:        transform.apply_patterns.vector.lower_contraction
 # CHECK-NEXT:      } : !transform.any_op
-# CHECK-NEXT:      %3 = transform.structured.match attributes {__xtc_id_relu_} in %arg0 : (!transform.any_op) -> !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_10, %loops_11 = transform.structured.tile_using_for %3 tile_sizes [1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_11 "./i" : !transform.any_op
+# CHECK-NEXT:      %2 = transform.structured.match attributes {__xtc_id_relu_} in %arg0 : (!transform.any_op) -> !transform.any_op
+# CHECK-NEXT:      %tiled_linalg_op_6, %loops_7 = transform.structured.tile_using_for %2 tile_sizes [1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      transform.annotate %loops_7 "./i" : !transform.any_op
 # CHECK-NEXT:      transform.yield 
 # CHECK-NEXT:    }
 # CHECK-NEXT:  }
@@ -99,21 +94,15 @@ print(f"CODE: {res}")
 # CHECK-NEXT:      %cst = arith.constant dense<0.000000e+00> : vector<1x16xf32>
 # CHECK-NEXT:      %0 = ub.poison : f32
 # CHECK-NEXT:      %c16 = arith.constant 16 : index
-# CHECK-NEXT:      %c2 = arith.constant 2 : index
-# CHECK-NEXT:      %c512 = arith.constant 512 : index
 # CHECK-NEXT:      %c32 = arith.constant 32 : index
-# CHECK-NEXT:      %c1 = arith.constant 1 : index
+# CHECK-NEXT:      %c2 = arith.constant 2 : index
 # CHECK-NEXT:      %c4 = arith.constant 4 : index
+# CHECK-NEXT:      %c1 = arith.constant 1 : index
+# CHECK-NEXT:      %c512 = arith.constant 512 : index
 # CHECK-NEXT:      %c0 = arith.constant 0 : index
 # CHECK-NEXT:      %cst_0 = arith.constant 0.000000e+00 : f32
 # CHECK-NEXT:      %alloca = memref.alloca() {alignment = 256 : i64} : memref<4x32xf32>
-# CHECK-NEXT:      scf.for %arg3 = %c0 to %c4 step %c1 {
-# CHECK-NEXT:        %subview = memref.subview %alloca[%arg3, 0] [1, 32] [1, 1] : memref<4x32xf32> to memref<1x32xf32, strided<[32, 1], offset: ?>>
-# CHECK-NEXT:        scf.for %arg4 = %c0 to %c32 step %c1 {
-# CHECK-NEXT:          %subview_4 = memref.subview %subview[0, %arg4] [1, 1] [1, 1] : memref<1x32xf32, strided<[32, 1], offset: ?>> to memref<1x1xf32, strided<[32, 1], offset: ?>>
-# CHECK-NEXT:          linalg.fill {__xtc_id_matmul_0_} ins(%cst_0 : f32) outs(%subview_4 : memref<1x1xf32, strided<[32, 1], offset: ?>>)
-# CHECK-NEXT:        } {"./j"}
-# CHECK-NEXT:      } {"./i"}
+# CHECK-NEXT:      linalg.fill {__xtc_id_matmul_0_} ins(%cst_0 : f32) outs(%alloca : memref<4x32xf32>)
 # CHECK-NEXT:      scf.for %arg3 = %c0 to %c512 step %c1 {
 # CHECK-NEXT:        %subview = memref.subview %arg0[0, %arg3] [4, 1] [1, 1] : memref<4x512xf32> to memref<4x1xf32, strided<[512, 1], offset: ?>>
 # CHECK-NEXT:        %subview_4 = memref.subview %arg1[%arg3, 0] [1, 32] [1, 1] : memref<512x32xf32> to memref<1x32xf32, strided<[32, 1], offset: ?>>

--- a/tests/filecheck/backends/test_matmul_scalar_mlir.py
+++ b/tests/filecheck/backends/test_matmul_scalar_mlir.py
@@ -45,23 +45,18 @@ print(f"CODE: {res}")
 # CHECK-NEXT:      transform.yield 
 # CHECK-NEXT:    }
 # CHECK-NEXT:    transform.named_sequence @__transform_main(%arg0: !transform.any_op {transform.readonly}) {
-# CHECK-NEXT:      %0 = transform.structured.match attributes {__xtc_id_C_0_} in %arg0 : (!transform.any_op) -> !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op, %loops = transform.structured.tile_using_for %0 tile_sizes [1, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops "./i" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_0, %loops_1 = transform.structured.tile_using_for %tiled_linalg_op tile_sizes [0, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_1 "./j" : !transform.any_op
-# CHECK-NEXT:      %1 = transform.structured.match attributes {__xtc_id_C_} in %arg0 : (!transform.any_op) -> !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_2, %loops_3 = transform.structured.tile_using_for %1 tile_sizes [0, 0, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_3 "./k" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_4, %loops_5 = transform.structured.tile_using_for %tiled_linalg_op_2 tile_sizes [2, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_5 "./i" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_6, %loops_7 = transform.structured.tile_using_for %tiled_linalg_op_4 tile_sizes [0, 16, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_7 "./j" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_8, %loops_9 = transform.structured.tile_using_for %tiled_linalg_op_6 tile_sizes [1, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_9 "./i1" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_10, %loops_11 = transform.structured.tile_using_for %tiled_linalg_op_8 tile_sizes [0, 1, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_11 "./j1" : !transform.any_op
-# CHECK-NEXT:      transform.loop.unroll %loops_9 {factor = 2 : i64} : !transform.any_op
+# CHECK-NEXT:      %0 = transform.structured.match attributes {__xtc_id_C_} in %arg0 : (!transform.any_op) -> !transform.any_op
+# CHECK-NEXT:      %tiled_linalg_op, %loops = transform.structured.tile_using_for %0 tile_sizes [0, 0, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      transform.annotate %loops "./k" : !transform.any_op
+# CHECK-NEXT:      %tiled_linalg_op_0, %loops_1 = transform.structured.tile_using_for %tiled_linalg_op tile_sizes [2, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      transform.annotate %loops_1 "./i" : !transform.any_op
+# CHECK-NEXT:      %tiled_linalg_op_2, %loops_3 = transform.structured.tile_using_for %tiled_linalg_op_0 tile_sizes [0, 16, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      transform.annotate %loops_3 "./j" : !transform.any_op
+# CHECK-NEXT:      %tiled_linalg_op_4, %loops_5 = transform.structured.tile_using_for %tiled_linalg_op_2 tile_sizes [1, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      transform.annotate %loops_5 "./i1" : !transform.any_op
+# CHECK-NEXT:      %tiled_linalg_op_6, %loops_7 = transform.structured.tile_using_for %tiled_linalg_op_4 tile_sizes [0, 1, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      transform.annotate %loops_7 "./j1" : !transform.any_op
+# CHECK-NEXT:      transform.loop.unroll %loops_5 {factor = 2 : i64} : !transform.any_op
 # CHECK-NEXT:      transform.yield 
 # CHECK-NEXT:    }
 # CHECK-NEXT:  }
@@ -70,70 +65,58 @@ print(f"CODE: {res}")
 # CHECK-NEXT:  module attributes {transform.with_named_sequence} {
 # CHECK-NEXT:    func.func @matmul(%arg0: memref<4x512xf32> {llvm.noalias}, %arg1: memref<512x32xf32> {llvm.noalias}, %arg2: memref<4x32xf32> {llvm.noalias}) {
 # CHECK-NEXT:      %cst = arith.constant 0.000000e+00 : f32
+# CHECK-NEXT:      linalg.fill {__xtc_id_C_0_} ins(%cst : f32) outs(%arg2 : memref<4x32xf32>)
 # CHECK-NEXT:      %c0 = arith.constant 0 : index
-# CHECK-NEXT:      %c4 = arith.constant 4 : index
-# CHECK-NEXT:      %c1 = arith.constant 1 : index
-# CHECK-NEXT:      scf.for %arg3 = %c0 to %c4 step %c1 {
-# CHECK-NEXT:        %subview = memref.subview %arg2[%arg3, 0] [1, 32] [1, 1] : memref<4x32xf32> to memref<1x32xf32, strided<[32, 1], offset: ?>>
-# CHECK-NEXT:        %c0_2 = arith.constant 0 : index
-# CHECK-NEXT:        %c32 = arith.constant 32 : index
-# CHECK-NEXT:        %c1_3 = arith.constant 1 : index
-# CHECK-NEXT:        scf.for %arg4 = %c0_2 to %c32 step %c1_3 {
-# CHECK-NEXT:          %subview_4 = memref.subview %subview[0, %arg4] [1, 1] [1, 1] : memref<1x32xf32, strided<[32, 1], offset: ?>> to memref<1x1xf32, strided<[32, 1], offset: ?>>
-# CHECK-NEXT:          linalg.fill {__xtc_id_C_0_} ins(%cst : f32) outs(%subview_4 : memref<1x1xf32, strided<[32, 1], offset: ?>>)
-# CHECK-NEXT:        } {"./j"}
-# CHECK-NEXT:      } {"./i"}
-# CHECK-NEXT:      %c0_0 = arith.constant 0 : index
 # CHECK-NEXT:      %c512 = arith.constant 512 : index
-# CHECK-NEXT:      %c1_1 = arith.constant 1 : index
-# CHECK-NEXT:      scf.for %arg3 = %c0_0 to %c512 step %c1_1 {
+# CHECK-NEXT:      %c1 = arith.constant 1 : index
+# CHECK-NEXT:      scf.for %arg3 = %c0 to %c512 step %c1 {
 # CHECK-NEXT:        %subview = memref.subview %arg0[0, %arg3] [4, 1] [1, 1] : memref<4x512xf32> to memref<4x1xf32, strided<[512, 1], offset: ?>>
-# CHECK-NEXT:        %subview_2 = memref.subview %arg1[%arg3, 0] [1, 32] [1, 1] : memref<512x32xf32> to memref<1x32xf32, strided<[32, 1], offset: ?>>
-# CHECK-NEXT:        %subview_3 = memref.subview %arg2[0, 0] [4, 32] [1, 1] : memref<4x32xf32> to memref<4x32xf32, strided<[32, 1]>>
-# CHECK-NEXT:        %c0_4 = arith.constant 0 : index
-# CHECK-NEXT:        %c4_5 = arith.constant 4 : index
+# CHECK-NEXT:        %subview_0 = memref.subview %arg1[%arg3, 0] [1, 32] [1, 1] : memref<512x32xf32> to memref<1x32xf32, strided<[32, 1], offset: ?>>
+# CHECK-NEXT:        %subview_1 = memref.subview %arg2[0, 0] [4, 32] [1, 1] : memref<4x32xf32> to memref<4x32xf32, strided<[32, 1]>>
+# CHECK-NEXT:        %c0_2 = arith.constant 0 : index
+# CHECK-NEXT:        %c4 = arith.constant 4 : index
 # CHECK-NEXT:        %c2 = arith.constant 2 : index
-# CHECK-NEXT:        scf.for %arg4 = %c0_4 to %c4_5 step %c2 {
-# CHECK-NEXT:          %subview_6 = memref.subview %subview[%arg4, 0] [2, 1] [1, 1] : memref<4x1xf32, strided<[512, 1], offset: ?>> to memref<2x1xf32, strided<[512, 1], offset: ?>>
-# CHECK-NEXT:          %subview_7 = memref.subview %subview_2[0, 0] [1, 32] [1, 1] : memref<1x32xf32, strided<[32, 1], offset: ?>> to memref<1x32xf32, strided<[32, 1], offset: ?>>
-# CHECK-NEXT:          %subview_8 = memref.subview %subview_3[%arg4, 0] [2, 32] [1, 1] : memref<4x32xf32, strided<[32, 1]>> to memref<2x32xf32, strided<[32, 1], offset: ?>>
-# CHECK-NEXT:          %c0_9 = arith.constant 0 : index
+# CHECK-NEXT:        scf.for %arg4 = %c0_2 to %c4 step %c2 {
+# CHECK-NEXT:          %subview_3 = memref.subview %subview[%arg4, 0] [2, 1] [1, 1] : memref<4x1xf32, strided<[512, 1], offset: ?>> to memref<2x1xf32, strided<[512, 1], offset: ?>>
+# CHECK-NEXT:          %subview_4 = memref.subview %subview_0[0, 0] [1, 32] [1, 1] : memref<1x32xf32, strided<[32, 1], offset: ?>> to memref<1x32xf32, strided<[32, 1], offset: ?>>
+# CHECK-NEXT:          %subview_5 = memref.subview %subview_1[%arg4, 0] [2, 32] [1, 1] : memref<4x32xf32, strided<[32, 1]>> to memref<2x32xf32, strided<[32, 1], offset: ?>>
+# CHECK-NEXT:          %c0_6 = arith.constant 0 : index
 # CHECK-NEXT:          %c32 = arith.constant 32 : index
 # CHECK-NEXT:          %c16 = arith.constant 16 : index
-# CHECK-NEXT:          scf.for %arg5 = %c0_9 to %c32 step %c16 {
-# CHECK-NEXT:            %subview_10 = memref.subview %subview_6[0, 0] [2, 1] [1, 1] : memref<2x1xf32, strided<[512, 1], offset: ?>> to memref<2x1xf32, strided<[512, 1], offset: ?>>
-# CHECK-NEXT:            %subview_11 = memref.subview %subview_7[0, %arg5] [1, 16] [1, 1] : memref<1x32xf32, strided<[32, 1], offset: ?>> to memref<1x16xf32, strided<[32, 1], offset: ?>>
-# CHECK-NEXT:            %subview_12 = memref.subview %subview_8[0, %arg5] [2, 16] [1, 1] : memref<2x32xf32, strided<[32, 1], offset: ?>> to memref<2x16xf32, strided<[32, 1], offset: ?>>
-# CHECK-NEXT:            %c0_13 = arith.constant 0 : index
-# CHECK-NEXT:            %c2_14 = arith.constant 2 : index
-# CHECK-NEXT:            %c1_15 = arith.constant 1 : index
-# CHECK-NEXT:            %c2_16 = arith.constant 2 : index
-# CHECK-NEXT:            %subview_17 = memref.subview %subview_10[%c0_13, 0] [1, 1] [1, 1] : memref<2x1xf32, strided<[512, 1], offset: ?>> to memref<1x1xf32, strided<[512, 1], offset: ?>>
-# CHECK-NEXT:            %subview_18 = memref.subview %subview_11[0, 0] [1, 16] [1, 1] : memref<1x16xf32, strided<[32, 1], offset: ?>> to memref<1x16xf32, strided<[32, 1], offset: ?>>
-# CHECK-NEXT:            %subview_19 = memref.subview %subview_12[%c0_13, 0] [1, 16] [1, 1] : memref<2x16xf32, strided<[32, 1], offset: ?>> to memref<1x16xf32, strided<[32, 1], offset: ?>>
-# CHECK-NEXT:            %c0_20 = arith.constant 0 : index
-# CHECK-NEXT:            %c16_21 = arith.constant 16 : index
-# CHECK-NEXT:            %c1_22 = arith.constant 1 : index
-# CHECK-NEXT:            scf.for %arg6 = %c0_20 to %c16_21 step %c1_22 {
-# CHECK-NEXT:              %subview_30 = memref.subview %subview_17[0, 0] [1, 1] [1, 1] : memref<1x1xf32, strided<[512, 1], offset: ?>> to memref<1x1xf32, strided<[512, 1], offset: ?>>
-# CHECK-NEXT:              %subview_31 = memref.subview %subview_18[0, %arg6] [1, 1] [1, 1] : memref<1x16xf32, strided<[32, 1], offset: ?>> to memref<1x1xf32, strided<[32, 1], offset: ?>>
-# CHECK-NEXT:              %subview_32 = memref.subview %subview_19[0, %arg6] [1, 1] [1, 1] : memref<1x16xf32, strided<[32, 1], offset: ?>> to memref<1x1xf32, strided<[32, 1], offset: ?>>
-# CHECK-NEXT:              linalg.matmul {__xtc_id_C_} ins(%subview_30, %subview_31 : memref<1x1xf32, strided<[512, 1], offset: ?>>, memref<1x1xf32, strided<[32, 1], offset: ?>>) outs(%subview_32 : memref<1x1xf32, strided<[32, 1], offset: ?>>)
+# CHECK-NEXT:          scf.for %arg5 = %c0_6 to %c32 step %c16 {
+# CHECK-NEXT:            %subview_7 = memref.subview %subview_3[0, 0] [2, 1] [1, 1] : memref<2x1xf32, strided<[512, 1], offset: ?>> to memref<2x1xf32, strided<[512, 1], offset: ?>>
+# CHECK-NEXT:            %subview_8 = memref.subview %subview_4[0, %arg5] [1, 16] [1, 1] : memref<1x32xf32, strided<[32, 1], offset: ?>> to memref<1x16xf32, strided<[32, 1], offset: ?>>
+# CHECK-NEXT:            %subview_9 = memref.subview %subview_5[0, %arg5] [2, 16] [1, 1] : memref<2x32xf32, strided<[32, 1], offset: ?>> to memref<2x16xf32, strided<[32, 1], offset: ?>>
+# CHECK-NEXT:            %c0_10 = arith.constant 0 : index
+# CHECK-NEXT:            %c2_11 = arith.constant 2 : index
+# CHECK-NEXT:            %c1_12 = arith.constant 1 : index
+# CHECK-NEXT:            %c2_13 = arith.constant 2 : index
+# CHECK-NEXT:            %subview_14 = memref.subview %subview_7[%c0_10, 0] [1, 1] [1, 1] : memref<2x1xf32, strided<[512, 1], offset: ?>> to memref<1x1xf32, strided<[512, 1], offset: ?>>
+# CHECK-NEXT:            %subview_15 = memref.subview %subview_8[0, 0] [1, 16] [1, 1] : memref<1x16xf32, strided<[32, 1], offset: ?>> to memref<1x16xf32, strided<[32, 1], offset: ?>>
+# CHECK-NEXT:            %subview_16 = memref.subview %subview_9[%c0_10, 0] [1, 16] [1, 1] : memref<2x16xf32, strided<[32, 1], offset: ?>> to memref<1x16xf32, strided<[32, 1], offset: ?>>
+# CHECK-NEXT:            %c0_17 = arith.constant 0 : index
+# CHECK-NEXT:            %c16_18 = arith.constant 16 : index
+# CHECK-NEXT:            %c1_19 = arith.constant 1 : index
+# CHECK-NEXT:            scf.for %arg6 = %c0_17 to %c16_18 step %c1_19 {
+# CHECK-NEXT:              %subview_27 = memref.subview %subview_14[0, 0] [1, 1] [1, 1] : memref<1x1xf32, strided<[512, 1], offset: ?>> to memref<1x1xf32, strided<[512, 1], offset: ?>>
+# CHECK-NEXT:              %subview_28 = memref.subview %subview_15[0, %arg6] [1, 1] [1, 1] : memref<1x16xf32, strided<[32, 1], offset: ?>> to memref<1x1xf32, strided<[32, 1], offset: ?>>
+# CHECK-NEXT:              %subview_29 = memref.subview %subview_16[0, %arg6] [1, 1] [1, 1] : memref<1x16xf32, strided<[32, 1], offset: ?>> to memref<1x1xf32, strided<[32, 1], offset: ?>>
+# CHECK-NEXT:              linalg.matmul {__xtc_id_C_} ins(%subview_27, %subview_28 : memref<1x1xf32, strided<[512, 1], offset: ?>>, memref<1x1xf32, strided<[32, 1], offset: ?>>) outs(%subview_29 : memref<1x1xf32, strided<[32, 1], offset: ?>>)
 # CHECK-NEXT:            } {"./j1"}
-# CHECK-NEXT:            %c1_23 = arith.constant 1 : index
-# CHECK-NEXT:            %0 = arith.muli %c1_15, %c1_23 : index
-# CHECK-NEXT:            %1 = arith.addi %c0_13, %0 : index
-# CHECK-NEXT:            %subview_24 = memref.subview %subview_10[%1, 0] [1, 1] [1, 1] : memref<2x1xf32, strided<[512, 1], offset: ?>> to memref<1x1xf32, strided<[512, 1], offset: ?>>
-# CHECK-NEXT:            %subview_25 = memref.subview %subview_11[0, 0] [1, 16] [1, 1] : memref<1x16xf32, strided<[32, 1], offset: ?>> to memref<1x16xf32, strided<[32, 1], offset: ?>>
-# CHECK-NEXT:            %subview_26 = memref.subview %subview_12[%1, 0] [1, 16] [1, 1] : memref<2x16xf32, strided<[32, 1], offset: ?>> to memref<1x16xf32, strided<[32, 1], offset: ?>>
-# CHECK-NEXT:            %c0_27 = arith.constant 0 : index
-# CHECK-NEXT:            %c16_28 = arith.constant 16 : index
-# CHECK-NEXT:            %c1_29 = arith.constant 1 : index
-# CHECK-NEXT:            scf.for %arg6 = %c0_27 to %c16_28 step %c1_29 {
-# CHECK-NEXT:              %subview_30 = memref.subview %subview_24[0, 0] [1, 1] [1, 1] : memref<1x1xf32, strided<[512, 1], offset: ?>> to memref<1x1xf32, strided<[512, 1], offset: ?>>
-# CHECK-NEXT:              %subview_31 = memref.subview %subview_25[0, %arg6] [1, 1] [1, 1] : memref<1x16xf32, strided<[32, 1], offset: ?>> to memref<1x1xf32, strided<[32, 1], offset: ?>>
-# CHECK-NEXT:              %subview_32 = memref.subview %subview_26[0, %arg6] [1, 1] [1, 1] : memref<1x16xf32, strided<[32, 1], offset: ?>> to memref<1x1xf32, strided<[32, 1], offset: ?>>
-# CHECK-NEXT:              linalg.matmul {__xtc_id_C_} ins(%subview_30, %subview_31 : memref<1x1xf32, strided<[512, 1], offset: ?>>, memref<1x1xf32, strided<[32, 1], offset: ?>>) outs(%subview_32 : memref<1x1xf32, strided<[32, 1], offset: ?>>)
+# CHECK-NEXT:            %c1_20 = arith.constant 1 : index
+# CHECK-NEXT:            %0 = arith.muli %c1_12, %c1_20 : index
+# CHECK-NEXT:            %1 = arith.addi %c0_10, %0 : index
+# CHECK-NEXT:            %subview_21 = memref.subview %subview_7[%1, 0] [1, 1] [1, 1] : memref<2x1xf32, strided<[512, 1], offset: ?>> to memref<1x1xf32, strided<[512, 1], offset: ?>>
+# CHECK-NEXT:            %subview_22 = memref.subview %subview_8[0, 0] [1, 16] [1, 1] : memref<1x16xf32, strided<[32, 1], offset: ?>> to memref<1x16xf32, strided<[32, 1], offset: ?>>
+# CHECK-NEXT:            %subview_23 = memref.subview %subview_9[%1, 0] [1, 16] [1, 1] : memref<2x16xf32, strided<[32, 1], offset: ?>> to memref<1x16xf32, strided<[32, 1], offset: ?>>
+# CHECK-NEXT:            %c0_24 = arith.constant 0 : index
+# CHECK-NEXT:            %c16_25 = arith.constant 16 : index
+# CHECK-NEXT:            %c1_26 = arith.constant 1 : index
+# CHECK-NEXT:            scf.for %arg6 = %c0_24 to %c16_25 step %c1_26 {
+# CHECK-NEXT:              %subview_27 = memref.subview %subview_21[0, 0] [1, 1] [1, 1] : memref<1x1xf32, strided<[512, 1], offset: ?>> to memref<1x1xf32, strided<[512, 1], offset: ?>>
+# CHECK-NEXT:              %subview_28 = memref.subview %subview_22[0, %arg6] [1, 1] [1, 1] : memref<1x16xf32, strided<[32, 1], offset: ?>> to memref<1x1xf32, strided<[32, 1], offset: ?>>
+# CHECK-NEXT:              %subview_29 = memref.subview %subview_23[0, %arg6] [1, 1] [1, 1] : memref<1x16xf32, strided<[32, 1], offset: ?>> to memref<1x1xf32, strided<[32, 1], offset: ?>>
+# CHECK-NEXT:              linalg.matmul {__xtc_id_C_} ins(%subview_27, %subview_28 : memref<1x1xf32, strided<[512, 1], offset: ?>>, memref<1x1xf32, strided<[32, 1], offset: ?>>) outs(%subview_29 : memref<1x1xf32, strided<[32, 1], offset: ?>>)
 # CHECK-NEXT:            } {"./j1"}
 # CHECK-NEXT:          } {"./j"}
 # CHECK-NEXT:        } {"./i"}

--- a/tests/filecheck/backends/test_mlir_pack_no_sdist.py
+++ b/tests/filecheck/backends/test_mlir_pack_no_sdist.py
@@ -47,26 +47,21 @@ print(f"CODE: {res}")
 # CHECK-NEXT:      transform.yield 
 # CHECK-NEXT:    }
 # CHECK-NEXT:    transform.named_sequence @__transform_main(%arg0: !transform.any_op {transform.readonly}) {
-# CHECK-NEXT:      %0 = transform.structured.match attributes {__xtc_id_C_0_} in %arg0 : (!transform.any_op) -> !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op, %loops = transform.structured.tile_using_for %0 tile_sizes [1, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops "./i" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_0, %loops_1 = transform.structured.tile_using_for %tiled_linalg_op tile_sizes [0, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_1 "./j" : !transform.any_op
-# CHECK-NEXT:      %1 = transform.structured.match attributes {__xtc_id_C_} in %arg0 : (!transform.any_op) -> !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_2, %loops_3 = transform.structured.tile_using_for %1 tile_sizes [0, 0, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_3 "./k" : !transform.any_op
-# CHECK-NEXT:      transform.apply_patterns to %tiled_linalg_op_2 {
+# CHECK-NEXT:      %0 = transform.structured.match attributes {__xtc_id_C_} in %arg0 : (!transform.any_op) -> !transform.any_op
+# CHECK-NEXT:      %tiled_linalg_op, %loops = transform.structured.tile_using_for %0 tile_sizes [0, 0, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      transform.annotate %loops "./k" : !transform.any_op
+# CHECK-NEXT:      transform.apply_patterns to %tiled_linalg_op {
 # CHECK-NEXT:        transform.apply_patterns.memref.fold_memref_alias_ops
 # CHECK-NEXT:      } : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_4, %loops_5 = transform.structured.tile_using_for %tiled_linalg_op_2 tile_sizes [2, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_5 "./i" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_6, %loops_7 = transform.structured.tile_using_for %tiled_linalg_op_4 tile_sizes [0, 16, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_7 "./j" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_8, %loops_9 = transform.structured.tile_using_for %tiled_linalg_op_6 tile_sizes [1, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_9 "./i1" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_10, %loops_11 = transform.structured.tile_using_for %tiled_linalg_op_8 tile_sizes [0, 1, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_11 "./j1" : !transform.any_op
-# CHECK-NEXT:      transform.loop.unroll %loops_9 {factor = 2 : i64} : !transform.any_op
+# CHECK-NEXT:      %tiled_linalg_op_0, %loops_1 = transform.structured.tile_using_for %tiled_linalg_op tile_sizes [2, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      transform.annotate %loops_1 "./i" : !transform.any_op
+# CHECK-NEXT:      %tiled_linalg_op_2, %loops_3 = transform.structured.tile_using_for %tiled_linalg_op_0 tile_sizes [0, 16, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      transform.annotate %loops_3 "./j" : !transform.any_op
+# CHECK-NEXT:      %tiled_linalg_op_4, %loops_5 = transform.structured.tile_using_for %tiled_linalg_op_2 tile_sizes [1, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      transform.annotate %loops_5 "./i1" : !transform.any_op
+# CHECK-NEXT:      %tiled_linalg_op_6, %loops_7 = transform.structured.tile_using_for %tiled_linalg_op_4 tile_sizes [0, 1, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      transform.annotate %loops_7 "./j1" : !transform.any_op
+# CHECK-NEXT:      transform.loop.unroll %loops_5 {factor = 2 : i64} : !transform.any_op
 # CHECK-NEXT:      transform.yield 
 # CHECK-NEXT:    }
 # CHECK-NEXT:  }
@@ -75,70 +70,58 @@ print(f"CODE: {res}")
 # CHECK-NEXT:  module attributes {transform.with_named_sequence} {
 # CHECK-NEXT:    func.func @matmul(%arg0: memref<4x512xf32> {llvm.noalias}, %arg1: memref<512x32xf32> {llvm.noalias}, %arg2: memref<4x32xf32> {llvm.noalias}) {
 # CHECK-NEXT:      %cst = arith.constant 0.000000e+00 : f32
+# CHECK-NEXT:      linalg.fill {__xtc_id_C_0_} ins(%cst : f32) outs(%arg2 : memref<4x32xf32>)
 # CHECK-NEXT:      %c0 = arith.constant 0 : index
-# CHECK-NEXT:      %c4 = arith.constant 4 : index
-# CHECK-NEXT:      %c1 = arith.constant 1 : index
-# CHECK-NEXT:      scf.for %arg3 = %c0 to %c4 step %c1 {
-# CHECK-NEXT:        %subview = memref.subview %arg2[%arg3, 0] [1, 32] [1, 1] : memref<4x32xf32> to memref<1x32xf32, strided<[32, 1], offset: ?>>
-# CHECK-NEXT:        %c0_2 = arith.constant 0 : index
-# CHECK-NEXT:        %c32 = arith.constant 32 : index
-# CHECK-NEXT:        %c1_3 = arith.constant 1 : index
-# CHECK-NEXT:        scf.for %arg4 = %c0_2 to %c32 step %c1_3 {
-# CHECK-NEXT:          %subview_4 = memref.subview %subview[0, %arg4] [1, 1] [1, 1] : memref<1x32xf32, strided<[32, 1], offset: ?>> to memref<1x1xf32, strided<[32, 1], offset: ?>>
-# CHECK-NEXT:          linalg.fill {__xtc_id_C_0_} ins(%cst : f32) outs(%subview_4 : memref<1x1xf32, strided<[32, 1], offset: ?>>)
-# CHECK-NEXT:        } {"./j"}
-# CHECK-NEXT:      } {"./i"}
-# CHECK-NEXT:      %c0_0 = arith.constant 0 : index
 # CHECK-NEXT:      %c512 = arith.constant 512 : index
-# CHECK-NEXT:      %c1_1 = arith.constant 1 : index
-# CHECK-NEXT:      scf.for %arg3 = %c0_0 to %c512 step %c1_1 {
+# CHECK-NEXT:      %c1 = arith.constant 1 : index
+# CHECK-NEXT:      scf.for %arg3 = %c0 to %c512 step %c1 {
 # CHECK-NEXT:        %subview = memref.subview %arg0[0, %arg3] [4, 1] [1, 1] : memref<4x512xf32> to memref<4x1xf32, strided<[512, 1], offset: ?>>
-# CHECK-NEXT:        %subview_2 = memref.subview %arg1[%arg3, 0] [1, 32] [1, 1] : memref<512x32xf32> to memref<1x32xf32, strided<[32, 1], offset: ?>>
-# CHECK-NEXT:        %subview_3 = memref.subview %arg2[0, 0] [4, 32] [1, 1] : memref<4x32xf32> to memref<4x32xf32, strided<[32, 1]>>
-# CHECK-NEXT:        %c0_4 = arith.constant 0 : index
-# CHECK-NEXT:        %c4_5 = arith.constant 4 : index
+# CHECK-NEXT:        %subview_0 = memref.subview %arg1[%arg3, 0] [1, 32] [1, 1] : memref<512x32xf32> to memref<1x32xf32, strided<[32, 1], offset: ?>>
+# CHECK-NEXT:        %subview_1 = memref.subview %arg2[0, 0] [4, 32] [1, 1] : memref<4x32xf32> to memref<4x32xf32, strided<[32, 1]>>
+# CHECK-NEXT:        %c0_2 = arith.constant 0 : index
+# CHECK-NEXT:        %c4 = arith.constant 4 : index
 # CHECK-NEXT:        %c2 = arith.constant 2 : index
-# CHECK-NEXT:        scf.for %arg4 = %c0_4 to %c4_5 step %c2 {
-# CHECK-NEXT:          %subview_6 = memref.subview %subview[%arg4, 0] [2, 1] [1, 1] : memref<4x1xf32, strided<[512, 1], offset: ?>> to memref<2x1xf32, strided<[512, 1], offset: ?>>
-# CHECK-NEXT:          %subview_7 = memref.subview %subview_2[0, 0] [1, 32] [1, 1] : memref<1x32xf32, strided<[32, 1], offset: ?>> to memref<1x32xf32, strided<[32, 1], offset: ?>>
-# CHECK-NEXT:          %subview_8 = memref.subview %subview_3[%arg4, 0] [2, 32] [1, 1] : memref<4x32xf32, strided<[32, 1]>> to memref<2x32xf32, strided<[32, 1], offset: ?>>
-# CHECK-NEXT:          %c0_9 = arith.constant 0 : index
+# CHECK-NEXT:        scf.for %arg4 = %c0_2 to %c4 step %c2 {
+# CHECK-NEXT:          %subview_3 = memref.subview %subview[%arg4, 0] [2, 1] [1, 1] : memref<4x1xf32, strided<[512, 1], offset: ?>> to memref<2x1xf32, strided<[512, 1], offset: ?>>
+# CHECK-NEXT:          %subview_4 = memref.subview %subview_0[0, 0] [1, 32] [1, 1] : memref<1x32xf32, strided<[32, 1], offset: ?>> to memref<1x32xf32, strided<[32, 1], offset: ?>>
+# CHECK-NEXT:          %subview_5 = memref.subview %subview_1[%arg4, 0] [2, 32] [1, 1] : memref<4x32xf32, strided<[32, 1]>> to memref<2x32xf32, strided<[32, 1], offset: ?>>
+# CHECK-NEXT:          %c0_6 = arith.constant 0 : index
 # CHECK-NEXT:          %c32 = arith.constant 32 : index
 # CHECK-NEXT:          %c16 = arith.constant 16 : index
-# CHECK-NEXT:          scf.for %arg5 = %c0_9 to %c32 step %c16 {
-# CHECK-NEXT:            %subview_10 = memref.subview %subview_6[0, 0] [2, 1] [1, 1] : memref<2x1xf32, strided<[512, 1], offset: ?>> to memref<2x1xf32, strided<[512, 1], offset: ?>>
-# CHECK-NEXT:            %subview_11 = memref.subview %subview_7[0, %arg5] [1, 16] [1, 1] : memref<1x32xf32, strided<[32, 1], offset: ?>> to memref<1x16xf32, strided<[32, 1], offset: ?>>
-# CHECK-NEXT:            %subview_12 = memref.subview %subview_8[0, %arg5] [2, 16] [1, 1] : memref<2x32xf32, strided<[32, 1], offset: ?>> to memref<2x16xf32, strided<[32, 1], offset: ?>>
-# CHECK-NEXT:            %c0_13 = arith.constant 0 : index
-# CHECK-NEXT:            %c2_14 = arith.constant 2 : index
-# CHECK-NEXT:            %c1_15 = arith.constant 1 : index
-# CHECK-NEXT:            %c2_16 = arith.constant 2 : index
-# CHECK-NEXT:            %subview_17 = memref.subview %subview_10[%c0_13, 0] [1, 1] [1, 1] : memref<2x1xf32, strided<[512, 1], offset: ?>> to memref<1x1xf32, strided<[512, 1], offset: ?>>
-# CHECK-NEXT:            %subview_18 = memref.subview %subview_11[0, 0] [1, 16] [1, 1] : memref<1x16xf32, strided<[32, 1], offset: ?>> to memref<1x16xf32, strided<[32, 1], offset: ?>>
-# CHECK-NEXT:            %subview_19 = memref.subview %subview_12[%c0_13, 0] [1, 16] [1, 1] : memref<2x16xf32, strided<[32, 1], offset: ?>> to memref<1x16xf32, strided<[32, 1], offset: ?>>
-# CHECK-NEXT:            %c0_20 = arith.constant 0 : index
-# CHECK-NEXT:            %c16_21 = arith.constant 16 : index
-# CHECK-NEXT:            %c1_22 = arith.constant 1 : index
-# CHECK-NEXT:            scf.for %arg6 = %c0_20 to %c16_21 step %c1_22 {
-# CHECK-NEXT:              %subview_30 = memref.subview %subview_17[0, 0] [1, 1] [1, 1] : memref<1x1xf32, strided<[512, 1], offset: ?>> to memref<1x1xf32, strided<[512, 1], offset: ?>>
-# CHECK-NEXT:              %subview_31 = memref.subview %subview_18[0, %arg6] [1, 1] [1, 1] : memref<1x16xf32, strided<[32, 1], offset: ?>> to memref<1x1xf32, strided<[32, 1], offset: ?>>
-# CHECK-NEXT:              %subview_32 = memref.subview %subview_19[0, %arg6] [1, 1] [1, 1] : memref<1x16xf32, strided<[32, 1], offset: ?>> to memref<1x1xf32, strided<[32, 1], offset: ?>>
-# CHECK-NEXT:              linalg.matmul {__xtc_id_C_} ins(%subview_30, %subview_31 : memref<1x1xf32, strided<[512, 1], offset: ?>>, memref<1x1xf32, strided<[32, 1], offset: ?>>) outs(%subview_32 : memref<1x1xf32, strided<[32, 1], offset: ?>>)
+# CHECK-NEXT:          scf.for %arg5 = %c0_6 to %c32 step %c16 {
+# CHECK-NEXT:            %subview_7 = memref.subview %subview_3[0, 0] [2, 1] [1, 1] : memref<2x1xf32, strided<[512, 1], offset: ?>> to memref<2x1xf32, strided<[512, 1], offset: ?>>
+# CHECK-NEXT:            %subview_8 = memref.subview %subview_4[0, %arg5] [1, 16] [1, 1] : memref<1x32xf32, strided<[32, 1], offset: ?>> to memref<1x16xf32, strided<[32, 1], offset: ?>>
+# CHECK-NEXT:            %subview_9 = memref.subview %subview_5[0, %arg5] [2, 16] [1, 1] : memref<2x32xf32, strided<[32, 1], offset: ?>> to memref<2x16xf32, strided<[32, 1], offset: ?>>
+# CHECK-NEXT:            %c0_10 = arith.constant 0 : index
+# CHECK-NEXT:            %c2_11 = arith.constant 2 : index
+# CHECK-NEXT:            %c1_12 = arith.constant 1 : index
+# CHECK-NEXT:            %c2_13 = arith.constant 2 : index
+# CHECK-NEXT:            %subview_14 = memref.subview %subview_7[%c0_10, 0] [1, 1] [1, 1] : memref<2x1xf32, strided<[512, 1], offset: ?>> to memref<1x1xf32, strided<[512, 1], offset: ?>>
+# CHECK-NEXT:            %subview_15 = memref.subview %subview_8[0, 0] [1, 16] [1, 1] : memref<1x16xf32, strided<[32, 1], offset: ?>> to memref<1x16xf32, strided<[32, 1], offset: ?>>
+# CHECK-NEXT:            %subview_16 = memref.subview %subview_9[%c0_10, 0] [1, 16] [1, 1] : memref<2x16xf32, strided<[32, 1], offset: ?>> to memref<1x16xf32, strided<[32, 1], offset: ?>>
+# CHECK-NEXT:            %c0_17 = arith.constant 0 : index
+# CHECK-NEXT:            %c16_18 = arith.constant 16 : index
+# CHECK-NEXT:            %c1_19 = arith.constant 1 : index
+# CHECK-NEXT:            scf.for %arg6 = %c0_17 to %c16_18 step %c1_19 {
+# CHECK-NEXT:              %subview_27 = memref.subview %subview_14[0, 0] [1, 1] [1, 1] : memref<1x1xf32, strided<[512, 1], offset: ?>> to memref<1x1xf32, strided<[512, 1], offset: ?>>
+# CHECK-NEXT:              %subview_28 = memref.subview %subview_15[0, %arg6] [1, 1] [1, 1] : memref<1x16xf32, strided<[32, 1], offset: ?>> to memref<1x1xf32, strided<[32, 1], offset: ?>>
+# CHECK-NEXT:              %subview_29 = memref.subview %subview_16[0, %arg6] [1, 1] [1, 1] : memref<1x16xf32, strided<[32, 1], offset: ?>> to memref<1x1xf32, strided<[32, 1], offset: ?>>
+# CHECK-NEXT:              linalg.matmul {__xtc_id_C_} ins(%subview_27, %subview_28 : memref<1x1xf32, strided<[512, 1], offset: ?>>, memref<1x1xf32, strided<[32, 1], offset: ?>>) outs(%subview_29 : memref<1x1xf32, strided<[32, 1], offset: ?>>)
 # CHECK-NEXT:            } {"./j1"}
-# CHECK-NEXT:            %c1_23 = arith.constant 1 : index
-# CHECK-NEXT:            %0 = arith.muli %c1_15, %c1_23 : index
-# CHECK-NEXT:            %1 = arith.addi %c0_13, %0 : index
-# CHECK-NEXT:            %subview_24 = memref.subview %subview_10[%1, 0] [1, 1] [1, 1] : memref<2x1xf32, strided<[512, 1], offset: ?>> to memref<1x1xf32, strided<[512, 1], offset: ?>>
-# CHECK-NEXT:            %subview_25 = memref.subview %subview_11[0, 0] [1, 16] [1, 1] : memref<1x16xf32, strided<[32, 1], offset: ?>> to memref<1x16xf32, strided<[32, 1], offset: ?>>
-# CHECK-NEXT:            %subview_26 = memref.subview %subview_12[%1, 0] [1, 16] [1, 1] : memref<2x16xf32, strided<[32, 1], offset: ?>> to memref<1x16xf32, strided<[32, 1], offset: ?>>
-# CHECK-NEXT:            %c0_27 = arith.constant 0 : index
-# CHECK-NEXT:            %c16_28 = arith.constant 16 : index
-# CHECK-NEXT:            %c1_29 = arith.constant 1 : index
-# CHECK-NEXT:            scf.for %arg6 = %c0_27 to %c16_28 step %c1_29 {
-# CHECK-NEXT:              %subview_30 = memref.subview %subview_24[0, 0] [1, 1] [1, 1] : memref<1x1xf32, strided<[512, 1], offset: ?>> to memref<1x1xf32, strided<[512, 1], offset: ?>>
-# CHECK-NEXT:              %subview_31 = memref.subview %subview_25[0, %arg6] [1, 1] [1, 1] : memref<1x16xf32, strided<[32, 1], offset: ?>> to memref<1x1xf32, strided<[32, 1], offset: ?>>
-# CHECK-NEXT:              %subview_32 = memref.subview %subview_26[0, %arg6] [1, 1] [1, 1] : memref<1x16xf32, strided<[32, 1], offset: ?>> to memref<1x1xf32, strided<[32, 1], offset: ?>>
-# CHECK-NEXT:              linalg.matmul {__xtc_id_C_} ins(%subview_30, %subview_31 : memref<1x1xf32, strided<[512, 1], offset: ?>>, memref<1x1xf32, strided<[32, 1], offset: ?>>) outs(%subview_32 : memref<1x1xf32, strided<[32, 1], offset: ?>>)
+# CHECK-NEXT:            %c1_20 = arith.constant 1 : index
+# CHECK-NEXT:            %0 = arith.muli %c1_12, %c1_20 : index
+# CHECK-NEXT:            %1 = arith.addi %c0_10, %0 : index
+# CHECK-NEXT:            %subview_21 = memref.subview %subview_7[%1, 0] [1, 1] [1, 1] : memref<2x1xf32, strided<[512, 1], offset: ?>> to memref<1x1xf32, strided<[512, 1], offset: ?>>
+# CHECK-NEXT:            %subview_22 = memref.subview %subview_8[0, 0] [1, 16] [1, 1] : memref<1x16xf32, strided<[32, 1], offset: ?>> to memref<1x16xf32, strided<[32, 1], offset: ?>>
+# CHECK-NEXT:            %subview_23 = memref.subview %subview_9[%1, 0] [1, 16] [1, 1] : memref<2x16xf32, strided<[32, 1], offset: ?>> to memref<1x16xf32, strided<[32, 1], offset: ?>>
+# CHECK-NEXT:            %c0_24 = arith.constant 0 : index
+# CHECK-NEXT:            %c16_25 = arith.constant 16 : index
+# CHECK-NEXT:            %c1_26 = arith.constant 1 : index
+# CHECK-NEXT:            scf.for %arg6 = %c0_24 to %c16_25 step %c1_26 {
+# CHECK-NEXT:              %subview_27 = memref.subview %subview_21[0, 0] [1, 1] [1, 1] : memref<1x1xf32, strided<[512, 1], offset: ?>> to memref<1x1xf32, strided<[512, 1], offset: ?>>
+# CHECK-NEXT:              %subview_28 = memref.subview %subview_22[0, %arg6] [1, 1] [1, 1] : memref<1x16xf32, strided<[32, 1], offset: ?>> to memref<1x1xf32, strided<[32, 1], offset: ?>>
+# CHECK-NEXT:              %subview_29 = memref.subview %subview_23[0, %arg6] [1, 1] [1, 1] : memref<1x16xf32, strided<[32, 1], offset: ?>> to memref<1x1xf32, strided<[32, 1], offset: ?>>
+# CHECK-NEXT:              linalg.matmul {__xtc_id_C_} ins(%subview_27, %subview_28 : memref<1x1xf32, strided<[512, 1], offset: ?>>, memref<1x1xf32, strided<[32, 1], offset: ?>>) outs(%subview_29 : memref<1x1xf32, strided<[32, 1], offset: ?>>)
 # CHECK-NEXT:            } {"./j1"}
 # CHECK-NEXT:          } {"./j"}
 # CHECK-NEXT:        } {"./i"}

--- a/tests/filecheck/backends/test_mlir_pack_sdist.py
+++ b/tests/filecheck/backends/test_mlir_pack_sdist.py
@@ -47,27 +47,22 @@ print(f"CODE: {res}")
 # CHECK-NEXT:      transform.yield 
 # CHECK-NEXT:    }
 # CHECK-NEXT:    transform.named_sequence @__transform_main(%arg0: !transform.any_op {transform.readonly}) {
-# CHECK-NEXT:      %0 = transform.structured.match attributes {__xtc_id_C_0_} in %arg0 : (!transform.any_op) -> !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op, %loops = transform.structured.tile_using_for %0 tile_sizes [1, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops "./i" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_0, %loops_1 = transform.structured.tile_using_for %tiled_linalg_op tile_sizes [0, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_1 "./j" : !transform.any_op
-# CHECK-NEXT:      %1 = transform.structured.match attributes {__xtc_id_C_} in %arg0 : (!transform.any_op) -> !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_2, %loops_3 = transform.structured.tile_using_for %1 tile_sizes [0, 0, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_3 "./k" : !transform.any_op
-# CHECK-NEXT:      transform.apply_patterns to %tiled_linalg_op_2 {
+# CHECK-NEXT:      %0 = transform.structured.match attributes {__xtc_id_C_} in %arg0 : (!transform.any_op) -> !transform.any_op
+# CHECK-NEXT:      %tiled_linalg_op, %loops = transform.structured.tile_using_for %0 tile_sizes [0, 0, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      transform.annotate %loops "./k" : !transform.any_op
+# CHECK-NEXT:      transform.apply_patterns to %tiled_linalg_op {
 # CHECK-NEXT:        transform.apply_patterns.memref.fold_memref_alias_ops
 # CHECK-NEXT:      } : !transform.any_op
-# CHECK-NEXT:      %2 = transform.sdist.local_buffer_at %tiled_linalg_op_2 tensor 1 : !transform.any_op -> !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_4, %loops_5 = transform.structured.tile_using_for %tiled_linalg_op_2 tile_sizes [2, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_5 "./i" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_6, %loops_7 = transform.structured.tile_using_for %tiled_linalg_op_4 tile_sizes [0, 16, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_7 "./j" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_8, %loops_9 = transform.structured.tile_using_for %tiled_linalg_op_6 tile_sizes [1, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_9 "./i1" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_10, %loops_11 = transform.structured.tile_using_for %tiled_linalg_op_8 tile_sizes [0, 1, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_11 "./j1" : !transform.any_op
-# CHECK-NEXT:      transform.loop.unroll %loops_9 {factor = 2 : i64} : !transform.any_op
+# CHECK-NEXT:      %1 = transform.sdist.local_buffer_at %tiled_linalg_op tensor 1 : !transform.any_op -> !transform.any_op
+# CHECK-NEXT:      %tiled_linalg_op_0, %loops_1 = transform.structured.tile_using_for %tiled_linalg_op tile_sizes [2, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      transform.annotate %loops_1 "./i" : !transform.any_op
+# CHECK-NEXT:      %tiled_linalg_op_2, %loops_3 = transform.structured.tile_using_for %tiled_linalg_op_0 tile_sizes [0, 16, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      transform.annotate %loops_3 "./j" : !transform.any_op
+# CHECK-NEXT:      %tiled_linalg_op_4, %loops_5 = transform.structured.tile_using_for %tiled_linalg_op_2 tile_sizes [1, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      transform.annotate %loops_5 "./i1" : !transform.any_op
+# CHECK-NEXT:      %tiled_linalg_op_6, %loops_7 = transform.structured.tile_using_for %tiled_linalg_op_4 tile_sizes [0, 1, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      transform.annotate %loops_7 "./j1" : !transform.any_op
+# CHECK-NEXT:      transform.loop.unroll %loops_5 {factor = 2 : i64} : !transform.any_op
 # CHECK-NEXT:      transform.yield 
 # CHECK-NEXT:    }
 # CHECK-NEXT:  }
@@ -76,73 +71,61 @@ print(f"CODE: {res}")
 # CHECK-NEXT:  module attributes {transform.with_named_sequence} {
 # CHECK-NEXT:    func.func @matmul(%arg0: memref<4x512xf32> {llvm.noalias}, %arg1: memref<512x32xf32> {llvm.noalias}, %arg2: memref<4x32xf32> {llvm.noalias}) {
 # CHECK-NEXT:      %cst = arith.constant 0.000000e+00 : f32
+# CHECK-NEXT:      linalg.fill {__xtc_id_C_0_} ins(%cst : f32) outs(%arg2 : memref<4x32xf32>)
 # CHECK-NEXT:      %c0 = arith.constant 0 : index
-# CHECK-NEXT:      %c4 = arith.constant 4 : index
-# CHECK-NEXT:      %c1 = arith.constant 1 : index
-# CHECK-NEXT:      scf.for %arg3 = %c0 to %c4 step %c1 {
-# CHECK-NEXT:        %subview = memref.subview %arg2[%arg3, 0] [1, 32] [1, 1] : memref<4x32xf32> to memref<1x32xf32, strided<[32, 1], offset: ?>>
-# CHECK-NEXT:        %c0_2 = arith.constant 0 : index
-# CHECK-NEXT:        %c32 = arith.constant 32 : index
-# CHECK-NEXT:        %c1_3 = arith.constant 1 : index
-# CHECK-NEXT:        scf.for %arg4 = %c0_2 to %c32 step %c1_3 {
-# CHECK-NEXT:          %subview_4 = memref.subview %subview[0, %arg4] [1, 1] [1, 1] : memref<1x32xf32, strided<[32, 1], offset: ?>> to memref<1x1xf32, strided<[32, 1], offset: ?>>
-# CHECK-NEXT:          linalg.fill {__xtc_id_C_0_} ins(%cst : f32) outs(%subview_4 : memref<1x1xf32, strided<[32, 1], offset: ?>>)
-# CHECK-NEXT:        } {"./j"}
-# CHECK-NEXT:      } {"./i"}
-# CHECK-NEXT:      %c0_0 = arith.constant 0 : index
 # CHECK-NEXT:      %c512 = arith.constant 512 : index
-# CHECK-NEXT:      %c1_1 = arith.constant 1 : index
-# CHECK-NEXT:      scf.for %arg3 = %c0_0 to %c512 step %c1_1 {
+# CHECK-NEXT:      %c1 = arith.constant 1 : index
+# CHECK-NEXT:      scf.for %arg3 = %c0 to %c512 step %c1 {
 # CHECK-NEXT:        %subview = memref.subview %arg0[0, %arg3] [4, 1] [1, 1] : memref<4x512xf32> to memref<4x1xf32, strided<[512, 1], offset: ?>>
-# CHECK-NEXT:        %subview_2 = memref.subview %arg1[%arg3, 0] [1, 32] [1, 1] : memref<512x32xf32> to memref<1x32xf32, strided<[32, 1], offset: ?>>
-# CHECK-NEXT:        %subview_3 = memref.subview %arg2[0, 0] [4, 32] [1, 1] : memref<4x32xf32> to memref<4x32xf32, strided<[32, 1]>>
+# CHECK-NEXT:        %subview_0 = memref.subview %arg1[%arg3, 0] [1, 32] [1, 1] : memref<512x32xf32> to memref<1x32xf32, strided<[32, 1], offset: ?>>
+# CHECK-NEXT:        %subview_1 = memref.subview %arg2[0, 0] [4, 32] [1, 1] : memref<4x32xf32> to memref<4x32xf32, strided<[32, 1]>>
 # CHECK-NEXT:        %alloc = memref.alloc() : memref<1x32xf32, 2>
-# CHECK-NEXT:        %c0_4 = arith.constant 0 : index
-# CHECK-NEXT:        sdist.read %arg1[%arg3, %c0_4] to %alloc : memref<512x32xf32>, memref<1x32xf32, 2>
-# CHECK-NEXT:        %c0_5 = arith.constant 0 : index
-# CHECK-NEXT:        %c4_6 = arith.constant 4 : index
+# CHECK-NEXT:        %c0_2 = arith.constant 0 : index
+# CHECK-NEXT:        sdist.read %arg1[%arg3, %c0_2] to %alloc : memref<512x32xf32>, memref<1x32xf32, 2>
+# CHECK-NEXT:        %c0_3 = arith.constant 0 : index
+# CHECK-NEXT:        %c4 = arith.constant 4 : index
 # CHECK-NEXT:        %c2 = arith.constant 2 : index
-# CHECK-NEXT:        scf.for %arg4 = %c0_5 to %c4_6 step %c2 {
-# CHECK-NEXT:          %subview_7 = memref.subview %subview[%arg4, 0] [2, 1] [1, 1] : memref<4x1xf32, strided<[512, 1], offset: ?>> to memref<2x1xf32, strided<[512, 1], offset: ?>>
-# CHECK-NEXT:          %subview_8 = memref.subview %alloc[0, 0] [1, 32] [1, 1] : memref<1x32xf32, 2> to memref<1x32xf32, strided<[32, 1]>, 2>
-# CHECK-NEXT:          %subview_9 = memref.subview %subview_3[%arg4, 0] [2, 32] [1, 1] : memref<4x32xf32, strided<[32, 1]>> to memref<2x32xf32, strided<[32, 1], offset: ?>>
-# CHECK-NEXT:          %c0_10 = arith.constant 0 : index
+# CHECK-NEXT:        scf.for %arg4 = %c0_3 to %c4 step %c2 {
+# CHECK-NEXT:          %subview_4 = memref.subview %subview[%arg4, 0] [2, 1] [1, 1] : memref<4x1xf32, strided<[512, 1], offset: ?>> to memref<2x1xf32, strided<[512, 1], offset: ?>>
+# CHECK-NEXT:          %subview_5 = memref.subview %alloc[0, 0] [1, 32] [1, 1] : memref<1x32xf32, 2> to memref<1x32xf32, strided<[32, 1]>, 2>
+# CHECK-NEXT:          %subview_6 = memref.subview %subview_1[%arg4, 0] [2, 32] [1, 1] : memref<4x32xf32, strided<[32, 1]>> to memref<2x32xf32, strided<[32, 1], offset: ?>>
+# CHECK-NEXT:          %c0_7 = arith.constant 0 : index
 # CHECK-NEXT:          %c32 = arith.constant 32 : index
 # CHECK-NEXT:          %c16 = arith.constant 16 : index
-# CHECK-NEXT:          scf.for %arg5 = %c0_10 to %c32 step %c16 {
-# CHECK-NEXT:            %subview_11 = memref.subview %subview_7[0, 0] [2, 1] [1, 1] : memref<2x1xf32, strided<[512, 1], offset: ?>> to memref<2x1xf32, strided<[512, 1], offset: ?>>
-# CHECK-NEXT:            %subview_12 = memref.subview %subview_8[0, %arg5] [1, 16] [1, 1] : memref<1x32xf32, strided<[32, 1]>, 2> to memref<1x16xf32, strided<[32, 1], offset: ?>, 2>
-# CHECK-NEXT:            %subview_13 = memref.subview %subview_9[0, %arg5] [2, 16] [1, 1] : memref<2x32xf32, strided<[32, 1], offset: ?>> to memref<2x16xf32, strided<[32, 1], offset: ?>>
-# CHECK-NEXT:            %c0_14 = arith.constant 0 : index
-# CHECK-NEXT:            %c2_15 = arith.constant 2 : index
-# CHECK-NEXT:            %c1_16 = arith.constant 1 : index
-# CHECK-NEXT:            %c2_17 = arith.constant 2 : index
-# CHECK-NEXT:            %subview_18 = memref.subview %subview_11[%c0_14, 0] [1, 1] [1, 1] : memref<2x1xf32, strided<[512, 1], offset: ?>> to memref<1x1xf32, strided<[512, 1], offset: ?>>
-# CHECK-NEXT:            %subview_19 = memref.subview %subview_12[0, 0] [1, 16] [1, 1] : memref<1x16xf32, strided<[32, 1], offset: ?>, 2> to memref<1x16xf32, strided<[32, 1], offset: ?>, 2>
-# CHECK-NEXT:            %subview_20 = memref.subview %subview_13[%c0_14, 0] [1, 16] [1, 1] : memref<2x16xf32, strided<[32, 1], offset: ?>> to memref<1x16xf32, strided<[32, 1], offset: ?>>
-# CHECK-NEXT:            %c0_21 = arith.constant 0 : index
-# CHECK-NEXT:            %c16_22 = arith.constant 16 : index
-# CHECK-NEXT:            %c1_23 = arith.constant 1 : index
-# CHECK-NEXT:            scf.for %arg6 = %c0_21 to %c16_22 step %c1_23 {
-# CHECK-NEXT:              %subview_31 = memref.subview %subview_18[0, 0] [1, 1] [1, 1] : memref<1x1xf32, strided<[512, 1], offset: ?>> to memref<1x1xf32, strided<[512, 1], offset: ?>>
-# CHECK-NEXT:              %subview_32 = memref.subview %subview_19[0, %arg6] [1, 1] [1, 1] : memref<1x16xf32, strided<[32, 1], offset: ?>, 2> to memref<1x1xf32, strided<[32, 1], offset: ?>, 2>
-# CHECK-NEXT:              %subview_33 = memref.subview %subview_20[0, %arg6] [1, 1] [1, 1] : memref<1x16xf32, strided<[32, 1], offset: ?>> to memref<1x1xf32, strided<[32, 1], offset: ?>>
-# CHECK-NEXT:              linalg.matmul {__xtc_id_C_} ins(%subview_31, %subview_32 : memref<1x1xf32, strided<[512, 1], offset: ?>>, memref<1x1xf32, strided<[32, 1], offset: ?>, 2>) outs(%subview_33 : memref<1x1xf32, strided<[32, 1], offset: ?>>)
+# CHECK-NEXT:          scf.for %arg5 = %c0_7 to %c32 step %c16 {
+# CHECK-NEXT:            %subview_8 = memref.subview %subview_4[0, 0] [2, 1] [1, 1] : memref<2x1xf32, strided<[512, 1], offset: ?>> to memref<2x1xf32, strided<[512, 1], offset: ?>>
+# CHECK-NEXT:            %subview_9 = memref.subview %subview_5[0, %arg5] [1, 16] [1, 1] : memref<1x32xf32, strided<[32, 1]>, 2> to memref<1x16xf32, strided<[32, 1], offset: ?>, 2>
+# CHECK-NEXT:            %subview_10 = memref.subview %subview_6[0, %arg5] [2, 16] [1, 1] : memref<2x32xf32, strided<[32, 1], offset: ?>> to memref<2x16xf32, strided<[32, 1], offset: ?>>
+# CHECK-NEXT:            %c0_11 = arith.constant 0 : index
+# CHECK-NEXT:            %c2_12 = arith.constant 2 : index
+# CHECK-NEXT:            %c1_13 = arith.constant 1 : index
+# CHECK-NEXT:            %c2_14 = arith.constant 2 : index
+# CHECK-NEXT:            %subview_15 = memref.subview %subview_8[%c0_11, 0] [1, 1] [1, 1] : memref<2x1xf32, strided<[512, 1], offset: ?>> to memref<1x1xf32, strided<[512, 1], offset: ?>>
+# CHECK-NEXT:            %subview_16 = memref.subview %subview_9[0, 0] [1, 16] [1, 1] : memref<1x16xf32, strided<[32, 1], offset: ?>, 2> to memref<1x16xf32, strided<[32, 1], offset: ?>, 2>
+# CHECK-NEXT:            %subview_17 = memref.subview %subview_10[%c0_11, 0] [1, 16] [1, 1] : memref<2x16xf32, strided<[32, 1], offset: ?>> to memref<1x16xf32, strided<[32, 1], offset: ?>>
+# CHECK-NEXT:            %c0_18 = arith.constant 0 : index
+# CHECK-NEXT:            %c16_19 = arith.constant 16 : index
+# CHECK-NEXT:            %c1_20 = arith.constant 1 : index
+# CHECK-NEXT:            scf.for %arg6 = %c0_18 to %c16_19 step %c1_20 {
+# CHECK-NEXT:              %subview_28 = memref.subview %subview_15[0, 0] [1, 1] [1, 1] : memref<1x1xf32, strided<[512, 1], offset: ?>> to memref<1x1xf32, strided<[512, 1], offset: ?>>
+# CHECK-NEXT:              %subview_29 = memref.subview %subview_16[0, %arg6] [1, 1] [1, 1] : memref<1x16xf32, strided<[32, 1], offset: ?>, 2> to memref<1x1xf32, strided<[32, 1], offset: ?>, 2>
+# CHECK-NEXT:              %subview_30 = memref.subview %subview_17[0, %arg6] [1, 1] [1, 1] : memref<1x16xf32, strided<[32, 1], offset: ?>> to memref<1x1xf32, strided<[32, 1], offset: ?>>
+# CHECK-NEXT:              linalg.matmul {__xtc_id_C_} ins(%subview_28, %subview_29 : memref<1x1xf32, strided<[512, 1], offset: ?>>, memref<1x1xf32, strided<[32, 1], offset: ?>, 2>) outs(%subview_30 : memref<1x1xf32, strided<[32, 1], offset: ?>>)
 # CHECK-NEXT:            } {"./j1"}
-# CHECK-NEXT:            %c1_24 = arith.constant 1 : index
-# CHECK-NEXT:            %0 = arith.muli %c1_16, %c1_24 : index
-# CHECK-NEXT:            %1 = arith.addi %c0_14, %0 : index
-# CHECK-NEXT:            %subview_25 = memref.subview %subview_11[%1, 0] [1, 1] [1, 1] : memref<2x1xf32, strided<[512, 1], offset: ?>> to memref<1x1xf32, strided<[512, 1], offset: ?>>
-# CHECK-NEXT:            %subview_26 = memref.subview %subview_12[0, 0] [1, 16] [1, 1] : memref<1x16xf32, strided<[32, 1], offset: ?>, 2> to memref<1x16xf32, strided<[32, 1], offset: ?>, 2>
-# CHECK-NEXT:            %subview_27 = memref.subview %subview_13[%1, 0] [1, 16] [1, 1] : memref<2x16xf32, strided<[32, 1], offset: ?>> to memref<1x16xf32, strided<[32, 1], offset: ?>>
-# CHECK-NEXT:            %c0_28 = arith.constant 0 : index
-# CHECK-NEXT:            %c16_29 = arith.constant 16 : index
-# CHECK-NEXT:            %c1_30 = arith.constant 1 : index
-# CHECK-NEXT:            scf.for %arg6 = %c0_28 to %c16_29 step %c1_30 {
-# CHECK-NEXT:              %subview_31 = memref.subview %subview_25[0, 0] [1, 1] [1, 1] : memref<1x1xf32, strided<[512, 1], offset: ?>> to memref<1x1xf32, strided<[512, 1], offset: ?>>
-# CHECK-NEXT:              %subview_32 = memref.subview %subview_26[0, %arg6] [1, 1] [1, 1] : memref<1x16xf32, strided<[32, 1], offset: ?>, 2> to memref<1x1xf32, strided<[32, 1], offset: ?>, 2>
-# CHECK-NEXT:              %subview_33 = memref.subview %subview_27[0, %arg6] [1, 1] [1, 1] : memref<1x16xf32, strided<[32, 1], offset: ?>> to memref<1x1xf32, strided<[32, 1], offset: ?>>
-# CHECK-NEXT:              linalg.matmul {__xtc_id_C_} ins(%subview_31, %subview_32 : memref<1x1xf32, strided<[512, 1], offset: ?>>, memref<1x1xf32, strided<[32, 1], offset: ?>, 2>) outs(%subview_33 : memref<1x1xf32, strided<[32, 1], offset: ?>>)
+# CHECK-NEXT:            %c1_21 = arith.constant 1 : index
+# CHECK-NEXT:            %0 = arith.muli %c1_13, %c1_21 : index
+# CHECK-NEXT:            %1 = arith.addi %c0_11, %0 : index
+# CHECK-NEXT:            %subview_22 = memref.subview %subview_8[%1, 0] [1, 1] [1, 1] : memref<2x1xf32, strided<[512, 1], offset: ?>> to memref<1x1xf32, strided<[512, 1], offset: ?>>
+# CHECK-NEXT:            %subview_23 = memref.subview %subview_9[0, 0] [1, 16] [1, 1] : memref<1x16xf32, strided<[32, 1], offset: ?>, 2> to memref<1x16xf32, strided<[32, 1], offset: ?>, 2>
+# CHECK-NEXT:            %subview_24 = memref.subview %subview_10[%1, 0] [1, 16] [1, 1] : memref<2x16xf32, strided<[32, 1], offset: ?>> to memref<1x16xf32, strided<[32, 1], offset: ?>>
+# CHECK-NEXT:            %c0_25 = arith.constant 0 : index
+# CHECK-NEXT:            %c16_26 = arith.constant 16 : index
+# CHECK-NEXT:            %c1_27 = arith.constant 1 : index
+# CHECK-NEXT:            scf.for %arg6 = %c0_25 to %c16_26 step %c1_27 {
+# CHECK-NEXT:              %subview_28 = memref.subview %subview_22[0, 0] [1, 1] [1, 1] : memref<1x1xf32, strided<[512, 1], offset: ?>> to memref<1x1xf32, strided<[512, 1], offset: ?>>
+# CHECK-NEXT:              %subview_29 = memref.subview %subview_23[0, %arg6] [1, 1] [1, 1] : memref<1x16xf32, strided<[32, 1], offset: ?>, 2> to memref<1x1xf32, strided<[32, 1], offset: ?>, 2>
+# CHECK-NEXT:              %subview_30 = memref.subview %subview_24[0, %arg6] [1, 1] [1, 1] : memref<1x16xf32, strided<[32, 1], offset: ?>> to memref<1x1xf32, strided<[32, 1], offset: ?>>
+# CHECK-NEXT:              linalg.matmul {__xtc_id_C_} ins(%subview_28, %subview_29 : memref<1x1xf32, strided<[512, 1], offset: ?>>, memref<1x1xf32, strided<[32, 1], offset: ?>, 2>) outs(%subview_30 : memref<1x1xf32, strided<[32, 1], offset: ?>>)
 # CHECK-NEXT:            } {"./j1"}
 # CHECK-NEXT:          } {"./j"}
 # CHECK-NEXT:        } {"./i"}

--- a/tests/filecheck/schedules/test_descript_slice_bigger.py
+++ b/tests/filecheck/schedules/test_descript_slice_bigger.py
@@ -62,38 +62,33 @@ print(f"CODE: {code}")
 # CHECK-NEXT:      transform.yield 
 # CHECK-NEXT:    }
 # CHECK-NEXT:    transform.named_sequence @__transform_main(%arg0: !transform.any_op {transform.readonly}) {
-# CHECK-NEXT:      %0 = transform.structured.match attributes {__xtc_id_C_0_} in %arg0 : (!transform.any_op) -> !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op, %loops = transform.structured.tile_using_for %0 tile_sizes [1, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops "./i" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_0, %loops_1 = transform.structured.tile_using_for %tiled_linalg_op tile_sizes [0, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_1 "./j" : !transform.any_op
-# CHECK-NEXT:      %1 = transform.structured.match attributes {__xtc_id_C_} in %arg0 : (!transform.any_op) -> !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_2, %loops_3 = transform.structured.tile_using_for %1 tile_sizes [0, 0, 32] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_3 "C/k" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_4, %loops_5 = transform.structured.tile_using_for %tiled_linalg_op_2 tile_sizes [0, 16, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_5 "C/j" : !transform.any_op
-# CHECK-NEXT:      %2 = transform.structured.split %tiled_linalg_op_4 after 32  {dimension = 0 : i64} : !transform.any_op
-# CHECK-NEXT:      %3:2 = transform.split_handle %2 : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      %tiled_linalg_op_6, %loops_7 = transform.structured.tile_using_for %3#0 tile_sizes [32, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_7 "C/i[0]/i" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_8, %loops_9 = transform.structured.tile_using_for %tiled_linalg_op_6 tile_sizes [1, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_9 "C/i[0]/i0" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_10, %loops_11 = transform.structured.tile_using_for %tiled_linalg_op_8 tile_sizes [0, 0, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_11 "C/i[0]/k0" : !transform.any_op
-# CHECK-NEXT:      transform.include @_vecto failures(suppress) (%tiled_linalg_op_10) : (!transform.any_op) -> ()
-# CHECK-NEXT:      %tiled_linalg_op_12, %loops_13 = transform.structured.tile_using_for %3#1 tile_sizes [18, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_13 "C/i[1]/i" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_14, %loops_15 = transform.structured.tile_using_for %tiled_linalg_op_12 tile_sizes [1, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_15 "C/i[1]/i0" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_16, %loops_17 = transform.structured.tile_using_for %tiled_linalg_op_14 tile_sizes [0, 0, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_17 "C/i[1]/k0" : !transform.any_op
-# CHECK-NEXT:      transform.include @_vecto failures(suppress) (%tiled_linalg_op_16) : (!transform.any_op) -> ()
-# CHECK-NEXT:      %4 = transform.get_parent_op %loops_3 {isolated_from_above} : (!transform.any_op) -> !transform.any_op
-# CHECK-NEXT:      transform.apply_patterns to %4 {
+# CHECK-NEXT:      %0 = transform.structured.match attributes {__xtc_id_C_} in %arg0 : (!transform.any_op) -> !transform.any_op
+# CHECK-NEXT:      %tiled_linalg_op, %loops = transform.structured.tile_using_for %0 tile_sizes [0, 0, 32] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      transform.annotate %loops "C/k" : !transform.any_op
+# CHECK-NEXT:      %tiled_linalg_op_0, %loops_1 = transform.structured.tile_using_for %tiled_linalg_op tile_sizes [0, 16, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      transform.annotate %loops_1 "C/j" : !transform.any_op
+# CHECK-NEXT:      %1 = transform.structured.split %tiled_linalg_op_0 after 32  {dimension = 0 : i64} : !transform.any_op
+# CHECK-NEXT:      %2:2 = transform.split_handle %1 : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      %tiled_linalg_op_2, %loops_3 = transform.structured.tile_using_for %2#0 tile_sizes [32, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      transform.annotate %loops_3 "C/i[0]/i" : !transform.any_op
+# CHECK-NEXT:      %tiled_linalg_op_4, %loops_5 = transform.structured.tile_using_for %tiled_linalg_op_2 tile_sizes [1, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      transform.annotate %loops_5 "C/i[0]/i0" : !transform.any_op
+# CHECK-NEXT:      %tiled_linalg_op_6, %loops_7 = transform.structured.tile_using_for %tiled_linalg_op_4 tile_sizes [0, 0, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      transform.annotate %loops_7 "C/i[0]/k0" : !transform.any_op
+# CHECK-NEXT:      transform.include @_vecto failures(suppress) (%tiled_linalg_op_6) : (!transform.any_op) -> ()
+# CHECK-NEXT:      %tiled_linalg_op_8, %loops_9 = transform.structured.tile_using_for %2#1 tile_sizes [18, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      transform.annotate %loops_9 "C/i[1]/i" : !transform.any_op
+# CHECK-NEXT:      %tiled_linalg_op_10, %loops_11 = transform.structured.tile_using_for %tiled_linalg_op_8 tile_sizes [1, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      transform.annotate %loops_11 "C/i[1]/i0" : !transform.any_op
+# CHECK-NEXT:      %tiled_linalg_op_12, %loops_13 = transform.structured.tile_using_for %tiled_linalg_op_10 tile_sizes [0, 0, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      transform.annotate %loops_13 "C/i[1]/k0" : !transform.any_op
+# CHECK-NEXT:      transform.include @_vecto failures(suppress) (%tiled_linalg_op_12) : (!transform.any_op) -> ()
+# CHECK-NEXT:      %3 = transform.get_parent_op %loops {isolated_from_above} : (!transform.any_op) -> !transform.any_op
+# CHECK-NEXT:      transform.apply_patterns to %3 {
 # CHECK-NEXT:        transform.apply_patterns.vector.reduction_to_contract
 # CHECK-NEXT:        transform.apply_patterns.vector.transfer_permutation_patterns
 # CHECK-NEXT:      } : !transform.any_op
-# CHECK-NEXT:      transform.apply_patterns to %4 {
+# CHECK-NEXT:      transform.apply_patterns to %3 {
 # CHECK-NEXT:        transform.apply_patterns.vector.lower_outerproduct
 # CHECK-NEXT:        transform.apply_patterns.vector.lower_contraction
 # CHECK-NEXT:      } : !transform.any_op
@@ -107,20 +102,13 @@ print(f"CODE: {code}")
 # CHECK-NEXT:      %cst = arith.constant dense<0.000000e+00> : vector<1x16xf32>
 # CHECK-NEXT:      %c18 = arith.constant 18 : index
 # CHECK-NEXT:      %0 = ub.poison : f32
+# CHECK-NEXT:      %c1 = arith.constant 1 : index
 # CHECK-NEXT:      %c16 = arith.constant 16 : index
 # CHECK-NEXT:      %c32 = arith.constant 32 : index
 # CHECK-NEXT:      %c64 = arith.constant 64 : index
-# CHECK-NEXT:      %cst_0 = arith.constant 0.000000e+00 : f32
 # CHECK-NEXT:      %c0 = arith.constant 0 : index
-# CHECK-NEXT:      %c50 = arith.constant 50 : index
-# CHECK-NEXT:      %c1 = arith.constant 1 : index
-# CHECK-NEXT:      scf.for %arg3 = %c0 to %c50 step %c1 {
-# CHECK-NEXT:        %subview = memref.subview %arg2[%arg3, 0] [1, 64] [1, 1] : memref<50x64xf32> to memref<1x64xf32, strided<[64, 1], offset: ?>>
-# CHECK-NEXT:        scf.for %arg4 = %c0 to %c64 step %c1 {
-# CHECK-NEXT:          %subview_1 = memref.subview %subview[0, %arg4] [1, 1] [1, 1] : memref<1x64xf32, strided<[64, 1], offset: ?>> to memref<1x1xf32, strided<[64, 1], offset: ?>>
-# CHECK-NEXT:          linalg.fill {__xtc_id_C_0_} ins(%cst_0 : f32) outs(%subview_1 : memref<1x1xf32, strided<[64, 1], offset: ?>>)
-# CHECK-NEXT:        } {"./j"}
-# CHECK-NEXT:      } {"./i"}
+# CHECK-NEXT:      %cst_0 = arith.constant 0.000000e+00 : f32
+# CHECK-NEXT:      linalg.fill {__xtc_id_C_0_} ins(%cst_0 : f32) outs(%arg2 : memref<50x64xf32>)
 # CHECK-NEXT:      scf.for %arg3 = %c0 to %c64 step %c32 {
 # CHECK-NEXT:        %subview = memref.subview %arg0[0, %arg3] [50, 32] [1, 1] : memref<50x64xf32> to memref<50x32xf32, strided<[64, 1], offset: ?>>
 # CHECK-NEXT:        %subview_1 = memref.subview %arg1[%arg3, 0] [32, 64] [1, 1] : memref<64x64xf32> to memref<32x64xf32, strided<[64, 1], offset: ?>>

--- a/tests/filecheck/schedules/test_descript_slice_bigger.py
+++ b/tests/filecheck/schedules/test_descript_slice_bigger.py
@@ -62,38 +62,33 @@ print(f"CODE: {code}")
 # CHECK-NEXT:      transform.yield 
 # CHECK-NEXT:    }
 # CHECK-NEXT:    transform.named_sequence @__transform_main(%arg0: !transform.any_op {transform.readonly}) {
-# CHECK-NEXT:      %0 = transform.structured.match attributes {__xtc_id_C_0_} in %arg0 : (!transform.any_op) -> !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op, %loops = transform.structured.tile_using_for %0 tile_sizes [1, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops "./i" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_0, %loops_1 = transform.structured.tile_using_for %tiled_linalg_op tile_sizes [0, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_1 "./j" : !transform.any_op
-# CHECK-NEXT:      %1 = transform.structured.match attributes {__xtc_id_C_} in %arg0 : (!transform.any_op) -> !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_2, %loops_3 = transform.structured.tile_using_for %1 tile_sizes [0, 0, 32] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_3 "C/k" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_4, %loops_5 = transform.structured.tile_using_for %tiled_linalg_op_2 tile_sizes [0, 16, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_5 "C/j" : !transform.any_op
-# CHECK-NEXT:      %2 = transform.structured.split %tiled_linalg_op_4 after 32  {dimension = 0 : i64} : !transform.any_op
-# CHECK-NEXT:      %3:2 = transform.split_handle %2 {fail_on_payload_too_small = false} : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      %tiled_linalg_op_6, %loops_7 = transform.structured.tile_using_for %3#0 tile_sizes [32, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_7 "C/i[0]/i" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_8, %loops_9 = transform.structured.tile_using_for %tiled_linalg_op_6 tile_sizes [1, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_9 "C/i[0]/i0" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_10, %loops_11 = transform.structured.tile_using_for %tiled_linalg_op_8 tile_sizes [0, 0, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_11 "C/i[0]/k0" : !transform.any_op
-# CHECK-NEXT:      transform.include @_vecto failures(suppress) (%tiled_linalg_op_10) : (!transform.any_op) -> ()
-# CHECK-NEXT:      %tiled_linalg_op_12, %loops_13 = transform.structured.tile_using_for %3#1 tile_sizes [18, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_13 "C/i[1]/i" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_14, %loops_15 = transform.structured.tile_using_for %tiled_linalg_op_12 tile_sizes [1, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_15 "C/i[1]/i0" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_16, %loops_17 = transform.structured.tile_using_for %tiled_linalg_op_14 tile_sizes [0, 0, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_17 "C/i[1]/k0" : !transform.any_op
-# CHECK-NEXT:      transform.include @_vecto failures(suppress) (%tiled_linalg_op_16) : (!transform.any_op) -> ()
-# CHECK-NEXT:      %4 = transform.get_parent_op %loops_3 {isolated_from_above} : (!transform.any_op) -> !transform.any_op
-# CHECK-NEXT:      transform.apply_patterns to %4 {
+# CHECK-NEXT:      %0 = transform.structured.match attributes {__xtc_id_C_} in %arg0 : (!transform.any_op) -> !transform.any_op
+# CHECK-NEXT:      %tiled_linalg_op, %loops = transform.structured.tile_using_for %0 tile_sizes [0, 0, 32] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      transform.annotate %loops "C/k" : !transform.any_op
+# CHECK-NEXT:      %tiled_linalg_op_0, %loops_1 = transform.structured.tile_using_for %tiled_linalg_op tile_sizes [0, 16, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      transform.annotate %loops_1 "C/j" : !transform.any_op
+# CHECK-NEXT:      %1 = transform.structured.split %tiled_linalg_op_0 after 32  {dimension = 0 : i64} : !transform.any_op
+# CHECK-NEXT:      %2:2 = transform.split_handle %1 {fail_on_payload_too_small = false} : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      %tiled_linalg_op_2, %loops_3 = transform.structured.tile_using_for %2#0 tile_sizes [32, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      transform.annotate %loops_3 "C/i[0]/i" : !transform.any_op
+# CHECK-NEXT:      %tiled_linalg_op_4, %loops_5 = transform.structured.tile_using_for %tiled_linalg_op_2 tile_sizes [1, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      transform.annotate %loops_5 "C/i[0]/i0" : !transform.any_op
+# CHECK-NEXT:      %tiled_linalg_op_6, %loops_7 = transform.structured.tile_using_for %tiled_linalg_op_4 tile_sizes [0, 0, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      transform.annotate %loops_7 "C/i[0]/k0" : !transform.any_op
+# CHECK-NEXT:      transform.include @_vecto failures(suppress) (%tiled_linalg_op_6) : (!transform.any_op) -> ()
+# CHECK-NEXT:      %tiled_linalg_op_8, %loops_9 = transform.structured.tile_using_for %2#1 tile_sizes [18, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      transform.annotate %loops_9 "C/i[1]/i" : !transform.any_op
+# CHECK-NEXT:      %tiled_linalg_op_10, %loops_11 = transform.structured.tile_using_for %tiled_linalg_op_8 tile_sizes [1, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      transform.annotate %loops_11 "C/i[1]/i0" : !transform.any_op
+# CHECK-NEXT:      %tiled_linalg_op_12, %loops_13 = transform.structured.tile_using_for %tiled_linalg_op_10 tile_sizes [0, 0, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      transform.annotate %loops_13 "C/i[1]/k0" : !transform.any_op
+# CHECK-NEXT:      transform.include @_vecto failures(suppress) (%tiled_linalg_op_12) : (!transform.any_op) -> ()
+# CHECK-NEXT:      %3 = transform.get_parent_op %loops {isolated_from_above} : (!transform.any_op) -> !transform.any_op
+# CHECK-NEXT:      transform.apply_patterns to %3 {
 # CHECK-NEXT:        transform.apply_patterns.vector.reduction_to_contract
 # CHECK-NEXT:        transform.apply_patterns.vector.transfer_permutation_patterns
 # CHECK-NEXT:      } : !transform.any_op
-# CHECK-NEXT:      transform.apply_patterns to %4 {
+# CHECK-NEXT:      transform.apply_patterns to %3 {
 # CHECK-NEXT:        transform.apply_patterns.vector.lower_outerproduct
 # CHECK-NEXT:        transform.apply_patterns.vector.lower_contraction
 # CHECK-NEXT:      } : !transform.any_op
@@ -107,20 +102,13 @@ print(f"CODE: {code}")
 # CHECK-NEXT:      %cst = arith.constant dense<0.000000e+00> : vector<1x16xf32>
 # CHECK-NEXT:      %c18 = arith.constant 18 : index
 # CHECK-NEXT:      %0 = ub.poison : f32
+# CHECK-NEXT:      %c1 = arith.constant 1 : index
 # CHECK-NEXT:      %c16 = arith.constant 16 : index
 # CHECK-NEXT:      %c32 = arith.constant 32 : index
 # CHECK-NEXT:      %c64 = arith.constant 64 : index
-# CHECK-NEXT:      %cst_0 = arith.constant 0.000000e+00 : f32
 # CHECK-NEXT:      %c0 = arith.constant 0 : index
-# CHECK-NEXT:      %c50 = arith.constant 50 : index
-# CHECK-NEXT:      %c1 = arith.constant 1 : index
-# CHECK-NEXT:      scf.for %arg3 = %c0 to %c50 step %c1 {
-# CHECK-NEXT:        %subview = memref.subview %arg2[%arg3, 0] [1, 64] [1, 1] : memref<50x64xf32> to memref<1x64xf32, strided<[64, 1], offset: ?>>
-# CHECK-NEXT:        scf.for %arg4 = %c0 to %c64 step %c1 {
-# CHECK-NEXT:          %subview_1 = memref.subview %subview[0, %arg4] [1, 1] [1, 1] : memref<1x64xf32, strided<[64, 1], offset: ?>> to memref<1x1xf32, strided<[64, 1], offset: ?>>
-# CHECK-NEXT:          linalg.fill {__xtc_id_C_0_} ins(%cst_0 : f32) outs(%subview_1 : memref<1x1xf32, strided<[64, 1], offset: ?>>)
-# CHECK-NEXT:        } {"./j"}
-# CHECK-NEXT:      } {"./i"}
+# CHECK-NEXT:      %cst_0 = arith.constant 0.000000e+00 : f32
+# CHECK-NEXT:      linalg.fill {__xtc_id_C_0_} ins(%cst_0 : f32) outs(%arg2 : memref<50x64xf32>)
 # CHECK-NEXT:      scf.for %arg3 = %c0 to %c64 step %c32 {
 # CHECK-NEXT:        %subview = memref.subview %arg0[0, %arg3] [50, 32] [1, 1] : memref<50x64xf32> to memref<50x32xf32, strided<[64, 1], offset: ?>>
 # CHECK-NEXT:        %subview_1 = memref.subview %arg1[%arg3, 0] [32, 64] [1, 1] : memref<64x64xf32> to memref<32x64xf32, strided<[64, 1], offset: ?>>

--- a/tests/filecheck/schedules/test_descript_slice_smaller.py
+++ b/tests/filecheck/schedules/test_descript_slice_smaller.py
@@ -62,38 +62,33 @@ print(f"CODE: {code}")
 # CHECK-NEXT:      transform.yield 
 # CHECK-NEXT:    }
 # CHECK-NEXT:    transform.named_sequence @__transform_main(%arg0: !transform.any_op {transform.readonly}) {
-# CHECK-NEXT:      %0 = transform.structured.match attributes {__xtc_id_C_0_} in %arg0 : (!transform.any_op) -> !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op, %loops = transform.structured.tile_using_for %0 tile_sizes [1, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops "./i" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_0, %loops_1 = transform.structured.tile_using_for %tiled_linalg_op tile_sizes [0, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_1 "./j" : !transform.any_op
-# CHECK-NEXT:      %1 = transform.structured.match attributes {__xtc_id_C_} in %arg0 : (!transform.any_op) -> !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_2, %loops_3 = transform.structured.tile_using_for %1 tile_sizes [0, 0, 32] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_3 "C/k" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_4, %loops_5 = transform.structured.tile_using_for %tiled_linalg_op_2 tile_sizes [0, 16, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_5 "C/j" : !transform.any_op
-# CHECK-NEXT:      %2 = transform.structured.split %tiled_linalg_op_4 after 18  {dimension = 0 : i64} : !transform.any_op
-# CHECK-NEXT:      %3:2 = transform.split_handle %2 : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      %tiled_linalg_op_6, %loops_7 = transform.structured.tile_using_for %3#0 tile_sizes [18, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_7 "C/i[0]/i" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_8, %loops_9 = transform.structured.tile_using_for %tiled_linalg_op_6 tile_sizes [1, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_9 "C/i[0]/i0" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_10, %loops_11 = transform.structured.tile_using_for %tiled_linalg_op_8 tile_sizes [0, 0, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_11 "C/i[0]/k0" : !transform.any_op
-# CHECK-NEXT:      transform.include @_vecto failures(suppress) (%tiled_linalg_op_10) : (!transform.any_op) -> ()
-# CHECK-NEXT:      %tiled_linalg_op_12, %loops_13 = transform.structured.tile_using_for %3#1 tile_sizes [32, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_13 "C/i[1]/i" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_14, %loops_15 = transform.structured.tile_using_for %tiled_linalg_op_12 tile_sizes [1, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_15 "C/i[1]/i0" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_16, %loops_17 = transform.structured.tile_using_for %tiled_linalg_op_14 tile_sizes [0, 0, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_17 "C/i[1]/k0" : !transform.any_op
-# CHECK-NEXT:      transform.include @_vecto failures(suppress) (%tiled_linalg_op_16) : (!transform.any_op) -> ()
-# CHECK-NEXT:      %4 = transform.get_parent_op %loops_3 {isolated_from_above} : (!transform.any_op) -> !transform.any_op
-# CHECK-NEXT:      transform.apply_patterns to %4 {
+# CHECK-NEXT:      %0 = transform.structured.match attributes {__xtc_id_C_} in %arg0 : (!transform.any_op) -> !transform.any_op
+# CHECK-NEXT:      %tiled_linalg_op, %loops = transform.structured.tile_using_for %0 tile_sizes [0, 0, 32] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      transform.annotate %loops "C/k" : !transform.any_op
+# CHECK-NEXT:      %tiled_linalg_op_0, %loops_1 = transform.structured.tile_using_for %tiled_linalg_op tile_sizes [0, 16, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      transform.annotate %loops_1 "C/j" : !transform.any_op
+# CHECK-NEXT:      %1 = transform.structured.split %tiled_linalg_op_0 after 18  {dimension = 0 : i64} : !transform.any_op
+# CHECK-NEXT:      %2:2 = transform.split_handle %1 : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      %tiled_linalg_op_2, %loops_3 = transform.structured.tile_using_for %2#0 tile_sizes [18, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      transform.annotate %loops_3 "C/i[0]/i" : !transform.any_op
+# CHECK-NEXT:      %tiled_linalg_op_4, %loops_5 = transform.structured.tile_using_for %tiled_linalg_op_2 tile_sizes [1, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      transform.annotate %loops_5 "C/i[0]/i0" : !transform.any_op
+# CHECK-NEXT:      %tiled_linalg_op_6, %loops_7 = transform.structured.tile_using_for %tiled_linalg_op_4 tile_sizes [0, 0, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      transform.annotate %loops_7 "C/i[0]/k0" : !transform.any_op
+# CHECK-NEXT:      transform.include @_vecto failures(suppress) (%tiled_linalg_op_6) : (!transform.any_op) -> ()
+# CHECK-NEXT:      %tiled_linalg_op_8, %loops_9 = transform.structured.tile_using_for %2#1 tile_sizes [32, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      transform.annotate %loops_9 "C/i[1]/i" : !transform.any_op
+# CHECK-NEXT:      %tiled_linalg_op_10, %loops_11 = transform.structured.tile_using_for %tiled_linalg_op_8 tile_sizes [1, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      transform.annotate %loops_11 "C/i[1]/i0" : !transform.any_op
+# CHECK-NEXT:      %tiled_linalg_op_12, %loops_13 = transform.structured.tile_using_for %tiled_linalg_op_10 tile_sizes [0, 0, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      transform.annotate %loops_13 "C/i[1]/k0" : !transform.any_op
+# CHECK-NEXT:      transform.include @_vecto failures(suppress) (%tiled_linalg_op_12) : (!transform.any_op) -> ()
+# CHECK-NEXT:      %3 = transform.get_parent_op %loops {isolated_from_above} : (!transform.any_op) -> !transform.any_op
+# CHECK-NEXT:      transform.apply_patterns to %3 {
 # CHECK-NEXT:        transform.apply_patterns.vector.reduction_to_contract
 # CHECK-NEXT:        transform.apply_patterns.vector.transfer_permutation_patterns
 # CHECK-NEXT:      } : !transform.any_op
-# CHECK-NEXT:      transform.apply_patterns to %4 {
+# CHECK-NEXT:      transform.apply_patterns to %3 {
 # CHECK-NEXT:        transform.apply_patterns.vector.lower_outerproduct
 # CHECK-NEXT:        transform.apply_patterns.vector.lower_contraction
 # CHECK-NEXT:      } : !transform.any_op
@@ -106,21 +101,14 @@ print(f"CODE: {code}")
 # CHECK-NEXT:    func.func @matmul(%arg0: memref<50x64xf32> {llvm.noalias}, %arg1: memref<64x64xf32> {llvm.noalias}, %arg2: memref<50x64xf32> {llvm.noalias}) {
 # CHECK-NEXT:      %cst = arith.constant dense<0.000000e+00> : vector<1x16xf32>
 # CHECK-NEXT:      %0 = ub.poison : f32
+# CHECK-NEXT:      %c1 = arith.constant 1 : index
 # CHECK-NEXT:      %c18 = arith.constant 18 : index
 # CHECK-NEXT:      %c16 = arith.constant 16 : index
 # CHECK-NEXT:      %c32 = arith.constant 32 : index
 # CHECK-NEXT:      %c64 = arith.constant 64 : index
-# CHECK-NEXT:      %cst_0 = arith.constant 0.000000e+00 : f32
 # CHECK-NEXT:      %c0 = arith.constant 0 : index
-# CHECK-NEXT:      %c50 = arith.constant 50 : index
-# CHECK-NEXT:      %c1 = arith.constant 1 : index
-# CHECK-NEXT:      scf.for %arg3 = %c0 to %c50 step %c1 {
-# CHECK-NEXT:        %subview = memref.subview %arg2[%arg3, 0] [1, 64] [1, 1] : memref<50x64xf32> to memref<1x64xf32, strided<[64, 1], offset: ?>>
-# CHECK-NEXT:        scf.for %arg4 = %c0 to %c64 step %c1 {
-# CHECK-NEXT:          %subview_1 = memref.subview %subview[0, %arg4] [1, 1] [1, 1] : memref<1x64xf32, strided<[64, 1], offset: ?>> to memref<1x1xf32, strided<[64, 1], offset: ?>>
-# CHECK-NEXT:          linalg.fill {__xtc_id_C_0_} ins(%cst_0 : f32) outs(%subview_1 : memref<1x1xf32, strided<[64, 1], offset: ?>>)
-# CHECK-NEXT:        } {"./j"}
-# CHECK-NEXT:      } {"./i"}
+# CHECK-NEXT:      %cst_0 = arith.constant 0.000000e+00 : f32
+# CHECK-NEXT:      linalg.fill {__xtc_id_C_0_} ins(%cst_0 : f32) outs(%arg2 : memref<50x64xf32>)
 # CHECK-NEXT:      scf.for %arg3 = %c0 to %c64 step %c32 {
 # CHECK-NEXT:        %subview = memref.subview %arg0[0, %arg3] [50, 32] [1, 1] : memref<50x64xf32> to memref<50x32xf32, strided<[64, 1], offset: ?>>
 # CHECK-NEXT:        %subview_1 = memref.subview %arg1[%arg3, 0] [32, 64] [1, 1] : memref<64x64xf32> to memref<32x64xf32, strided<[64, 1], offset: ?>>

--- a/tests/filecheck/schedules/test_descript_slice_smaller.py
+++ b/tests/filecheck/schedules/test_descript_slice_smaller.py
@@ -62,38 +62,33 @@ print(f"CODE: {code}")
 # CHECK-NEXT:      transform.yield 
 # CHECK-NEXT:    }
 # CHECK-NEXT:    transform.named_sequence @__transform_main(%arg0: !transform.any_op {transform.readonly}) {
-# CHECK-NEXT:      %0 = transform.structured.match attributes {__xtc_id_C_0_} in %arg0 : (!transform.any_op) -> !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op, %loops = transform.structured.tile_using_for %0 tile_sizes [1, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops "./i" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_0, %loops_1 = transform.structured.tile_using_for %tiled_linalg_op tile_sizes [0, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_1 "./j" : !transform.any_op
-# CHECK-NEXT:      %1 = transform.structured.match attributes {__xtc_id_C_} in %arg0 : (!transform.any_op) -> !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_2, %loops_3 = transform.structured.tile_using_for %1 tile_sizes [0, 0, 32] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_3 "C/k" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_4, %loops_5 = transform.structured.tile_using_for %tiled_linalg_op_2 tile_sizes [0, 16, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_5 "C/j" : !transform.any_op
-# CHECK-NEXT:      %2 = transform.structured.split %tiled_linalg_op_4 after 18  {dimension = 0 : i64} : !transform.any_op
-# CHECK-NEXT:      %3:2 = transform.split_handle %2 {fail_on_payload_too_small = false} : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      %tiled_linalg_op_6, %loops_7 = transform.structured.tile_using_for %3#0 tile_sizes [18, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_7 "C/i[0]/i" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_8, %loops_9 = transform.structured.tile_using_for %tiled_linalg_op_6 tile_sizes [1, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_9 "C/i[0]/i0" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_10, %loops_11 = transform.structured.tile_using_for %tiled_linalg_op_8 tile_sizes [0, 0, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_11 "C/i[0]/k0" : !transform.any_op
-# CHECK-NEXT:      transform.include @_vecto failures(suppress) (%tiled_linalg_op_10) : (!transform.any_op) -> ()
-# CHECK-NEXT:      %tiled_linalg_op_12, %loops_13 = transform.structured.tile_using_for %3#1 tile_sizes [32, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_13 "C/i[1]/i" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_14, %loops_15 = transform.structured.tile_using_for %tiled_linalg_op_12 tile_sizes [1, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_15 "C/i[1]/i0" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_16, %loops_17 = transform.structured.tile_using_for %tiled_linalg_op_14 tile_sizes [0, 0, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_17 "C/i[1]/k0" : !transform.any_op
-# CHECK-NEXT:      transform.include @_vecto failures(suppress) (%tiled_linalg_op_16) : (!transform.any_op) -> ()
-# CHECK-NEXT:      %4 = transform.get_parent_op %loops_3 {isolated_from_above} : (!transform.any_op) -> !transform.any_op
-# CHECK-NEXT:      transform.apply_patterns to %4 {
+# CHECK-NEXT:      %0 = transform.structured.match attributes {__xtc_id_C_} in %arg0 : (!transform.any_op) -> !transform.any_op
+# CHECK-NEXT:      %tiled_linalg_op, %loops = transform.structured.tile_using_for %0 tile_sizes [0, 0, 32] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      transform.annotate %loops "C/k" : !transform.any_op
+# CHECK-NEXT:      %tiled_linalg_op_0, %loops_1 = transform.structured.tile_using_for %tiled_linalg_op tile_sizes [0, 16, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      transform.annotate %loops_1 "C/j" : !transform.any_op
+# CHECK-NEXT:      %1 = transform.structured.split %tiled_linalg_op_0 after 18  {dimension = 0 : i64} : !transform.any_op
+# CHECK-NEXT:      %2:2 = transform.split_handle %1 {fail_on_payload_too_small = false} : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      %tiled_linalg_op_2, %loops_3 = transform.structured.tile_using_for %2#0 tile_sizes [18, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      transform.annotate %loops_3 "C/i[0]/i" : !transform.any_op
+# CHECK-NEXT:      %tiled_linalg_op_4, %loops_5 = transform.structured.tile_using_for %tiled_linalg_op_2 tile_sizes [1, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      transform.annotate %loops_5 "C/i[0]/i0" : !transform.any_op
+# CHECK-NEXT:      %tiled_linalg_op_6, %loops_7 = transform.structured.tile_using_for %tiled_linalg_op_4 tile_sizes [0, 0, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      transform.annotate %loops_7 "C/i[0]/k0" : !transform.any_op
+# CHECK-NEXT:      transform.include @_vecto failures(suppress) (%tiled_linalg_op_6) : (!transform.any_op) -> ()
+# CHECK-NEXT:      %tiled_linalg_op_8, %loops_9 = transform.structured.tile_using_for %2#1 tile_sizes [32, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      transform.annotate %loops_9 "C/i[1]/i" : !transform.any_op
+# CHECK-NEXT:      %tiled_linalg_op_10, %loops_11 = transform.structured.tile_using_for %tiled_linalg_op_8 tile_sizes [1, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      transform.annotate %loops_11 "C/i[1]/i0" : !transform.any_op
+# CHECK-NEXT:      %tiled_linalg_op_12, %loops_13 = transform.structured.tile_using_for %tiled_linalg_op_10 tile_sizes [0, 0, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      transform.annotate %loops_13 "C/i[1]/k0" : !transform.any_op
+# CHECK-NEXT:      transform.include @_vecto failures(suppress) (%tiled_linalg_op_12) : (!transform.any_op) -> ()
+# CHECK-NEXT:      %3 = transform.get_parent_op %loops {isolated_from_above} : (!transform.any_op) -> !transform.any_op
+# CHECK-NEXT:      transform.apply_patterns to %3 {
 # CHECK-NEXT:        transform.apply_patterns.vector.reduction_to_contract
 # CHECK-NEXT:        transform.apply_patterns.vector.transfer_permutation_patterns
 # CHECK-NEXT:      } : !transform.any_op
-# CHECK-NEXT:      transform.apply_patterns to %4 {
+# CHECK-NEXT:      transform.apply_patterns to %3 {
 # CHECK-NEXT:        transform.apply_patterns.vector.lower_outerproduct
 # CHECK-NEXT:        transform.apply_patterns.vector.lower_contraction
 # CHECK-NEXT:      } : !transform.any_op
@@ -106,21 +101,14 @@ print(f"CODE: {code}")
 # CHECK-NEXT:    func.func @matmul(%arg0: memref<50x64xf32> {llvm.noalias}, %arg1: memref<64x64xf32> {llvm.noalias}, %arg2: memref<50x64xf32> {llvm.noalias}) {
 # CHECK-NEXT:      %cst = arith.constant dense<0.000000e+00> : vector<1x16xf32>
 # CHECK-NEXT:      %0 = ub.poison : f32
+# CHECK-NEXT:      %c1 = arith.constant 1 : index
 # CHECK-NEXT:      %c18 = arith.constant 18 : index
 # CHECK-NEXT:      %c16 = arith.constant 16 : index
 # CHECK-NEXT:      %c32 = arith.constant 32 : index
 # CHECK-NEXT:      %c64 = arith.constant 64 : index
-# CHECK-NEXT:      %cst_0 = arith.constant 0.000000e+00 : f32
 # CHECK-NEXT:      %c0 = arith.constant 0 : index
-# CHECK-NEXT:      %c50 = arith.constant 50 : index
-# CHECK-NEXT:      %c1 = arith.constant 1 : index
-# CHECK-NEXT:      scf.for %arg3 = %c0 to %c50 step %c1 {
-# CHECK-NEXT:        %subview = memref.subview %arg2[%arg3, 0] [1, 64] [1, 1] : memref<50x64xf32> to memref<1x64xf32, strided<[64, 1], offset: ?>>
-# CHECK-NEXT:        scf.for %arg4 = %c0 to %c64 step %c1 {
-# CHECK-NEXT:          %subview_1 = memref.subview %subview[0, %arg4] [1, 1] [1, 1] : memref<1x64xf32, strided<[64, 1], offset: ?>> to memref<1x1xf32, strided<[64, 1], offset: ?>>
-# CHECK-NEXT:          linalg.fill {__xtc_id_C_0_} ins(%cst_0 : f32) outs(%subview_1 : memref<1x1xf32, strided<[64, 1], offset: ?>>)
-# CHECK-NEXT:        } {"./j"}
-# CHECK-NEXT:      } {"./i"}
+# CHECK-NEXT:      %cst_0 = arith.constant 0.000000e+00 : f32
+# CHECK-NEXT:      linalg.fill {__xtc_id_C_0_} ins(%cst_0 : f32) outs(%arg2 : memref<50x64xf32>)
 # CHECK-NEXT:      scf.for %arg3 = %c0 to %c64 step %c32 {
 # CHECK-NEXT:        %subview = memref.subview %arg0[0, %arg3] [50, 32] [1, 1] : memref<50x64xf32> to memref<50x32xf32, strided<[64, 1], offset: ?>>
 # CHECK-NEXT:        %subview_1 = memref.subview %arg1[%arg3, 0] [32, 64] [1, 1] : memref<64x64xf32> to memref<32x64xf32, strided<[64, 1], offset: ?>>

--- a/tests/filecheck/schedules/test_descript_tile_split.py
+++ b/tests/filecheck/schedules/test_descript_tile_split.py
@@ -61,32 +61,27 @@ print(f"CODE: {code}")
 # CHECK-NEXT:      transform.yield 
 # CHECK-NEXT:    }
 # CHECK-NEXT:    transform.named_sequence @__transform_main(%arg0: !transform.any_op {transform.readonly}) {
-# CHECK-NEXT:      %0 = transform.structured.match attributes {__xtc_id_C_0_} in %arg0 : (!transform.any_op) -> !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op, %loops = transform.structured.tile_using_for %0 tile_sizes [1, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops "./i" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_0, %loops_1 = transform.structured.tile_using_for %tiled_linalg_op tile_sizes [0, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_1 "./j" : !transform.any_op
-# CHECK-NEXT:      %1 = transform.structured.match attributes {__xtc_id_C_} in %arg0 : (!transform.any_op) -> !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_2, %loops_3 = transform.structured.tile_using_for %1 tile_sizes [0, 0, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_3 "C/k" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_4, %loops_5 = transform.structured.tile_using_for %tiled_linalg_op_2 tile_sizes [10, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_5 "C/i" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_6, %loops_7 = transform.structured.tile_using_for %tiled_linalg_op_4 tile_sizes [5, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_7 "C/i0" : !transform.any_op
-# CHECK-NEXT:      %2 = transform.structured.split %tiled_linalg_op_6 after 5  {dimension = 0 : i64} : !transform.any_op
-# CHECK-NEXT:      %3:2 = transform.split_handle %2 {fail_on_payload_too_small = false} : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      %tiled_linalg_op_8, %loops_9 = transform.structured.tile_using_for %3#0 tile_sizes [5, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_9 "C/i[0]/i" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_10, %loops_11 = transform.structured.tile_using_for %tiled_linalg_op_8 tile_sizes [1, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_11 "C/i[0]/i0" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_12, %loops_13 = transform.structured.tile_using_for %tiled_linalg_op_10 tile_sizes [0, 1, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_13 "C/i[0]/j" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_14, %loops_15 = transform.structured.tile_using_for %3#1 tile_sizes [5, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_15 "C/i[1]/i" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_16, %loops_17 = transform.structured.tile_using_for %tiled_linalg_op_14 tile_sizes [1, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_17 "C/i[1]/i0" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_18, %loops_19 = transform.structured.tile_using_for %tiled_linalg_op_16 tile_sizes [0, 1, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_19 "C/i[1]/j" : !transform.any_op
+# CHECK-NEXT:      %0 = transform.structured.match attributes {__xtc_id_C_} in %arg0 : (!transform.any_op) -> !transform.any_op
+# CHECK-NEXT:      %tiled_linalg_op, %loops = transform.structured.tile_using_for %0 tile_sizes [0, 0, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      transform.annotate %loops "C/k" : !transform.any_op
+# CHECK-NEXT:      %tiled_linalg_op_0, %loops_1 = transform.structured.tile_using_for %tiled_linalg_op tile_sizes [10, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      transform.annotate %loops_1 "C/i" : !transform.any_op
+# CHECK-NEXT:      %tiled_linalg_op_2, %loops_3 = transform.structured.tile_using_for %tiled_linalg_op_0 tile_sizes [5, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      transform.annotate %loops_3 "C/i0" : !transform.any_op
+# CHECK-NEXT:      %1 = transform.structured.split %tiled_linalg_op_2 after 5  {dimension = 0 : i64} : !transform.any_op
+# CHECK-NEXT:      %2:2 = transform.split_handle %1 {fail_on_payload_too_small = false} : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      %tiled_linalg_op_4, %loops_5 = transform.structured.tile_using_for %2#0 tile_sizes [5, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      transform.annotate %loops_5 "C/i[0]/i" : !transform.any_op
+# CHECK-NEXT:      %tiled_linalg_op_6, %loops_7 = transform.structured.tile_using_for %tiled_linalg_op_4 tile_sizes [1, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      transform.annotate %loops_7 "C/i[0]/i0" : !transform.any_op
+# CHECK-NEXT:      %tiled_linalg_op_8, %loops_9 = transform.structured.tile_using_for %tiled_linalg_op_6 tile_sizes [0, 1, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      transform.annotate %loops_9 "C/i[0]/j" : !transform.any_op
+# CHECK-NEXT:      %tiled_linalg_op_10, %loops_11 = transform.structured.tile_using_for %2#1 tile_sizes [5, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      transform.annotate %loops_11 "C/i[1]/i" : !transform.any_op
+# CHECK-NEXT:      %tiled_linalg_op_12, %loops_13 = transform.structured.tile_using_for %tiled_linalg_op_10 tile_sizes [1, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      transform.annotate %loops_13 "C/i[1]/i0" : !transform.any_op
+# CHECK-NEXT:      %tiled_linalg_op_14, %loops_15 = transform.structured.tile_using_for %tiled_linalg_op_12 tile_sizes [0, 1, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      transform.annotate %loops_15 "C/i[1]/j" : !transform.any_op
 # CHECK-NEXT:      transform.yield 
 # CHECK-NEXT:    }
 # CHECK-NEXT:  }
@@ -95,62 +90,50 @@ print(f"CODE: {code}")
 # CHECK-NEXT:  module attributes {transform.with_named_sequence} {
 # CHECK-NEXT:    func.func @matmul(%arg0: memref<50x64xf32> {llvm.noalias}, %arg1: memref<64x64xf32> {llvm.noalias}, %arg2: memref<50x64xf32> {llvm.noalias}) {
 # CHECK-NEXT:      %cst = arith.constant 0.000000e+00 : f32
+# CHECK-NEXT:      linalg.fill {__xtc_id_C_0_} ins(%cst : f32) outs(%arg2 : memref<50x64xf32>)
 # CHECK-NEXT:      %c0 = arith.constant 0 : index
-# CHECK-NEXT:      %c50 = arith.constant 50 : index
-# CHECK-NEXT:      %c1 = arith.constant 1 : index
-# CHECK-NEXT:      scf.for %arg3 = %c0 to %c50 step %c1 {
-# CHECK-NEXT:        %subview = memref.subview %arg2[%arg3, 0] [1, 64] [1, 1] : memref<50x64xf32> to memref<1x64xf32, strided<[64, 1], offset: ?>>
-# CHECK-NEXT:        %c0_2 = arith.constant 0 : index
-# CHECK-NEXT:        %c64_3 = arith.constant 64 : index
-# CHECK-NEXT:        %c1_4 = arith.constant 1 : index
-# CHECK-NEXT:        scf.for %arg4 = %c0_2 to %c64_3 step %c1_4 {
-# CHECK-NEXT:          %subview_5 = memref.subview %subview[0, %arg4] [1, 1] [1, 1] : memref<1x64xf32, strided<[64, 1], offset: ?>> to memref<1x1xf32, strided<[64, 1], offset: ?>>
-# CHECK-NEXT:          linalg.fill {__xtc_id_C_0_} ins(%cst : f32) outs(%subview_5 : memref<1x1xf32, strided<[64, 1], offset: ?>>)
-# CHECK-NEXT:        } {"./j"}
-# CHECK-NEXT:      } {"./i"}
-# CHECK-NEXT:      %c0_0 = arith.constant 0 : index
 # CHECK-NEXT:      %c64 = arith.constant 64 : index
-# CHECK-NEXT:      %c1_1 = arith.constant 1 : index
-# CHECK-NEXT:      scf.for %arg3 = %c0_0 to %c64 step %c1_1 {
+# CHECK-NEXT:      %c1 = arith.constant 1 : index
+# CHECK-NEXT:      scf.for %arg3 = %c0 to %c64 step %c1 {
 # CHECK-NEXT:        %subview = memref.subview %arg0[0, %arg3] [50, 1] [1, 1] : memref<50x64xf32> to memref<50x1xf32, strided<[64, 1], offset: ?>>
-# CHECK-NEXT:        %subview_2 = memref.subview %arg1[%arg3, 0] [1, 64] [1, 1] : memref<64x64xf32> to memref<1x64xf32, strided<[64, 1], offset: ?>>
-# CHECK-NEXT:        %subview_3 = memref.subview %arg2[0, 0] [50, 64] [1, 1] : memref<50x64xf32> to memref<50x64xf32, strided<[64, 1]>>
-# CHECK-NEXT:        %c0_4 = arith.constant 0 : index
-# CHECK-NEXT:        %c50_5 = arith.constant 50 : index
+# CHECK-NEXT:        %subview_0 = memref.subview %arg1[%arg3, 0] [1, 64] [1, 1] : memref<64x64xf32> to memref<1x64xf32, strided<[64, 1], offset: ?>>
+# CHECK-NEXT:        %subview_1 = memref.subview %arg2[0, 0] [50, 64] [1, 1] : memref<50x64xf32> to memref<50x64xf32, strided<[64, 1]>>
+# CHECK-NEXT:        %c0_2 = arith.constant 0 : index
+# CHECK-NEXT:        %c50 = arith.constant 50 : index
 # CHECK-NEXT:        %c10 = arith.constant 10 : index
-# CHECK-NEXT:        scf.for %arg4 = %c0_4 to %c50_5 step %c10 {
-# CHECK-NEXT:          %subview_6 = memref.subview %subview[%arg4, 0] [10, 1] [1, 1] : memref<50x1xf32, strided<[64, 1], offset: ?>> to memref<10x1xf32, strided<[64, 1], offset: ?>>
-# CHECK-NEXT:          %subview_7 = memref.subview %subview_2[0, 0] [1, 64] [1, 1] : memref<1x64xf32, strided<[64, 1], offset: ?>> to memref<1x64xf32, strided<[64, 1], offset: ?>>
-# CHECK-NEXT:          %subview_8 = memref.subview %subview_3[%arg4, 0] [10, 64] [1, 1] : memref<50x64xf32, strided<[64, 1]>> to memref<10x64xf32, strided<[64, 1], offset: ?>>
-# CHECK-NEXT:          %c0_9 = arith.constant 0 : index
-# CHECK-NEXT:          %c10_10 = arith.constant 10 : index
+# CHECK-NEXT:        scf.for %arg4 = %c0_2 to %c50 step %c10 {
+# CHECK-NEXT:          %subview_3 = memref.subview %subview[%arg4, 0] [10, 1] [1, 1] : memref<50x1xf32, strided<[64, 1], offset: ?>> to memref<10x1xf32, strided<[64, 1], offset: ?>>
+# CHECK-NEXT:          %subview_4 = memref.subview %subview_0[0, 0] [1, 64] [1, 1] : memref<1x64xf32, strided<[64, 1], offset: ?>> to memref<1x64xf32, strided<[64, 1], offset: ?>>
+# CHECK-NEXT:          %subview_5 = memref.subview %subview_1[%arg4, 0] [10, 64] [1, 1] : memref<50x64xf32, strided<[64, 1]>> to memref<10x64xf32, strided<[64, 1], offset: ?>>
+# CHECK-NEXT:          %c0_6 = arith.constant 0 : index
+# CHECK-NEXT:          %c10_7 = arith.constant 10 : index
 # CHECK-NEXT:          %c5 = arith.constant 5 : index
-# CHECK-NEXT:          scf.for %arg5 = %c0_9 to %c10_10 step %c5 {
-# CHECK-NEXT:            %subview_11 = memref.subview %subview_6[%arg5, 0] [5, 1] [1, 1] : memref<10x1xf32, strided<[64, 1], offset: ?>> to memref<5x1xf32, strided<[64, 1], offset: ?>>
-# CHECK-NEXT:            %subview_12 = memref.subview %subview_7[0, 0] [1, 64] [1, 1] : memref<1x64xf32, strided<[64, 1], offset: ?>> to memref<1x64xf32, strided<[64, 1], offset: ?>>
-# CHECK-NEXT:            %subview_13 = memref.subview %subview_8[%arg5, 0] [5, 64] [1, 1] : memref<10x64xf32, strided<[64, 1], offset: ?>> to memref<5x64xf32, strided<[64, 1], offset: ?>>
-# CHECK-NEXT:            %c0_14 = arith.constant 0 : index
-# CHECK-NEXT:            %c5_15 = arith.constant 5 : index
-# CHECK-NEXT:            %c5_16 = arith.constant 5 : index
-# CHECK-NEXT:            scf.for %arg6 = %c0_14 to %c5_15 step %c5_16 {
-# CHECK-NEXT:              %subview_17 = memref.subview %subview_11[%arg6, 0] [5, 1] [1, 1] : memref<5x1xf32, strided<[64, 1], offset: ?>> to memref<5x1xf32, strided<[64, 1], offset: ?>>
-# CHECK-NEXT:              %subview_18 = memref.subview %subview_12[0, 0] [1, 64] [1, 1] : memref<1x64xf32, strided<[64, 1], offset: ?>> to memref<1x64xf32, strided<[64, 1], offset: ?>>
-# CHECK-NEXT:              %subview_19 = memref.subview %subview_13[%arg6, 0] [5, 64] [1, 1] : memref<5x64xf32, strided<[64, 1], offset: ?>> to memref<5x64xf32, strided<[64, 1], offset: ?>>
-# CHECK-NEXT:              %c0_20 = arith.constant 0 : index
-# CHECK-NEXT:              %c5_21 = arith.constant 5 : index
-# CHECK-NEXT:              %c1_22 = arith.constant 1 : index
-# CHECK-NEXT:              scf.for %arg7 = %c0_20 to %c5_21 step %c1_22 {
-# CHECK-NEXT:                %subview_23 = memref.subview %subview_17[%arg7, 0] [1, 1] [1, 1] : memref<5x1xf32, strided<[64, 1], offset: ?>> to memref<1x1xf32, strided<[64, 1], offset: ?>>
-# CHECK-NEXT:                %subview_24 = memref.subview %subview_18[0, 0] [1, 64] [1, 1] : memref<1x64xf32, strided<[64, 1], offset: ?>> to memref<1x64xf32, strided<[64, 1], offset: ?>>
-# CHECK-NEXT:                %subview_25 = memref.subview %subview_19[%arg7, 0] [1, 64] [1, 1] : memref<5x64xf32, strided<[64, 1], offset: ?>> to memref<1x64xf32, strided<[64, 1], offset: ?>>
-# CHECK-NEXT:                %c0_26 = arith.constant 0 : index
-# CHECK-NEXT:                %c64_27 = arith.constant 64 : index
-# CHECK-NEXT:                %c1_28 = arith.constant 1 : index
-# CHECK-NEXT:                scf.for %arg8 = %c0_26 to %c64_27 step %c1_28 {
-# CHECK-NEXT:                  %subview_29 = memref.subview %subview_23[0, 0] [1, 1] [1, 1] : memref<1x1xf32, strided<[64, 1], offset: ?>> to memref<1x1xf32, strided<[64, 1], offset: ?>>
-# CHECK-NEXT:                  %subview_30 = memref.subview %subview_24[0, %arg8] [1, 1] [1, 1] : memref<1x64xf32, strided<[64, 1], offset: ?>> to memref<1x1xf32, strided<[64, 1], offset: ?>>
-# CHECK-NEXT:                  %subview_31 = memref.subview %subview_25[0, %arg8] [1, 1] [1, 1] : memref<1x64xf32, strided<[64, 1], offset: ?>> to memref<1x1xf32, strided<[64, 1], offset: ?>>
-# CHECK-NEXT:                  linalg.matmul {__xtc_id_C_} ins(%subview_29, %subview_30 : memref<1x1xf32, strided<[64, 1], offset: ?>>, memref<1x1xf32, strided<[64, 1], offset: ?>>) outs(%subview_31 : memref<1x1xf32, strided<[64, 1], offset: ?>>)
+# CHECK-NEXT:          scf.for %arg5 = %c0_6 to %c10_7 step %c5 {
+# CHECK-NEXT:            %subview_8 = memref.subview %subview_3[%arg5, 0] [5, 1] [1, 1] : memref<10x1xf32, strided<[64, 1], offset: ?>> to memref<5x1xf32, strided<[64, 1], offset: ?>>
+# CHECK-NEXT:            %subview_9 = memref.subview %subview_4[0, 0] [1, 64] [1, 1] : memref<1x64xf32, strided<[64, 1], offset: ?>> to memref<1x64xf32, strided<[64, 1], offset: ?>>
+# CHECK-NEXT:            %subview_10 = memref.subview %subview_5[%arg5, 0] [5, 64] [1, 1] : memref<10x64xf32, strided<[64, 1], offset: ?>> to memref<5x64xf32, strided<[64, 1], offset: ?>>
+# CHECK-NEXT:            %c0_11 = arith.constant 0 : index
+# CHECK-NEXT:            %c5_12 = arith.constant 5 : index
+# CHECK-NEXT:            %c5_13 = arith.constant 5 : index
+# CHECK-NEXT:            scf.for %arg6 = %c0_11 to %c5_12 step %c5_13 {
+# CHECK-NEXT:              %subview_14 = memref.subview %subview_8[%arg6, 0] [5, 1] [1, 1] : memref<5x1xf32, strided<[64, 1], offset: ?>> to memref<5x1xf32, strided<[64, 1], offset: ?>>
+# CHECK-NEXT:              %subview_15 = memref.subview %subview_9[0, 0] [1, 64] [1, 1] : memref<1x64xf32, strided<[64, 1], offset: ?>> to memref<1x64xf32, strided<[64, 1], offset: ?>>
+# CHECK-NEXT:              %subview_16 = memref.subview %subview_10[%arg6, 0] [5, 64] [1, 1] : memref<5x64xf32, strided<[64, 1], offset: ?>> to memref<5x64xf32, strided<[64, 1], offset: ?>>
+# CHECK-NEXT:              %c0_17 = arith.constant 0 : index
+# CHECK-NEXT:              %c5_18 = arith.constant 5 : index
+# CHECK-NEXT:              %c1_19 = arith.constant 1 : index
+# CHECK-NEXT:              scf.for %arg7 = %c0_17 to %c5_18 step %c1_19 {
+# CHECK-NEXT:                %subview_20 = memref.subview %subview_14[%arg7, 0] [1, 1] [1, 1] : memref<5x1xf32, strided<[64, 1], offset: ?>> to memref<1x1xf32, strided<[64, 1], offset: ?>>
+# CHECK-NEXT:                %subview_21 = memref.subview %subview_15[0, 0] [1, 64] [1, 1] : memref<1x64xf32, strided<[64, 1], offset: ?>> to memref<1x64xf32, strided<[64, 1], offset: ?>>
+# CHECK-NEXT:                %subview_22 = memref.subview %subview_16[%arg7, 0] [1, 64] [1, 1] : memref<5x64xf32, strided<[64, 1], offset: ?>> to memref<1x64xf32, strided<[64, 1], offset: ?>>
+# CHECK-NEXT:                %c0_23 = arith.constant 0 : index
+# CHECK-NEXT:                %c64_24 = arith.constant 64 : index
+# CHECK-NEXT:                %c1_25 = arith.constant 1 : index
+# CHECK-NEXT:                scf.for %arg8 = %c0_23 to %c64_24 step %c1_25 {
+# CHECK-NEXT:                  %subview_26 = memref.subview %subview_20[0, 0] [1, 1] [1, 1] : memref<1x1xf32, strided<[64, 1], offset: ?>> to memref<1x1xf32, strided<[64, 1], offset: ?>>
+# CHECK-NEXT:                  %subview_27 = memref.subview %subview_21[0, %arg8] [1, 1] [1, 1] : memref<1x64xf32, strided<[64, 1], offset: ?>> to memref<1x1xf32, strided<[64, 1], offset: ?>>
+# CHECK-NEXT:                  %subview_28 = memref.subview %subview_22[0, %arg8] [1, 1] [1, 1] : memref<1x64xf32, strided<[64, 1], offset: ?>> to memref<1x1xf32, strided<[64, 1], offset: ?>>
+# CHECK-NEXT:                  linalg.matmul {__xtc_id_C_} ins(%subview_26, %subview_27 : memref<1x1xf32, strided<[64, 1], offset: ?>>, memref<1x1xf32, strided<[64, 1], offset: ?>>) outs(%subview_28 : memref<1x1xf32, strided<[64, 1], offset: ?>>)
 # CHECK-NEXT:                } {"C/i[0]/j"}
 # CHECK-NEXT:              } {"C/i[0]/i0"}
 # CHECK-NEXT:            } {"C/i[0]/i"}

--- a/tests/filecheck/schedules/test_matmul_descript_extend_mlir_sample.py
+++ b/tests/filecheck/schedules/test_matmul_descript_extend_mlir_sample.py
@@ -46,118 +46,106 @@ executor = module.get_executor(validate=True)
 res = executor.execute()
 print(f"CODE: {res}")
 
-#CHECK:// -----// IR Dump Before transform //----- //
-#CHECK-NEXT: module attributes {transform.with_named_sequence} {
-#CHECK-NEXT:   func.func @matmul(%arg0: memref<4x512xf32> {llvm.noalias}, %arg1: memref<512x32xf32> {llvm.noalias}, %arg2: memref<4x32xf32> {llvm.noalias}) {
-#CHECK-NEXT:     %cst = arith.constant 0.000000e+00 : f32
-#CHECK-NEXT:     linalg.fill {__xtc_id_C_0_} ins(%cst : f32) outs(%arg2 : memref<4x32xf32>)
-#CHECK-NEXT:     linalg.matmul {__xtc_id_C_} ins(%arg0, %arg1 : memref<4x512xf32>, memref<512x32xf32>) outs(%arg2 : memref<4x32xf32>)
-#CHECK-NEXT:     return
-#CHECK-NEXT:   }
-#CHECK-NEXT:   transform.named_sequence @_vecto(%arg0: !transform.any_op {transform.consumed}) {
-#CHECK-NEXT:     transform.structured.vectorize %arg0 : !transform.any_op
-#CHECK-NEXT:     transform.yield 
-#CHECK-NEXT:   }
-#CHECK-NEXT:   transform.named_sequence @__transform_main(%arg0: !transform.any_op {transform.readonly}) {
-#CHECK-NEXT:     %0 = transform.structured.match attributes {__xtc_id_C_0_} in %arg0 : (!transform.any_op) -> !transform.any_op
-#CHECK-NEXT:     %tiled_linalg_op, %loops = transform.structured.tile_using_for %0 tile_sizes [1, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-#CHECK-NEXT:     transform.annotate %loops "./i" : !transform.any_op
-#CHECK-NEXT:     %tiled_linalg_op_0, %loops_1 = transform.structured.tile_using_for %tiled_linalg_op tile_sizes [0, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-#CHECK-NEXT:     transform.annotate %loops_1 "./j" : !transform.any_op
-#CHECK-NEXT:     %1 = transform.structured.match attributes {__xtc_id_C_} in %arg0 : (!transform.any_op) -> !transform.any_op
-#CHECK-NEXT:     %tiled_linalg_op_2, %loops_3 = transform.structured.tile_using_for %1 tile_sizes [0, 0, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-#CHECK-NEXT:     transform.annotate %loops_3 "C/k" : !transform.any_op
-#CHECK-NEXT:     %tiled_linalg_op_4, %loops_5 = transform.structured.tile_using_for %tiled_linalg_op_2 tile_sizes [2, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-#CHECK-NEXT:     transform.annotate %loops_5 "C/i" : !transform.any_op
-#CHECK-NEXT:     %tiled_linalg_op_6, %loops_7 = transform.structured.tile_using_for %tiled_linalg_op_4 tile_sizes [0, 16, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-#CHECK-NEXT:     transform.annotate %loops_7 "C/j" : !transform.any_op
-#CHECK-NEXT:     %tiled_linalg_op_8, %loops_9 = transform.structured.tile_using_for %tiled_linalg_op_6 tile_sizes [1, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-#CHECK-NEXT:     transform.annotate %loops_9 "C/i0" : !transform.any_op
-#CHECK-NEXT:     transform.include @_vecto failures(suppress) (%tiled_linalg_op_8) : (!transform.any_op) -> ()
-#CHECK-NEXT:     transform.loop.unroll %loops_9 {factor = 2 : i64} : !transform.any_op
-#CHECK-NEXT:     %2 = transform.get_parent_op %loops_3 {isolated_from_above} : (!transform.any_op) -> !transform.any_op
-#CHECK-NEXT:     transform.apply_patterns to %2 {
-#CHECK-NEXT:       transform.apply_patterns.vector.reduction_to_contract
-#CHECK-NEXT:       transform.apply_patterns.vector.transfer_permutation_patterns
-#CHECK-NEXT:     } : !transform.any_op
-#CHECK-NEXT:     transform.apply_patterns to %2 {
-#CHECK-NEXT:       transform.apply_patterns.vector.lower_outerproduct
-#CHECK-NEXT:       transform.apply_patterns.vector.lower_contraction
-#CHECK-NEXT:     } : !transform.any_op
-#CHECK-NEXT:     transform.yield 
-#CHECK-NEXT:   }
-#CHECK-NEXT: }
-#CHECK-EMPTY:
-#CHECK-NEXT: // -----// IR Dump After transform //----- //
-#CHECK-NEXT: module attributes {transform.with_named_sequence} {
-#CHECK-NEXT:   func.func @matmul(%arg0: memref<4x512xf32> {llvm.noalias}, %arg1: memref<512x32xf32> {llvm.noalias}, %arg2: memref<4x32xf32> {llvm.noalias}) {
-#CHECK-NEXT:     %cst = arith.constant dense<0.000000e+00> : vector<1x16xf32>
-#CHECK-NEXT:     %0 = ub.poison : f32
-#CHECK-NEXT:     %c16 = arith.constant 16 : index
-#CHECK-NEXT:     %c2 = arith.constant 2 : index
-#CHECK-NEXT:     %c512 = arith.constant 512 : index
-#CHECK-NEXT:     %c32 = arith.constant 32 : index
-#CHECK-NEXT:     %cst_0 = arith.constant 0.000000e+00 : f32
-#CHECK-NEXT:     %c0 = arith.constant 0 : index
-#CHECK-NEXT:     %c4 = arith.constant 4 : index
-#CHECK-NEXT:     %c1 = arith.constant 1 : index
-#CHECK-NEXT:     scf.for %arg3 = %c0 to %c4 step %c1 {
-#CHECK-NEXT:       %subview = memref.subview %arg2[%arg3, 0] [1, 32] [1, 1] : memref<4x32xf32> to memref<1x32xf32, strided<[32, 1], offset: ?>>
-#CHECK-NEXT:       scf.for %arg4 = %c0 to %c32 step %c1 {
-#CHECK-NEXT:         %subview_1 = memref.subview %subview[0, %arg4] [1, 1] [1, 1] : memref<1x32xf32, strided<[32, 1], offset: ?>> to memref<1x1xf32, strided<[32, 1], offset: ?>>
-#CHECK-NEXT:         linalg.fill {__xtc_id_C_0_} ins(%cst_0 : f32) outs(%subview_1 : memref<1x1xf32, strided<[32, 1], offset: ?>>)
-#CHECK-NEXT:       } {"./j"}
-#CHECK-NEXT:     } {"./i"}
-#CHECK-NEXT:     scf.for %arg3 = %c0 to %c512 step %c1 {
-#CHECK-NEXT:       %subview = memref.subview %arg0[0, %arg3] [4, 1] [1, 1] : memref<4x512xf32> to memref<4x1xf32, strided<[512, 1], offset: ?>>
-#CHECK-NEXT:       %subview_1 = memref.subview %arg1[%arg3, 0] [1, 32] [1, 1] : memref<512x32xf32> to memref<1x32xf32, strided<[32, 1], offset: ?>>
-#CHECK-NEXT:       %subview_2 = memref.subview %arg2[0, 0] [4, 32] [1, 1] : memref<4x32xf32> to memref<4x32xf32, strided<[32, 1]>>
-#CHECK-NEXT:       scf.for %arg4 = %c0 to %c4 step %c2 {
-#CHECK-NEXT:         %subview_3 = memref.subview %subview[%arg4, 0] [2, 1] [1, 1] : memref<4x1xf32, strided<[512, 1], offset: ?>> to memref<2x1xf32, strided<[512, 1], offset: ?>>
-#CHECK-NEXT:         %subview_4 = memref.subview %subview_2[%arg4, 0] [2, 32] [1, 1] : memref<4x32xf32, strided<[32, 1]>> to memref<2x32xf32, strided<[32, 1], offset: ?>>
-#CHECK-NEXT:         scf.for %arg5 = %c0 to %c32 step %c16 {
-#CHECK-NEXT:           %subview_5 = memref.subview %subview_1[0, %arg5] [1, 16] [1, 1] : memref<1x32xf32, strided<[32, 1], offset: ?>> to memref<1x16xf32, strided<[32, 1], offset: ?>>
-#CHECK-NEXT:           %subview_6 = memref.subview %subview_4[0, %arg5] [2, 16] [1, 1] : memref<2x32xf32, strided<[32, 1], offset: ?>> to memref<2x16xf32, strided<[32, 1], offset: ?>>
-#CHECK-NEXT:           %subview_7 = memref.subview %subview_3[%c0, 0] [1, 1] [1, 1] : memref<2x1xf32, strided<[512, 1], offset: ?>> to memref<1x1xf32, strided<[512, 1], offset: ?>>
-#CHECK-NEXT:           %subview_8 = memref.subview %subview_6[%c0, 0] [1, 16] [1, 1] : memref<2x16xf32, strided<[32, 1], offset: ?>> to memref<1x16xf32, strided<[32, 1], offset: ?>>
-#CHECK-NEXT:           %1 = vector.transfer_read %subview_7[%c0, %c0], %0 {in_bounds = [true, true]} : memref<1x1xf32, strided<[512, 1], offset: ?>>, vector<1x1xf32>
-#CHECK-NEXT:           %2 = vector.transfer_read %subview_5[%c0, %c0], %0 {in_bounds = [true, true]} : memref<1x16xf32, strided<[32, 1], offset: ?>>, vector<1x16xf32>
-#CHECK-NEXT:           %3 = vector.transfer_read %subview_8[%c0, %c0], %0 {in_bounds = [true, true]} : memref<1x16xf32, strided<[32, 1], offset: ?>>, vector<1x16xf32>
-#CHECK-NEXT:           %4 = vector.extract %2[0] : vector<16xf32> from vector<1x16xf32>
-#CHECK-NEXT:           %5 = vector.extract %1[0, 0] : f32 from vector<1x1xf32>
-#CHECK-NEXT:           %6 = vector.broadcast %5 : f32 to vector<16xf32>
-#CHECK-NEXT:           %7 = vector.extract %3[0] : vector<16xf32> from vector<1x16xf32>
-#CHECK-NEXT:           %8 = vector.fma %6, %4, %7 : vector<16xf32>
-#CHECK-NEXT:           %9 = vector.insert %8, %cst [0] : vector<16xf32> into vector<1x16xf32>
-#CHECK-NEXT:           vector.transfer_write %9, %subview_8[%c0, %c0] {in_bounds = [true, true]} : vector<1x16xf32>, memref<1x16xf32, strided<[32, 1], offset: ?>>
-#CHECK-NEXT:           %subview_9 = memref.subview %subview_3[%c1, 0] [1, 1] [1, 1] : memref<2x1xf32, strided<[512, 1], offset: ?>> to memref<1x1xf32, strided<[512, 1], offset: ?>>
-#CHECK-NEXT:           %subview_10 = memref.subview %subview_6[%c1, 0] [1, 16] [1, 1] : memref<2x16xf32, strided<[32, 1], offset: ?>> to memref<1x16xf32, strided<[32, 1], offset: ?>>
-#CHECK-NEXT:           %10 = vector.transfer_read %subview_9[%c0, %c0], %0 {in_bounds = [true, true]} : memref<1x1xf32, strided<[512, 1], offset: ?>>, vector<1x1xf32>
-#CHECK-NEXT:           %11 = vector.transfer_read %subview_5[%c0, %c0], %0 {in_bounds = [true, true]} : memref<1x16xf32, strided<[32, 1], offset: ?>>, vector<1x16xf32>
-#CHECK-NEXT:           %12 = vector.transfer_read %subview_10[%c0, %c0], %0 {in_bounds = [true, true]} : memref<1x16xf32, strided<[32, 1], offset: ?>>, vector<1x16xf32>
-#CHECK-NEXT:           %13 = vector.extract %11[0] : vector<16xf32> from vector<1x16xf32>
-#CHECK-NEXT:           %14 = vector.extract %10[0, 0] : f32 from vector<1x1xf32>
-#CHECK-NEXT:           %15 = vector.broadcast %14 : f32 to vector<16xf32>
-#CHECK-NEXT:           %16 = vector.extract %12[0] : vector<16xf32> from vector<1x16xf32>
-#CHECK-NEXT:           %17 = vector.fma %15, %13, %16 : vector<16xf32>
-#CHECK-NEXT:           %18 = vector.insert %17, %cst [0] : vector<16xf32> into vector<1x16xf32>
-#CHECK-NEXT:           vector.transfer_write %18, %subview_10[%c0, %c0] {in_bounds = [true, true]} : vector<1x16xf32>, memref<1x16xf32, strided<[32, 1], offset: ?>>
-#CHECK-NEXT:         } {"C/j"}
-#CHECK-NEXT:       } {"C/i"}
-#CHECK-NEXT:     } {"C/k"}
-#CHECK-NEXT:     return
-#CHECK-NEXT:   }
-#CHECK-NEXT: }
-#CHECK-EMPTY:
-#CHECK-NEXT: graph:
-#CHECK-NEXT:   name: matmul
-#CHECK-NEXT:   inputs:
-#CHECK-NEXT:   - %0 : 4x512xfloat32
-#CHECK-NEXT:   - %1 : 512x32xfloat32
-#CHECK-NEXT:   outputs:
-#CHECK-NEXT:   - %2 : 4x32xfloat32
-#CHECK-NEXT:   nodes:
-#CHECK-NEXT:   - %2: matmul(%0, %1) {name = 'C'} : [4x512xfloat32, 512x32xfloat32] -> [4x32xfloat32]
-#CHECK-EMPTY:
-#CHECK-NEXT: CODE: 0
-
+# CHECK:       // -----// IR Dump Before transform //----- //
+# CHECK-NEXT:  module attributes {transform.with_named_sequence} {
+# CHECK-NEXT:    func.func @matmul(%arg0: memref<4x512xf32> {llvm.noalias}, %arg1: memref<512x32xf32> {llvm.noalias}, %arg2: memref<4x32xf32> {llvm.noalias}) {
+# CHECK-NEXT:      %cst = arith.constant 0.000000e+00 : f32
+# CHECK-NEXT:      linalg.fill {__xtc_id_C_0_} ins(%cst : f32) outs(%arg2 : memref<4x32xf32>)
+# CHECK-NEXT:      linalg.matmul {__xtc_id_C_} ins(%arg0, %arg1 : memref<4x512xf32>, memref<512x32xf32>) outs(%arg2 : memref<4x32xf32>)
+# CHECK-NEXT:      return
+# CHECK-NEXT:    }
+# CHECK-NEXT:    transform.named_sequence @_vecto(%arg0: !transform.any_op {transform.consumed}) {
+# CHECK-NEXT:      transform.structured.vectorize %arg0 : !transform.any_op
+# CHECK-NEXT:      transform.yield 
+# CHECK-NEXT:    }
+# CHECK-NEXT:    transform.named_sequence @__transform_main(%arg0: !transform.any_op {transform.readonly}) {
+# CHECK-NEXT:      %0 = transform.structured.match attributes {__xtc_id_C_} in %arg0 : (!transform.any_op) -> !transform.any_op
+# CHECK-NEXT:      %tiled_linalg_op, %loops = transform.structured.tile_using_for %0 tile_sizes [0, 0, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      transform.annotate %loops "C/k" : !transform.any_op
+# CHECK-NEXT:      %tiled_linalg_op_0, %loops_1 = transform.structured.tile_using_for %tiled_linalg_op tile_sizes [2, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      transform.annotate %loops_1 "C/i" : !transform.any_op
+# CHECK-NEXT:      %tiled_linalg_op_2, %loops_3 = transform.structured.tile_using_for %tiled_linalg_op_0 tile_sizes [0, 16, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      transform.annotate %loops_3 "C/j" : !transform.any_op
+# CHECK-NEXT:      %tiled_linalg_op_4, %loops_5 = transform.structured.tile_using_for %tiled_linalg_op_2 tile_sizes [1, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      transform.annotate %loops_5 "C/i0" : !transform.any_op
+# CHECK-NEXT:      transform.include @_vecto failures(suppress) (%tiled_linalg_op_4) : (!transform.any_op) -> ()
+# CHECK-NEXT:      transform.loop.unroll %loops_5 {factor = 2 : i64} : !transform.any_op
+# CHECK-NEXT:      %1 = transform.get_parent_op %loops {isolated_from_above} : (!transform.any_op) -> !transform.any_op
+# CHECK-NEXT:      transform.apply_patterns to %1 {
+# CHECK-NEXT:        transform.apply_patterns.vector.reduction_to_contract
+# CHECK-NEXT:        transform.apply_patterns.vector.transfer_permutation_patterns
+# CHECK-NEXT:      } : !transform.any_op
+# CHECK-NEXT:      transform.apply_patterns to %1 {
+# CHECK-NEXT:        transform.apply_patterns.vector.lower_outerproduct
+# CHECK-NEXT:        transform.apply_patterns.vector.lower_contraction
+# CHECK-NEXT:      } : !transform.any_op
+# CHECK-NEXT:      transform.yield 
+# CHECK-NEXT:    }
+# CHECK-NEXT:  }
+# CHECK-NEXT:  
+# CHECK-NEXT:  // -----// IR Dump After transform //----- //
+# CHECK-NEXT:  module attributes {transform.with_named_sequence} {
+# CHECK-NEXT:    func.func @matmul(%arg0: memref<4x512xf32> {llvm.noalias}, %arg1: memref<512x32xf32> {llvm.noalias}, %arg2: memref<4x32xf32> {llvm.noalias}) {
+# CHECK-NEXT:      %cst = arith.constant dense<0.000000e+00> : vector<1x16xf32>
+# CHECK-NEXT:      %0 = ub.poison : f32
+# CHECK-NEXT:      %c16 = arith.constant 16 : index
+# CHECK-NEXT:      %c32 = arith.constant 32 : index
+# CHECK-NEXT:      %c2 = arith.constant 2 : index
+# CHECK-NEXT:      %c4 = arith.constant 4 : index
+# CHECK-NEXT:      %c1 = arith.constant 1 : index
+# CHECK-NEXT:      %c512 = arith.constant 512 : index
+# CHECK-NEXT:      %c0 = arith.constant 0 : index
+# CHECK-NEXT:      %cst_0 = arith.constant 0.000000e+00 : f32
+# CHECK-NEXT:      linalg.fill {__xtc_id_C_0_} ins(%cst_0 : f32) outs(%arg2 : memref<4x32xf32>)
+# CHECK-NEXT:      scf.for %arg3 = %c0 to %c512 step %c1 {
+# CHECK-NEXT:        %subview = memref.subview %arg0[0, %arg3] [4, 1] [1, 1] : memref<4x512xf32> to memref<4x1xf32, strided<[512, 1], offset: ?>>
+# CHECK-NEXT:        %subview_1 = memref.subview %arg1[%arg3, 0] [1, 32] [1, 1] : memref<512x32xf32> to memref<1x32xf32, strided<[32, 1], offset: ?>>
+# CHECK-NEXT:        %subview_2 = memref.subview %arg2[0, 0] [4, 32] [1, 1] : memref<4x32xf32> to memref<4x32xf32, strided<[32, 1]>>
+# CHECK-NEXT:        scf.for %arg4 = %c0 to %c4 step %c2 {
+# CHECK-NEXT:          %subview_3 = memref.subview %subview[%arg4, 0] [2, 1] [1, 1] : memref<4x1xf32, strided<[512, 1], offset: ?>> to memref<2x1xf32, strided<[512, 1], offset: ?>>
+# CHECK-NEXT:          %subview_4 = memref.subview %subview_2[%arg4, 0] [2, 32] [1, 1] : memref<4x32xf32, strided<[32, 1]>> to memref<2x32xf32, strided<[32, 1], offset: ?>>
+# CHECK-NEXT:          scf.for %arg5 = %c0 to %c32 step %c16 {
+# CHECK-NEXT:            %subview_5 = memref.subview %subview_1[0, %arg5] [1, 16] [1, 1] : memref<1x32xf32, strided<[32, 1], offset: ?>> to memref<1x16xf32, strided<[32, 1], offset: ?>>
+# CHECK-NEXT:            %subview_6 = memref.subview %subview_4[0, %arg5] [2, 16] [1, 1] : memref<2x32xf32, strided<[32, 1], offset: ?>> to memref<2x16xf32, strided<[32, 1], offset: ?>>
+# CHECK-NEXT:            %subview_7 = memref.subview %subview_3[%c0, 0] [1, 1] [1, 1] : memref<2x1xf32, strided<[512, 1], offset: ?>> to memref<1x1xf32, strided<[512, 1], offset: ?>>
+# CHECK-NEXT:            %subview_8 = memref.subview %subview_6[%c0, 0] [1, 16] [1, 1] : memref<2x16xf32, strided<[32, 1], offset: ?>> to memref<1x16xf32, strided<[32, 1], offset: ?>>
+# CHECK-NEXT:            %1 = vector.transfer_read %subview_7[%c0, %c0], %0 {in_bounds = [true, true]} : memref<1x1xf32, strided<[512, 1], offset: ?>>, vector<1x1xf32>
+# CHECK-NEXT:            %2 = vector.transfer_read %subview_5[%c0, %c0], %0 {in_bounds = [true, true]} : memref<1x16xf32, strided<[32, 1], offset: ?>>, vector<1x16xf32>
+# CHECK-NEXT:            %3 = vector.transfer_read %subview_8[%c0, %c0], %0 {in_bounds = [true, true]} : memref<1x16xf32, strided<[32, 1], offset: ?>>, vector<1x16xf32>
+# CHECK-NEXT:            %4 = vector.extract %2[0] : vector<16xf32> from vector<1x16xf32>
+# CHECK-NEXT:            %5 = vector.extract %1[0, 0] : f32 from vector<1x1xf32>
+# CHECK-NEXT:            %6 = vector.broadcast %5 : f32 to vector<16xf32>
+# CHECK-NEXT:            %7 = vector.extract %3[0] : vector<16xf32> from vector<1x16xf32>
+# CHECK-NEXT:            %8 = vector.fma %6, %4, %7 : vector<16xf32>
+# CHECK-NEXT:            %9 = vector.insert %8, %cst [0] : vector<16xf32> into vector<1x16xf32>
+# CHECK-NEXT:            vector.transfer_write %9, %subview_8[%c0, %c0] {in_bounds = [true, true]} : vector<1x16xf32>, memref<1x16xf32, strided<[32, 1], offset: ?>>
+# CHECK-NEXT:            %subview_9 = memref.subview %subview_3[%c1, 0] [1, 1] [1, 1] : memref<2x1xf32, strided<[512, 1], offset: ?>> to memref<1x1xf32, strided<[512, 1], offset: ?>>
+# CHECK-NEXT:            %subview_10 = memref.subview %subview_6[%c1, 0] [1, 16] [1, 1] : memref<2x16xf32, strided<[32, 1], offset: ?>> to memref<1x16xf32, strided<[32, 1], offset: ?>>
+# CHECK-NEXT:            %10 = vector.transfer_read %subview_9[%c0, %c0], %0 {in_bounds = [true, true]} : memref<1x1xf32, strided<[512, 1], offset: ?>>, vector<1x1xf32>
+# CHECK-NEXT:            %11 = vector.transfer_read %subview_5[%c0, %c0], %0 {in_bounds = [true, true]} : memref<1x16xf32, strided<[32, 1], offset: ?>>, vector<1x16xf32>
+# CHECK-NEXT:            %12 = vector.transfer_read %subview_10[%c0, %c0], %0 {in_bounds = [true, true]} : memref<1x16xf32, strided<[32, 1], offset: ?>>, vector<1x16xf32>
+# CHECK-NEXT:            %13 = vector.extract %11[0] : vector<16xf32> from vector<1x16xf32>
+# CHECK-NEXT:            %14 = vector.extract %10[0, 0] : f32 from vector<1x1xf32>
+# CHECK-NEXT:            %15 = vector.broadcast %14 : f32 to vector<16xf32>
+# CHECK-NEXT:            %16 = vector.extract %12[0] : vector<16xf32> from vector<1x16xf32>
+# CHECK-NEXT:            %17 = vector.fma %15, %13, %16 : vector<16xf32>
+# CHECK-NEXT:            %18 = vector.insert %17, %cst [0] : vector<16xf32> into vector<1x16xf32>
+# CHECK-NEXT:            vector.transfer_write %18, %subview_10[%c0, %c0] {in_bounds = [true, true]} : vector<1x16xf32>, memref<1x16xf32, strided<[32, 1], offset: ?>>
+# CHECK-NEXT:          } {"C/j"}
+# CHECK-NEXT:        } {"C/i"}
+# CHECK-NEXT:      } {"C/k"}
+# CHECK-NEXT:      return
+# CHECK-NEXT:    }
+# CHECK-NEXT:  }
+# CHECK-NEXT:  
+# CHECK-NEXT:  graph:
+# CHECK-NEXT:    name: matmul
+# CHECK-NEXT:    inputs:
+# CHECK-NEXT:    - %0 : 4x512xfloat32
+# CHECK-NEXT:    - %1 : 512x32xfloat32
+# CHECK-NEXT:    outputs:
+# CHECK-NEXT:    - %2 : 4x32xfloat32
+# CHECK-NEXT:    nodes:
+# CHECK-NEXT:    - %2: matmul(%0, %1) {name = 'C'} : [4x512xfloat32, 512x32xfloat32] -> [4x32xfloat32]
+# CHECK-NEXT:  
+# CHECK-NEXT:  CODE: 0

--- a/tests/filecheck/schedules/test_matmul_descript_extend_mlir_split.py
+++ b/tests/filecheck/schedules/test_matmul_descript_extend_mlir_split.py
@@ -52,189 +52,178 @@ executor = module.get_executor(validate=True)
 res = executor.execute()
 print(f"CODE: {res}")
 
-#CHECK: // -----// IR Dump Before transform //----- //
-#CHECK-NEXT: module attributes {transform.with_named_sequence} {
-#CHECK-NEXT:   func.func @matmul(%arg0: memref<16x512xf32> {llvm.noalias}, %arg1: memref<512x32xf32> {llvm.noalias}, %arg2: memref<16x32xf32> {llvm.noalias}) {
-#CHECK-NEXT:     %cst = arith.constant 0.000000e+00 : f32
-#CHECK-NEXT:     linalg.fill {__xtc_id_C_0_} ins(%cst : f32) outs(%arg2 : memref<16x32xf32>)
-#CHECK-NEXT:     linalg.matmul {__xtc_id_C_} ins(%arg0, %arg1 : memref<16x512xf32>, memref<512x32xf32>) outs(%arg2 : memref<16x32xf32>)
-#CHECK-NEXT:     return
-#CHECK-NEXT:   }
-#CHECK-NEXT:   transform.named_sequence @_vecto(%arg0: !transform.any_op {transform.consumed}) {
-#CHECK-NEXT:     transform.structured.vectorize %arg0 : !transform.any_op
-#CHECK-NEXT:     transform.yield 
-#CHECK-NEXT:   }
-#CHECK-NEXT:   transform.named_sequence @__transform_main(%arg0: !transform.any_op {transform.readonly}) {
-#CHECK-NEXT:     %0 = transform.structured.match attributes {__xtc_id_C_0_} in %arg0 : (!transform.any_op) -> !transform.any_op
-#CHECK-NEXT:     %tiled_linalg_op, %loops = transform.structured.tile_using_for %0 tile_sizes [1, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-#CHECK-NEXT:     transform.annotate %loops "./i" : !transform.any_op
-#CHECK-NEXT:     %tiled_linalg_op_0, %loops_1 = transform.structured.tile_using_for %tiled_linalg_op tile_sizes [0, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-#CHECK-NEXT:     transform.annotate %loops_1 "./j" : !transform.any_op
-#CHECK-NEXT:     %1 = transform.structured.match attributes {__xtc_id_C_} in %arg0 : (!transform.any_op) -> !transform.any_op
-#CHECK-NEXT:     %tiled_linalg_op_2, %loops_3 = transform.structured.tile_using_for %1 tile_sizes [0, 16, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-#CHECK-NEXT:     transform.annotate %loops_3 "C/j" : !transform.any_op
-#CHECK-NEXT:     %tiled_linalg_op_4, %loops_5 = transform.structured.tile_using_for %tiled_linalg_op_2 tile_sizes [0, 0, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-#CHECK-NEXT:     transform.annotate %loops_5 "C/k" : !transform.any_op
-#CHECK-NEXT:     %tiled_linalg_op_6, %loops_7 = transform.structured.tile_using_for %tiled_linalg_op_4 tile_sizes [0, 4, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-#CHECK-NEXT:     transform.annotate %loops_7 "C/j0" : !transform.any_op
-#CHECK-NEXT:     %2 = transform.structured.split %tiled_linalg_op_6 after 4  {dimension = 0 : i64} : !transform.any_op
-#CHECK-NEXT:     %3:2 = transform.split_handle %2 {fail_on_payload_too_small = false} : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-#CHECK-NEXT:     %tiled_linalg_op_8, %loops_9 = transform.structured.tile_using_for %3#0 tile_sizes [2, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-#CHECK-NEXT:     transform.annotate %loops_9 "C/i[0]/i" : !transform.any_op
-#CHECK-NEXT:     %tiled_linalg_op_10, %loops_11 = transform.structured.tile_using_for %tiled_linalg_op_8 tile_sizes [1, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-#CHECK-NEXT:     transform.annotate %loops_11 "C/i[0]/i0" : !transform.any_op
-#CHECK-NEXT:     transform.include @_vecto failures(suppress) (%tiled_linalg_op_10) : (!transform.any_op) -> ()
-#CHECK-NEXT:     transform.loop.unroll %loops_11 {factor = 2 : i64} : !transform.any_op
-#CHECK-NEXT:     %tiled_linalg_op_12, %loops_13 = transform.structured.tile_using_for %3#1 tile_sizes [4, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-#CHECK-NEXT:     transform.annotate %loops_13 "C/i[1]/i" : !transform.any_op
-#CHECK-NEXT:     %tiled_linalg_op_14, %loops_15 = transform.structured.tile_using_for %tiled_linalg_op_12 tile_sizes [1, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-#CHECK-NEXT:     transform.annotate %loops_15 "C/i[1]/i0" : !transform.any_op
-#CHECK-NEXT:     transform.include @_vecto failures(suppress) (%tiled_linalg_op_14) : (!transform.any_op) -> ()
-#CHECK-NEXT:     transform.loop.unroll %loops_15 {factor = 4 : i64} : !transform.any_op
-#CHECK-NEXT:     %4 = transform.get_parent_op %loops_3 {isolated_from_above} : (!transform.any_op) -> !transform.any_op
-#CHECK-NEXT:     transform.apply_patterns to %4 {
-#CHECK-NEXT:       transform.apply_patterns.vector.reduction_to_contract
-#CHECK-NEXT:       transform.apply_patterns.vector.transfer_permutation_patterns
-#CHECK-NEXT:     } : !transform.any_op
-#CHECK-NEXT:     transform.apply_patterns to %4 {
-#CHECK-NEXT:       transform.apply_patterns.vector.lower_outerproduct
-#CHECK-NEXT:       transform.apply_patterns.vector.lower_contraction
-#CHECK-NEXT:     } : !transform.any_op
-#CHECK-NEXT:     transform.yield 
-#CHECK-NEXT:   }
-#CHECK-NEXT: }
-#CHECK-EMPTY:
-#CHECK-NEXT: // -----// IR Dump After transform //----- //
-#CHECK-NEXT: module attributes {transform.with_named_sequence} {
-#CHECK-NEXT:   func.func @matmul(%arg0: memref<16x512xf32> {llvm.noalias}, %arg1: memref<512x32xf32> {llvm.noalias}, %arg2: memref<16x32xf32> {llvm.noalias}) {
-#CHECK-NEXT:     %cst = arith.constant dense<0.000000e+00> : vector<1x4xf32>
-#CHECK-NEXT:     %c3 = arith.constant 3 : index
-#CHECK-NEXT:     %c12 = arith.constant 12 : index
-#CHECK-NEXT:     %0 = ub.poison : f32
-#CHECK-NEXT:     %c2 = arith.constant 2 : index
-#CHECK-NEXT:     %c4 = arith.constant 4 : index
-#CHECK-NEXT:     %c512 = arith.constant 512 : index
-#CHECK-NEXT:     %c32 = arith.constant 32 : index
-#CHECK-NEXT:     %cst_0 = arith.constant 0.000000e+00 : f32
-#CHECK-NEXT:     %c0 = arith.constant 0 : index
-#CHECK-NEXT:     %c16 = arith.constant 16 : index
-#CHECK-NEXT:     %c1 = arith.constant 1 : index
-#CHECK-NEXT:     scf.for %arg3 = %c0 to %c16 step %c1 {
-#CHECK-NEXT:       %subview = memref.subview %arg2[%arg3, 0] [1, 32] [1, 1] : memref<16x32xf32> to memref<1x32xf32, strided<[32, 1], offset: ?>>
-#CHECK-NEXT:       scf.for %arg4 = %c0 to %c32 step %c1 {
-#CHECK-NEXT:         %subview_1 = memref.subview %subview[0, %arg4] [1, 1] [1, 1] : memref<1x32xf32, strided<[32, 1], offset: ?>> to memref<1x1xf32, strided<[32, 1], offset: ?>>
-#CHECK-NEXT:         linalg.fill {__xtc_id_C_0_} ins(%cst_0 : f32) outs(%subview_1 : memref<1x1xf32, strided<[32, 1], offset: ?>>)
-#CHECK-NEXT:       } {"./j"}
-#CHECK-NEXT:     } {"./i"}
-#CHECK-NEXT:     scf.for %arg3 = %c0 to %c32 step %c16 {
-#CHECK-NEXT:       %subview = memref.subview %arg0[0, 0] [16, 512] [1, 1] : memref<16x512xf32> to memref<16x512xf32, strided<[512, 1]>>
-#CHECK-NEXT:       %subview_1 = memref.subview %arg1[0, %arg3] [512, 16] [1, 1] : memref<512x32xf32> to memref<512x16xf32, strided<[32, 1], offset: ?>>
-#CHECK-NEXT:       %subview_2 = memref.subview %arg2[0, %arg3] [16, 16] [1, 1] : memref<16x32xf32> to memref<16x16xf32, strided<[32, 1], offset: ?>>
-#CHECK-NEXT:       scf.for %arg4 = %c0 to %c512 step %c1 {
-#CHECK-NEXT:         %subview_3 = memref.subview %subview[0, %arg4] [16, 1] [1, 1] : memref<16x512xf32, strided<[512, 1]>> to memref<16x1xf32, strided<[512, 1], offset: ?>>
-#CHECK-NEXT:         %subview_4 = memref.subview %subview_1[%arg4, 0] [1, 16] [1, 1] : memref<512x16xf32, strided<[32, 1], offset: ?>> to memref<1x16xf32, strided<[32, 1], offset: ?>>
-#CHECK-NEXT:         scf.for %arg5 = %c0 to %c16 step %c4 {
-#CHECK-NEXT:           %subview_5 = memref.subview %subview_4[0, %arg5] [1, 4] [1, 1] : memref<1x16xf32, strided<[32, 1], offset: ?>> to memref<1x4xf32, strided<[32, 1], offset: ?>>
-#CHECK-NEXT:           %subview_6 = memref.subview %subview_2[0, %arg5] [16, 4] [1, 1] : memref<16x16xf32, strided<[32, 1], offset: ?>> to memref<16x4xf32, strided<[32, 1], offset: ?>>
-#CHECK-NEXT:           %subview_7 = memref.subview %subview_3[0, 0] [4, 1] [1, 1] : memref<16x1xf32, strided<[512, 1], offset: ?>> to memref<4x1xf32, strided<[512, 1], offset: ?>>
-#CHECK-NEXT:           %subview_8 = memref.subview %subview_6[0, 0] [4, 4] [1, 1] : memref<16x4xf32, strided<[32, 1], offset: ?>> to memref<4x4xf32, strided<[32, 1], offset: ?>>
-#CHECK-NEXT:           scf.for %arg6 = %c0 to %c4 step %c2 {
-#CHECK-NEXT:             %subview_11 = memref.subview %subview_7[%arg6, 0] [2, 1] [1, 1] : memref<4x1xf32, strided<[512, 1], offset: ?>> to memref<2x1xf32, strided<[512, 1], offset: ?>>
-#CHECK-NEXT:             %subview_12 = memref.subview %subview_8[%arg6, 0] [2, 4] [1, 1] : memref<4x4xf32, strided<[32, 1], offset: ?>> to memref<2x4xf32, strided<[32, 1], offset: ?>>
-#CHECK-NEXT:             %subview_13 = memref.subview %subview_11[%c0, 0] [1, 1] [1, 1] : memref<2x1xf32, strided<[512, 1], offset: ?>> to memref<1x1xf32, strided<[512, 1], offset: ?>>
-#CHECK-NEXT:             %subview_14 = memref.subview %subview_12[%c0, 0] [1, 4] [1, 1] : memref<2x4xf32, strided<[32, 1], offset: ?>> to memref<1x4xf32, strided<[32, 1], offset: ?>>
-#CHECK-NEXT:             %1 = vector.transfer_read %subview_13[%c0, %c0], %0 {in_bounds = [true, true]} : memref<1x1xf32, strided<[512, 1], offset: ?>>, vector<1x1xf32>
-#CHECK-NEXT:             %2 = vector.transfer_read %subview_5[%c0, %c0], %0 {in_bounds = [true, true]} : memref<1x4xf32, strided<[32, 1], offset: ?>>, vector<1x4xf32>
-#CHECK-NEXT:             %3 = vector.transfer_read %subview_14[%c0, %c0], %0 {in_bounds = [true, true]} : memref<1x4xf32, strided<[32, 1], offset: ?>>, vector<1x4xf32>
-#CHECK-NEXT:             %4 = vector.extract %2[0] : vector<4xf32> from vector<1x4xf32>
-#CHECK-NEXT:             %5 = vector.extract %1[0, 0] : f32 from vector<1x1xf32>
-#CHECK-NEXT:             %6 = vector.broadcast %5 : f32 to vector<4xf32>
-#CHECK-NEXT:             %7 = vector.extract %3[0] : vector<4xf32> from vector<1x4xf32>
-#CHECK-NEXT:             %8 = vector.fma %6, %4, %7 : vector<4xf32>
-#CHECK-NEXT:             %9 = vector.insert %8, %cst [0] : vector<4xf32> into vector<1x4xf32>
-#CHECK-NEXT:             vector.transfer_write %9, %subview_14[%c0, %c0] {in_bounds = [true, true]} : vector<1x4xf32>, memref<1x4xf32, strided<[32, 1], offset: ?>>
-#CHECK-NEXT:             %subview_15 = memref.subview %subview_11[%c1, 0] [1, 1] [1, 1] : memref<2x1xf32, strided<[512, 1], offset: ?>> to memref<1x1xf32, strided<[512, 1], offset: ?>>
-#CHECK-NEXT:             %subview_16 = memref.subview %subview_12[%c1, 0] [1, 4] [1, 1] : memref<2x4xf32, strided<[32, 1], offset: ?>> to memref<1x4xf32, strided<[32, 1], offset: ?>>
-#CHECK-NEXT:             %10 = vector.transfer_read %subview_15[%c0, %c0], %0 {in_bounds = [true, true]} : memref<1x1xf32, strided<[512, 1], offset: ?>>, vector<1x1xf32>
-#CHECK-NEXT:             %11 = vector.transfer_read %subview_5[%c0, %c0], %0 {in_bounds = [true, true]} : memref<1x4xf32, strided<[32, 1], offset: ?>>, vector<1x4xf32>
-#CHECK-NEXT:             %12 = vector.transfer_read %subview_16[%c0, %c0], %0 {in_bounds = [true, true]} : memref<1x4xf32, strided<[32, 1], offset: ?>>, vector<1x4xf32>
-#CHECK-NEXT:             %13 = vector.extract %11[0] : vector<4xf32> from vector<1x4xf32>
-#CHECK-NEXT:             %14 = vector.extract %10[0, 0] : f32 from vector<1x1xf32>
-#CHECK-NEXT:             %15 = vector.broadcast %14 : f32 to vector<4xf32>
-#CHECK-NEXT:             %16 = vector.extract %12[0] : vector<4xf32> from vector<1x4xf32>
-#CHECK-NEXT:             %17 = vector.fma %15, %13, %16 : vector<4xf32>
-#CHECK-NEXT:             %18 = vector.insert %17, %cst [0] : vector<4xf32> into vector<1x4xf32>
-#CHECK-NEXT:             vector.transfer_write %18, %subview_16[%c0, %c0] {in_bounds = [true, true]} : vector<1x4xf32>, memref<1x4xf32, strided<[32, 1], offset: ?>>
-#CHECK-NEXT:           } {"C/i[0]/i"}
-#CHECK-NEXT:           %subview_9 = memref.subview %subview_3[4, 0] [12, 1] [1, 1] : memref<16x1xf32, strided<[512, 1], offset: ?>> to memref<12x1xf32, strided<[512, 1], offset: ?>>
-#CHECK-NEXT:           %subview_10 = memref.subview %subview_6[4, 0] [12, 4] [1, 1] : memref<16x4xf32, strided<[32, 1], offset: ?>> to memref<12x4xf32, strided<[32, 1], offset: ?>>
-#CHECK-NEXT:           scf.for %arg6 = %c0 to %c12 step %c4 {
-#CHECK-NEXT:             %subview_11 = memref.subview %subview_9[%arg6, 0] [4, 1] [1, 1] : memref<12x1xf32, strided<[512, 1], offset: ?>> to memref<4x1xf32, strided<[512, 1], offset: ?>>
-#CHECK-NEXT:             %subview_12 = memref.subview %subview_10[%arg6, 0] [4, 4] [1, 1] : memref<12x4xf32, strided<[32, 1], offset: ?>> to memref<4x4xf32, strided<[32, 1], offset: ?>>
-#CHECK-NEXT:             %subview_13 = memref.subview %subview_11[%c0, 0] [1, 1] [1, 1] : memref<4x1xf32, strided<[512, 1], offset: ?>> to memref<1x1xf32, strided<[512, 1], offset: ?>>
-#CHECK-NEXT:             %subview_14 = memref.subview %subview_12[%c0, 0] [1, 4] [1, 1] : memref<4x4xf32, strided<[32, 1], offset: ?>> to memref<1x4xf32, strided<[32, 1], offset: ?>>
-#CHECK-NEXT:             %1 = vector.transfer_read %subview_13[%c0, %c0], %0 {in_bounds = [true, true]} : memref<1x1xf32, strided<[512, 1], offset: ?>>, vector<1x1xf32>
-#CHECK-NEXT:             %2 = vector.transfer_read %subview_5[%c0, %c0], %0 {in_bounds = [true, true]} : memref<1x4xf32, strided<[32, 1], offset: ?>>, vector<1x4xf32>
-#CHECK-NEXT:             %3 = vector.transfer_read %subview_14[%c0, %c0], %0 {in_bounds = [true, true]} : memref<1x4xf32, strided<[32, 1], offset: ?>>, vector<1x4xf32>
-#CHECK-NEXT:             %4 = vector.extract %2[0] : vector<4xf32> from vector<1x4xf32>
-#CHECK-NEXT:             %5 = vector.extract %1[0, 0] : f32 from vector<1x1xf32>
-#CHECK-NEXT:             %6 = vector.broadcast %5 : f32 to vector<4xf32>
-#CHECK-NEXT:             %7 = vector.extract %3[0] : vector<4xf32> from vector<1x4xf32>
-#CHECK-NEXT:             %8 = vector.fma %6, %4, %7 : vector<4xf32>
-#CHECK-NEXT:             %9 = vector.insert %8, %cst [0] : vector<4xf32> into vector<1x4xf32>
-#CHECK-NEXT:             vector.transfer_write %9, %subview_14[%c0, %c0] {in_bounds = [true, true]} : vector<1x4xf32>, memref<1x4xf32, strided<[32, 1], offset: ?>>
-#CHECK-NEXT:             %subview_15 = memref.subview %subview_11[%c1, 0] [1, 1] [1, 1] : memref<4x1xf32, strided<[512, 1], offset: ?>> to memref<1x1xf32, strided<[512, 1], offset: ?>>
-#CHECK-NEXT:             %subview_16 = memref.subview %subview_12[%c1, 0] [1, 4] [1, 1] : memref<4x4xf32, strided<[32, 1], offset: ?>> to memref<1x4xf32, strided<[32, 1], offset: ?>>
-#CHECK-NEXT:             %10 = vector.transfer_read %subview_15[%c0, %c0], %0 {in_bounds = [true, true]} : memref<1x1xf32, strided<[512, 1], offset: ?>>, vector<1x1xf32>
-#CHECK-NEXT:             %11 = vector.transfer_read %subview_5[%c0, %c0], %0 {in_bounds = [true, true]} : memref<1x4xf32, strided<[32, 1], offset: ?>>, vector<1x4xf32>
-#CHECK-NEXT:             %12 = vector.transfer_read %subview_16[%c0, %c0], %0 {in_bounds = [true, true]} : memref<1x4xf32, strided<[32, 1], offset: ?>>, vector<1x4xf32>
-#CHECK-NEXT:             %13 = vector.extract %11[0] : vector<4xf32> from vector<1x4xf32>
-#CHECK-NEXT:             %14 = vector.extract %10[0, 0] : f32 from vector<1x1xf32>
-#CHECK-NEXT:             %15 = vector.broadcast %14 : f32 to vector<4xf32>
-#CHECK-NEXT:             %16 = vector.extract %12[0] : vector<4xf32> from vector<1x4xf32>
-#CHECK-NEXT:             %17 = vector.fma %15, %13, %16 : vector<4xf32>
-#CHECK-NEXT:             %18 = vector.insert %17, %cst [0] : vector<4xf32> into vector<1x4xf32>
-#CHECK-NEXT:             vector.transfer_write %18, %subview_16[%c0, %c0] {in_bounds = [true, true]} : vector<1x4xf32>, memref<1x4xf32, strided<[32, 1], offset: ?>>
-#CHECK-NEXT:             %subview_17 = memref.subview %subview_11[%c2, 0] [1, 1] [1, 1] : memref<4x1xf32, strided<[512, 1], offset: ?>> to memref<1x1xf32, strided<[512, 1], offset: ?>>
-#CHECK-NEXT:             %subview_18 = memref.subview %subview_12[%c2, 0] [1, 4] [1, 1] : memref<4x4xf32, strided<[32, 1], offset: ?>> to memref<1x4xf32, strided<[32, 1], offset: ?>>
-#CHECK-NEXT:             %19 = vector.transfer_read %subview_17[%c0, %c0], %0 {in_bounds = [true, true]} : memref<1x1xf32, strided<[512, 1], offset: ?>>, vector<1x1xf32>
-#CHECK-NEXT:             %20 = vector.transfer_read %subview_5[%c0, %c0], %0 {in_bounds = [true, true]} : memref<1x4xf32, strided<[32, 1], offset: ?>>, vector<1x4xf32>
-#CHECK-NEXT:             %21 = vector.transfer_read %subview_18[%c0, %c0], %0 {in_bounds = [true, true]} : memref<1x4xf32, strided<[32, 1], offset: ?>>, vector<1x4xf32>
-#CHECK-NEXT:             %22 = vector.extract %20[0] : vector<4xf32> from vector<1x4xf32>
-#CHECK-NEXT:             %23 = vector.extract %19[0, 0] : f32 from vector<1x1xf32>
-#CHECK-NEXT:             %24 = vector.broadcast %23 : f32 to vector<4xf32>
-#CHECK-NEXT:             %25 = vector.extract %21[0] : vector<4xf32> from vector<1x4xf32>
-#CHECK-NEXT:             %26 = vector.fma %24, %22, %25 : vector<4xf32>
-#CHECK-NEXT:             %27 = vector.insert %26, %cst [0] : vector<4xf32> into vector<1x4xf32>
-#CHECK-NEXT:             vector.transfer_write %27, %subview_18[%c0, %c0] {in_bounds = [true, true]} : vector<1x4xf32>, memref<1x4xf32, strided<[32, 1], offset: ?>>
-#CHECK-NEXT:             %subview_19 = memref.subview %subview_11[%c3, 0] [1, 1] [1, 1] : memref<4x1xf32, strided<[512, 1], offset: ?>> to memref<1x1xf32, strided<[512, 1], offset: ?>>
-#CHECK-NEXT:             %subview_20 = memref.subview %subview_12[%c3, 0] [1, 4] [1, 1] : memref<4x4xf32, strided<[32, 1], offset: ?>> to memref<1x4xf32, strided<[32, 1], offset: ?>>
-#CHECK-NEXT:             %28 = vector.transfer_read %subview_19[%c0, %c0], %0 {in_bounds = [true, true]} : memref<1x1xf32, strided<[512, 1], offset: ?>>, vector<1x1xf32>
-#CHECK-NEXT:             %29 = vector.transfer_read %subview_5[%c0, %c0], %0 {in_bounds = [true, true]} : memref<1x4xf32, strided<[32, 1], offset: ?>>, vector<1x4xf32>
-#CHECK-NEXT:             %30 = vector.transfer_read %subview_20[%c0, %c0], %0 {in_bounds = [true, true]} : memref<1x4xf32, strided<[32, 1], offset: ?>>, vector<1x4xf32>
-#CHECK-NEXT:             %31 = vector.extract %29[0] : vector<4xf32> from vector<1x4xf32>
-#CHECK-NEXT:             %32 = vector.extract %28[0, 0] : f32 from vector<1x1xf32>
-#CHECK-NEXT:             %33 = vector.broadcast %32 : f32 to vector<4xf32>
-#CHECK-NEXT:             %34 = vector.extract %30[0] : vector<4xf32> from vector<1x4xf32>
-#CHECK-NEXT:             %35 = vector.fma %33, %31, %34 : vector<4xf32>
-#CHECK-NEXT:             %36 = vector.insert %35, %cst [0] : vector<4xf32> into vector<1x4xf32>
-#CHECK-NEXT:             vector.transfer_write %36, %subview_20[%c0, %c0] {in_bounds = [true, true]} : vector<1x4xf32>, memref<1x4xf32, strided<[32, 1], offset: ?>>
-#CHECK-NEXT:           } {"C/i[1]/i"}
-#CHECK-NEXT:         } {"C/j0"}
-#CHECK-NEXT:       } {"C/k"}
-#CHECK-NEXT:     } {"C/j"}
-#CHECK-NEXT:     return
-#CHECK-NEXT:   }
-#CHECK-NEXT: }
-#CHECK-EMPTY:
-#CHECK-NEXT: graph:
-#CHECK-NEXT:   name: matmul
-#CHECK-NEXT:   inputs:
-#CHECK-NEXT:   - %0 : 16x512xfloat32
-#CHECK-NEXT:   - %1 : 512x32xfloat32
-#CHECK-NEXT:   outputs:
-#CHECK-NEXT:   - %2 : 16x32xfloat32
-#CHECK-NEXT:   nodes:
-#CHECK-NEXT:   - %2: matmul(%0, %1) {name = 'C'} : [16x512xfloat32, 512x32xfloat32] -> [16x32xfloat32]
-#CHECK-EMPTY:
-#CHECK-NEXT: CODE: 0
+# CHECK:       // -----// IR Dump Before transform //----- //
+# CHECK-NEXT:  module attributes {transform.with_named_sequence} {
+# CHECK-NEXT:    func.func @matmul(%arg0: memref<16x512xf32> {llvm.noalias}, %arg1: memref<512x32xf32> {llvm.noalias}, %arg2: memref<16x32xf32> {llvm.noalias}) {
+# CHECK-NEXT:      %cst = arith.constant 0.000000e+00 : f32
+# CHECK-NEXT:      linalg.fill {__xtc_id_C_0_} ins(%cst : f32) outs(%arg2 : memref<16x32xf32>)
+# CHECK-NEXT:      linalg.matmul {__xtc_id_C_} ins(%arg0, %arg1 : memref<16x512xf32>, memref<512x32xf32>) outs(%arg2 : memref<16x32xf32>)
+# CHECK-NEXT:      return
+# CHECK-NEXT:    }
+# CHECK-NEXT:    transform.named_sequence @_vecto(%arg0: !transform.any_op {transform.consumed}) {
+# CHECK-NEXT:      transform.structured.vectorize %arg0 : !transform.any_op
+# CHECK-NEXT:      transform.yield 
+# CHECK-NEXT:    }
+# CHECK-NEXT:    transform.named_sequence @__transform_main(%arg0: !transform.any_op {transform.readonly}) {
+# CHECK-NEXT:      %0 = transform.structured.match attributes {__xtc_id_C_} in %arg0 : (!transform.any_op) -> !transform.any_op
+# CHECK-NEXT:      %tiled_linalg_op, %loops = transform.structured.tile_using_for %0 tile_sizes [0, 16, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      transform.annotate %loops "C/j" : !transform.any_op
+# CHECK-NEXT:      %tiled_linalg_op_0, %loops_1 = transform.structured.tile_using_for %tiled_linalg_op tile_sizes [0, 0, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      transform.annotate %loops_1 "C/k" : !transform.any_op
+# CHECK-NEXT:      %tiled_linalg_op_2, %loops_3 = transform.structured.tile_using_for %tiled_linalg_op_0 tile_sizes [0, 4, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      transform.annotate %loops_3 "C/j0" : !transform.any_op
+# CHECK-NEXT:      %1 = transform.structured.split %tiled_linalg_op_2 after 4  {dimension = 0 : i64} : !transform.any_op
+# CHECK-NEXT:      %2:2 = transform.split_handle %1 {fail_on_payload_too_small = false} : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      %tiled_linalg_op_4, %loops_5 = transform.structured.tile_using_for %2#0 tile_sizes [2, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      transform.annotate %loops_5 "C/i[0]/i" : !transform.any_op
+# CHECK-NEXT:      %tiled_linalg_op_6, %loops_7 = transform.structured.tile_using_for %tiled_linalg_op_4 tile_sizes [1, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      transform.annotate %loops_7 "C/i[0]/i0" : !transform.any_op
+# CHECK-NEXT:      transform.include @_vecto failures(suppress) (%tiled_linalg_op_6) : (!transform.any_op) -> ()
+# CHECK-NEXT:      transform.loop.unroll %loops_7 {factor = 2 : i64} : !transform.any_op
+# CHECK-NEXT:      %tiled_linalg_op_8, %loops_9 = transform.structured.tile_using_for %2#1 tile_sizes [4, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      transform.annotate %loops_9 "C/i[1]/i" : !transform.any_op
+# CHECK-NEXT:      %tiled_linalg_op_10, %loops_11 = transform.structured.tile_using_for %tiled_linalg_op_8 tile_sizes [1, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      transform.annotate %loops_11 "C/i[1]/i0" : !transform.any_op
+# CHECK-NEXT:      transform.include @_vecto failures(suppress) (%tiled_linalg_op_10) : (!transform.any_op) -> ()
+# CHECK-NEXT:      transform.loop.unroll %loops_11 {factor = 4 : i64} : !transform.any_op
+# CHECK-NEXT:      %3 = transform.get_parent_op %loops {isolated_from_above} : (!transform.any_op) -> !transform.any_op
+# CHECK-NEXT:      transform.apply_patterns to %3 {
+# CHECK-NEXT:        transform.apply_patterns.vector.reduction_to_contract
+# CHECK-NEXT:        transform.apply_patterns.vector.transfer_permutation_patterns
+# CHECK-NEXT:      } : !transform.any_op
+# CHECK-NEXT:      transform.apply_patterns to %3 {
+# CHECK-NEXT:        transform.apply_patterns.vector.lower_outerproduct
+# CHECK-NEXT:        transform.apply_patterns.vector.lower_contraction
+# CHECK-NEXT:      } : !transform.any_op
+# CHECK-NEXT:      transform.yield 
+# CHECK-NEXT:    }
+# CHECK-NEXT:  }
+# CHECK-NEXT:  
+# CHECK-NEXT:  // -----// IR Dump After transform //----- //
+# CHECK-NEXT:  module attributes {transform.with_named_sequence} {
+# CHECK-NEXT:    func.func @matmul(%arg0: memref<16x512xf32> {llvm.noalias}, %arg1: memref<512x32xf32> {llvm.noalias}, %arg2: memref<16x32xf32> {llvm.noalias}) {
+# CHECK-NEXT:      %cst = arith.constant dense<0.000000e+00> : vector<1x4xf32>
+# CHECK-NEXT:      %c3 = arith.constant 3 : index
+# CHECK-NEXT:      %c12 = arith.constant 12 : index
+# CHECK-NEXT:      %0 = ub.poison : f32
+# CHECK-NEXT:      %c2 = arith.constant 2 : index
+# CHECK-NEXT:      %c4 = arith.constant 4 : index
+# CHECK-NEXT:      %c1 = arith.constant 1 : index
+# CHECK-NEXT:      %c512 = arith.constant 512 : index
+# CHECK-NEXT:      %c16 = arith.constant 16 : index
+# CHECK-NEXT:      %c32 = arith.constant 32 : index
+# CHECK-NEXT:      %c0 = arith.constant 0 : index
+# CHECK-NEXT:      %cst_0 = arith.constant 0.000000e+00 : f32
+# CHECK-NEXT:      linalg.fill {__xtc_id_C_0_} ins(%cst_0 : f32) outs(%arg2 : memref<16x32xf32>)
+# CHECK-NEXT:      scf.for %arg3 = %c0 to %c32 step %c16 {
+# CHECK-NEXT:        %subview = memref.subview %arg0[0, 0] [16, 512] [1, 1] : memref<16x512xf32> to memref<16x512xf32, strided<[512, 1]>>
+# CHECK-NEXT:        %subview_1 = memref.subview %arg1[0, %arg3] [512, 16] [1, 1] : memref<512x32xf32> to memref<512x16xf32, strided<[32, 1], offset: ?>>
+# CHECK-NEXT:        %subview_2 = memref.subview %arg2[0, %arg3] [16, 16] [1, 1] : memref<16x32xf32> to memref<16x16xf32, strided<[32, 1], offset: ?>>
+# CHECK-NEXT:        scf.for %arg4 = %c0 to %c512 step %c1 {
+# CHECK-NEXT:          %subview_3 = memref.subview %subview[0, %arg4] [16, 1] [1, 1] : memref<16x512xf32, strided<[512, 1]>> to memref<16x1xf32, strided<[512, 1], offset: ?>>
+# CHECK-NEXT:          %subview_4 = memref.subview %subview_1[%arg4, 0] [1, 16] [1, 1] : memref<512x16xf32, strided<[32, 1], offset: ?>> to memref<1x16xf32, strided<[32, 1], offset: ?>>
+# CHECK-NEXT:          scf.for %arg5 = %c0 to %c16 step %c4 {
+# CHECK-NEXT:            %subview_5 = memref.subview %subview_4[0, %arg5] [1, 4] [1, 1] : memref<1x16xf32, strided<[32, 1], offset: ?>> to memref<1x4xf32, strided<[32, 1], offset: ?>>
+# CHECK-NEXT:            %subview_6 = memref.subview %subview_2[0, %arg5] [16, 4] [1, 1] : memref<16x16xf32, strided<[32, 1], offset: ?>> to memref<16x4xf32, strided<[32, 1], offset: ?>>
+# CHECK-NEXT:            %subview_7 = memref.subview %subview_3[0, 0] [4, 1] [1, 1] : memref<16x1xf32, strided<[512, 1], offset: ?>> to memref<4x1xf32, strided<[512, 1], offset: ?>>
+# CHECK-NEXT:            %subview_8 = memref.subview %subview_6[0, 0] [4, 4] [1, 1] : memref<16x4xf32, strided<[32, 1], offset: ?>> to memref<4x4xf32, strided<[32, 1], offset: ?>>
+# CHECK-NEXT:            scf.for %arg6 = %c0 to %c4 step %c2 {
+# CHECK-NEXT:              %subview_11 = memref.subview %subview_7[%arg6, 0] [2, 1] [1, 1] : memref<4x1xf32, strided<[512, 1], offset: ?>> to memref<2x1xf32, strided<[512, 1], offset: ?>>
+# CHECK-NEXT:              %subview_12 = memref.subview %subview_8[%arg6, 0] [2, 4] [1, 1] : memref<4x4xf32, strided<[32, 1], offset: ?>> to memref<2x4xf32, strided<[32, 1], offset: ?>>
+# CHECK-NEXT:              %subview_13 = memref.subview %subview_11[%c0, 0] [1, 1] [1, 1] : memref<2x1xf32, strided<[512, 1], offset: ?>> to memref<1x1xf32, strided<[512, 1], offset: ?>>
+# CHECK-NEXT:              %subview_14 = memref.subview %subview_12[%c0, 0] [1, 4] [1, 1] : memref<2x4xf32, strided<[32, 1], offset: ?>> to memref<1x4xf32, strided<[32, 1], offset: ?>>
+# CHECK-NEXT:              %1 = vector.transfer_read %subview_13[%c0, %c0], %0 {in_bounds = [true, true]} : memref<1x1xf32, strided<[512, 1], offset: ?>>, vector<1x1xf32>
+# CHECK-NEXT:              %2 = vector.transfer_read %subview_5[%c0, %c0], %0 {in_bounds = [true, true]} : memref<1x4xf32, strided<[32, 1], offset: ?>>, vector<1x4xf32>
+# CHECK-NEXT:              %3 = vector.transfer_read %subview_14[%c0, %c0], %0 {in_bounds = [true, true]} : memref<1x4xf32, strided<[32, 1], offset: ?>>, vector<1x4xf32>
+# CHECK-NEXT:              %4 = vector.extract %2[0] : vector<4xf32> from vector<1x4xf32>
+# CHECK-NEXT:              %5 = vector.extract %1[0, 0] : f32 from vector<1x1xf32>
+# CHECK-NEXT:              %6 = vector.broadcast %5 : f32 to vector<4xf32>
+# CHECK-NEXT:              %7 = vector.extract %3[0] : vector<4xf32> from vector<1x4xf32>
+# CHECK-NEXT:              %8 = vector.fma %6, %4, %7 : vector<4xf32>
+# CHECK-NEXT:              %9 = vector.insert %8, %cst [0] : vector<4xf32> into vector<1x4xf32>
+# CHECK-NEXT:              vector.transfer_write %9, %subview_14[%c0, %c0] {in_bounds = [true, true]} : vector<1x4xf32>, memref<1x4xf32, strided<[32, 1], offset: ?>>
+# CHECK-NEXT:              %subview_15 = memref.subview %subview_11[%c1, 0] [1, 1] [1, 1] : memref<2x1xf32, strided<[512, 1], offset: ?>> to memref<1x1xf32, strided<[512, 1], offset: ?>>
+# CHECK-NEXT:              %subview_16 = memref.subview %subview_12[%c1, 0] [1, 4] [1, 1] : memref<2x4xf32, strided<[32, 1], offset: ?>> to memref<1x4xf32, strided<[32, 1], offset: ?>>
+# CHECK-NEXT:              %10 = vector.transfer_read %subview_15[%c0, %c0], %0 {in_bounds = [true, true]} : memref<1x1xf32, strided<[512, 1], offset: ?>>, vector<1x1xf32>
+# CHECK-NEXT:              %11 = vector.transfer_read %subview_5[%c0, %c0], %0 {in_bounds = [true, true]} : memref<1x4xf32, strided<[32, 1], offset: ?>>, vector<1x4xf32>
+# CHECK-NEXT:              %12 = vector.transfer_read %subview_16[%c0, %c0], %0 {in_bounds = [true, true]} : memref<1x4xf32, strided<[32, 1], offset: ?>>, vector<1x4xf32>
+# CHECK-NEXT:              %13 = vector.extract %11[0] : vector<4xf32> from vector<1x4xf32>
+# CHECK-NEXT:              %14 = vector.extract %10[0, 0] : f32 from vector<1x1xf32>
+# CHECK-NEXT:              %15 = vector.broadcast %14 : f32 to vector<4xf32>
+# CHECK-NEXT:              %16 = vector.extract %12[0] : vector<4xf32> from vector<1x4xf32>
+# CHECK-NEXT:              %17 = vector.fma %15, %13, %16 : vector<4xf32>
+# CHECK-NEXT:              %18 = vector.insert %17, %cst [0] : vector<4xf32> into vector<1x4xf32>
+# CHECK-NEXT:              vector.transfer_write %18, %subview_16[%c0, %c0] {in_bounds = [true, true]} : vector<1x4xf32>, memref<1x4xf32, strided<[32, 1], offset: ?>>
+# CHECK-NEXT:            } {"C/i[0]/i"}
+# CHECK-NEXT:            %subview_9 = memref.subview %subview_3[4, 0] [12, 1] [1, 1] : memref<16x1xf32, strided<[512, 1], offset: ?>> to memref<12x1xf32, strided<[512, 1], offset: ?>>
+# CHECK-NEXT:            %subview_10 = memref.subview %subview_6[4, 0] [12, 4] [1, 1] : memref<16x4xf32, strided<[32, 1], offset: ?>> to memref<12x4xf32, strided<[32, 1], offset: ?>>
+# CHECK-NEXT:            scf.for %arg6 = %c0 to %c12 step %c4 {
+# CHECK-NEXT:              %subview_11 = memref.subview %subview_9[%arg6, 0] [4, 1] [1, 1] : memref<12x1xf32, strided<[512, 1], offset: ?>> to memref<4x1xf32, strided<[512, 1], offset: ?>>
+# CHECK-NEXT:              %subview_12 = memref.subview %subview_10[%arg6, 0] [4, 4] [1, 1] : memref<12x4xf32, strided<[32, 1], offset: ?>> to memref<4x4xf32, strided<[32, 1], offset: ?>>
+# CHECK-NEXT:              %subview_13 = memref.subview %subview_11[%c0, 0] [1, 1] [1, 1] : memref<4x1xf32, strided<[512, 1], offset: ?>> to memref<1x1xf32, strided<[512, 1], offset: ?>>
+# CHECK-NEXT:              %subview_14 = memref.subview %subview_12[%c0, 0] [1, 4] [1, 1] : memref<4x4xf32, strided<[32, 1], offset: ?>> to memref<1x4xf32, strided<[32, 1], offset: ?>>
+# CHECK-NEXT:              %1 = vector.transfer_read %subview_13[%c0, %c0], %0 {in_bounds = [true, true]} : memref<1x1xf32, strided<[512, 1], offset: ?>>, vector<1x1xf32>
+# CHECK-NEXT:              %2 = vector.transfer_read %subview_5[%c0, %c0], %0 {in_bounds = [true, true]} : memref<1x4xf32, strided<[32, 1], offset: ?>>, vector<1x4xf32>
+# CHECK-NEXT:              %3 = vector.transfer_read %subview_14[%c0, %c0], %0 {in_bounds = [true, true]} : memref<1x4xf32, strided<[32, 1], offset: ?>>, vector<1x4xf32>
+# CHECK-NEXT:              %4 = vector.extract %2[0] : vector<4xf32> from vector<1x4xf32>
+# CHECK-NEXT:              %5 = vector.extract %1[0, 0] : f32 from vector<1x1xf32>
+# CHECK-NEXT:              %6 = vector.broadcast %5 : f32 to vector<4xf32>
+# CHECK-NEXT:              %7 = vector.extract %3[0] : vector<4xf32> from vector<1x4xf32>
+# CHECK-NEXT:              %8 = vector.fma %6, %4, %7 : vector<4xf32>
+# CHECK-NEXT:              %9 = vector.insert %8, %cst [0] : vector<4xf32> into vector<1x4xf32>
+# CHECK-NEXT:              vector.transfer_write %9, %subview_14[%c0, %c0] {in_bounds = [true, true]} : vector<1x4xf32>, memref<1x4xf32, strided<[32, 1], offset: ?>>
+# CHECK-NEXT:              %subview_15 = memref.subview %subview_11[%c1, 0] [1, 1] [1, 1] : memref<4x1xf32, strided<[512, 1], offset: ?>> to memref<1x1xf32, strided<[512, 1], offset: ?>>
+# CHECK-NEXT:              %subview_16 = memref.subview %subview_12[%c1, 0] [1, 4] [1, 1] : memref<4x4xf32, strided<[32, 1], offset: ?>> to memref<1x4xf32, strided<[32, 1], offset: ?>>
+# CHECK-NEXT:              %10 = vector.transfer_read %subview_15[%c0, %c0], %0 {in_bounds = [true, true]} : memref<1x1xf32, strided<[512, 1], offset: ?>>, vector<1x1xf32>
+# CHECK-NEXT:              %11 = vector.transfer_read %subview_5[%c0, %c0], %0 {in_bounds = [true, true]} : memref<1x4xf32, strided<[32, 1], offset: ?>>, vector<1x4xf32>
+# CHECK-NEXT:              %12 = vector.transfer_read %subview_16[%c0, %c0], %0 {in_bounds = [true, true]} : memref<1x4xf32, strided<[32, 1], offset: ?>>, vector<1x4xf32>
+# CHECK-NEXT:              %13 = vector.extract %11[0] : vector<4xf32> from vector<1x4xf32>
+# CHECK-NEXT:              %14 = vector.extract %10[0, 0] : f32 from vector<1x1xf32>
+# CHECK-NEXT:              %15 = vector.broadcast %14 : f32 to vector<4xf32>
+# CHECK-NEXT:              %16 = vector.extract %12[0] : vector<4xf32> from vector<1x4xf32>
+# CHECK-NEXT:              %17 = vector.fma %15, %13, %16 : vector<4xf32>
+# CHECK-NEXT:              %18 = vector.insert %17, %cst [0] : vector<4xf32> into vector<1x4xf32>
+# CHECK-NEXT:              vector.transfer_write %18, %subview_16[%c0, %c0] {in_bounds = [true, true]} : vector<1x4xf32>, memref<1x4xf32, strided<[32, 1], offset: ?>>
+# CHECK-NEXT:              %subview_17 = memref.subview %subview_11[%c2, 0] [1, 1] [1, 1] : memref<4x1xf32, strided<[512, 1], offset: ?>> to memref<1x1xf32, strided<[512, 1], offset: ?>>
+# CHECK-NEXT:              %subview_18 = memref.subview %subview_12[%c2, 0] [1, 4] [1, 1] : memref<4x4xf32, strided<[32, 1], offset: ?>> to memref<1x4xf32, strided<[32, 1], offset: ?>>
+# CHECK-NEXT:              %19 = vector.transfer_read %subview_17[%c0, %c0], %0 {in_bounds = [true, true]} : memref<1x1xf32, strided<[512, 1], offset: ?>>, vector<1x1xf32>
+# CHECK-NEXT:              %20 = vector.transfer_read %subview_5[%c0, %c0], %0 {in_bounds = [true, true]} : memref<1x4xf32, strided<[32, 1], offset: ?>>, vector<1x4xf32>
+# CHECK-NEXT:              %21 = vector.transfer_read %subview_18[%c0, %c0], %0 {in_bounds = [true, true]} : memref<1x4xf32, strided<[32, 1], offset: ?>>, vector<1x4xf32>
+# CHECK-NEXT:              %22 = vector.extract %20[0] : vector<4xf32> from vector<1x4xf32>
+# CHECK-NEXT:              %23 = vector.extract %19[0, 0] : f32 from vector<1x1xf32>
+# CHECK-NEXT:              %24 = vector.broadcast %23 : f32 to vector<4xf32>
+# CHECK-NEXT:              %25 = vector.extract %21[0] : vector<4xf32> from vector<1x4xf32>
+# CHECK-NEXT:              %26 = vector.fma %24, %22, %25 : vector<4xf32>
+# CHECK-NEXT:              %27 = vector.insert %26, %cst [0] : vector<4xf32> into vector<1x4xf32>
+# CHECK-NEXT:              vector.transfer_write %27, %subview_18[%c0, %c0] {in_bounds = [true, true]} : vector<1x4xf32>, memref<1x4xf32, strided<[32, 1], offset: ?>>
+# CHECK-NEXT:              %subview_19 = memref.subview %subview_11[%c3, 0] [1, 1] [1, 1] : memref<4x1xf32, strided<[512, 1], offset: ?>> to memref<1x1xf32, strided<[512, 1], offset: ?>>
+# CHECK-NEXT:              %subview_20 = memref.subview %subview_12[%c3, 0] [1, 4] [1, 1] : memref<4x4xf32, strided<[32, 1], offset: ?>> to memref<1x4xf32, strided<[32, 1], offset: ?>>
+# CHECK-NEXT:              %28 = vector.transfer_read %subview_19[%c0, %c0], %0 {in_bounds = [true, true]} : memref<1x1xf32, strided<[512, 1], offset: ?>>, vector<1x1xf32>
+# CHECK-NEXT:              %29 = vector.transfer_read %subview_5[%c0, %c0], %0 {in_bounds = [true, true]} : memref<1x4xf32, strided<[32, 1], offset: ?>>, vector<1x4xf32>
+# CHECK-NEXT:              %30 = vector.transfer_read %subview_20[%c0, %c0], %0 {in_bounds = [true, true]} : memref<1x4xf32, strided<[32, 1], offset: ?>>, vector<1x4xf32>
+# CHECK-NEXT:              %31 = vector.extract %29[0] : vector<4xf32> from vector<1x4xf32>
+# CHECK-NEXT:              %32 = vector.extract %28[0, 0] : f32 from vector<1x1xf32>
+# CHECK-NEXT:              %33 = vector.broadcast %32 : f32 to vector<4xf32>
+# CHECK-NEXT:              %34 = vector.extract %30[0] : vector<4xf32> from vector<1x4xf32>
+# CHECK-NEXT:              %35 = vector.fma %33, %31, %34 : vector<4xf32>
+# CHECK-NEXT:              %36 = vector.insert %35, %cst [0] : vector<4xf32> into vector<1x4xf32>
+# CHECK-NEXT:              vector.transfer_write %36, %subview_20[%c0, %c0] {in_bounds = [true, true]} : vector<1x4xf32>, memref<1x4xf32, strided<[32, 1], offset: ?>>
+# CHECK-NEXT:            } {"C/i[1]/i"}
+# CHECK-NEXT:          } {"C/j0"}
+# CHECK-NEXT:        } {"C/k"}
+# CHECK-NEXT:      } {"C/j"}
+# CHECK-NEXT:      return
+# CHECK-NEXT:    }
+# CHECK-NEXT:  }
+# CHECK-NEXT:  
+# CHECK-NEXT:  graph:
+# CHECK-NEXT:    name: matmul
+# CHECK-NEXT:    inputs:
+# CHECK-NEXT:    - %0 : 16x512xfloat32
+# CHECK-NEXT:    - %1 : 512x32xfloat32
+# CHECK-NEXT:    outputs:
+# CHECK-NEXT:    - %2 : 16x32xfloat32
+# CHECK-NEXT:    nodes:
+# CHECK-NEXT:    - %2: matmul(%0, %1) {name = 'C'} : [16x512xfloat32, 512x32xfloat32] -> [16x32xfloat32]
+# CHECK-NEXT:  
+# CHECK-NEXT:  CODE: 0

--- a/tests/filecheck/schedules/test_matmul_descript_mlir.py
+++ b/tests/filecheck/schedules/test_matmul_descript_mlir.py
@@ -56,28 +56,23 @@ print(f"CODE: {res}")
 # CHECK-NEXT:      transform.yield 
 # CHECK-NEXT:    }
 # CHECK-NEXT:    transform.named_sequence @__transform_main(%arg0: !transform.any_op {transform.readonly}) {
-# CHECK-NEXT:      %0 = transform.structured.match attributes {__xtc_id_C_0_} in %arg0 : (!transform.any_op) -> !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op, %loops = transform.structured.tile_using_for %0 tile_sizes [1, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops "./i" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_0, %loops_1 = transform.structured.tile_using_for %tiled_linalg_op tile_sizes [0, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_1 "./j" : !transform.any_op
-# CHECK-NEXT:      %1 = transform.structured.match attributes {__xtc_id_C_} in %arg0 : (!transform.any_op) -> !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_2, %loops_3 = transform.structured.tile_using_for %1 tile_sizes [0, 0, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_3 "C/K" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_4, %loops_5 = transform.structured.tile_using_for %tiled_linalg_op_2 tile_sizes [2, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_5 "C/I" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_6, %loops_7 = transform.structured.tile_using_for %tiled_linalg_op_4 tile_sizes [0, 16, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_7 "C/J" : !transform.any_op
-# CHECK-NEXT:      %tiled_linalg_op_8, %loops_9 = transform.structured.tile_using_for %tiled_linalg_op_6 tile_sizes [1, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-# CHECK-NEXT:      transform.annotate %loops_9 "C/I0" : !transform.any_op
-# CHECK-NEXT:      transform.include @_vecto failures(suppress) (%tiled_linalg_op_8) : (!transform.any_op) -> ()
-# CHECK-NEXT:      transform.loop.unroll %loops_9 {factor = 2 : i64} : !transform.any_op
-# CHECK-NEXT:      %2 = transform.get_parent_op %loops_3 {isolated_from_above} : (!transform.any_op) -> !transform.any_op
-# CHECK-NEXT:      transform.apply_patterns to %2 {
+# CHECK-NEXT:      %0 = transform.structured.match attributes {__xtc_id_C_} in %arg0 : (!transform.any_op) -> !transform.any_op
+# CHECK-NEXT:      %tiled_linalg_op, %loops = transform.structured.tile_using_for %0 tile_sizes [0, 0, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      transform.annotate %loops "C/K" : !transform.any_op
+# CHECK-NEXT:      %tiled_linalg_op_0, %loops_1 = transform.structured.tile_using_for %tiled_linalg_op tile_sizes [2, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      transform.annotate %loops_1 "C/I" : !transform.any_op
+# CHECK-NEXT:      %tiled_linalg_op_2, %loops_3 = transform.structured.tile_using_for %tiled_linalg_op_0 tile_sizes [0, 16, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      transform.annotate %loops_3 "C/J" : !transform.any_op
+# CHECK-NEXT:      %tiled_linalg_op_4, %loops_5 = transform.structured.tile_using_for %tiled_linalg_op_2 tile_sizes [1, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      transform.annotate %loops_5 "C/I0" : !transform.any_op
+# CHECK-NEXT:      transform.include @_vecto failures(suppress) (%tiled_linalg_op_4) : (!transform.any_op) -> ()
+# CHECK-NEXT:      transform.loop.unroll %loops_5 {factor = 2 : i64} : !transform.any_op
+# CHECK-NEXT:      %1 = transform.get_parent_op %loops {isolated_from_above} : (!transform.any_op) -> !transform.any_op
+# CHECK-NEXT:      transform.apply_patterns to %1 {
 # CHECK-NEXT:        transform.apply_patterns.vector.reduction_to_contract
 # CHECK-NEXT:        transform.apply_patterns.vector.transfer_permutation_patterns
 # CHECK-NEXT:      } : !transform.any_op
-# CHECK-NEXT:      transform.apply_patterns to %2 {
+# CHECK-NEXT:      transform.apply_patterns to %1 {
 # CHECK-NEXT:        transform.apply_patterns.vector.lower_outerproduct
 # CHECK-NEXT:        transform.apply_patterns.vector.lower_contraction
 # CHECK-NEXT:      } : !transform.any_op
@@ -91,20 +86,14 @@ print(f"CODE: {res}")
 # CHECK-NEXT:      %cst = arith.constant dense<0.000000e+00> : vector<1x16xf32>
 # CHECK-NEXT:      %0 = ub.poison : f32
 # CHECK-NEXT:      %c16 = arith.constant 16 : index
-# CHECK-NEXT:      %c2 = arith.constant 2 : index
-# CHECK-NEXT:      %c512 = arith.constant 512 : index
 # CHECK-NEXT:      %c32 = arith.constant 32 : index
-# CHECK-NEXT:      %cst_0 = arith.constant 0.000000e+00 : f32
-# CHECK-NEXT:      %c0 = arith.constant 0 : index
+# CHECK-NEXT:      %c2 = arith.constant 2 : index
 # CHECK-NEXT:      %c4 = arith.constant 4 : index
 # CHECK-NEXT:      %c1 = arith.constant 1 : index
-# CHECK-NEXT:      scf.for %arg3 = %c0 to %c4 step %c1 {
-# CHECK-NEXT:        %subview = memref.subview %arg2[%arg3, 0] [1, 32] [1, 1] : memref<4x32xf32> to memref<1x32xf32, strided<[32, 1], offset: ?>>
-# CHECK-NEXT:        scf.for %arg4 = %c0 to %c32 step %c1 {
-# CHECK-NEXT:          %subview_1 = memref.subview %subview[0, %arg4] [1, 1] [1, 1] : memref<1x32xf32, strided<[32, 1], offset: ?>> to memref<1x1xf32, strided<[32, 1], offset: ?>>
-# CHECK-NEXT:          linalg.fill {__xtc_id_C_0_} ins(%cst_0 : f32) outs(%subview_1 : memref<1x1xf32, strided<[32, 1], offset: ?>>)
-# CHECK-NEXT:        } {"./j"}
-# CHECK-NEXT:      } {"./i"}
+# CHECK-NEXT:      %c512 = arith.constant 512 : index
+# CHECK-NEXT:      %c0 = arith.constant 0 : index
+# CHECK-NEXT:      %cst_0 = arith.constant 0.000000e+00 : f32
+# CHECK-NEXT:      linalg.fill {__xtc_id_C_0_} ins(%cst_0 : f32) outs(%arg2 : memref<4x32xf32>)
 # CHECK-NEXT:      scf.for %arg3 = %c0 to %c512 step %c1 {
 # CHECK-NEXT:        %subview = memref.subview %arg0[0, %arg3] [4, 1] [1, 1] : memref<4x512xf32> to memref<4x1xf32, strided<[512, 1], offset: ?>>
 # CHECK-NEXT:        %subview_1 = memref.subview %arg1[%arg3, 0] [1, 32] [1, 1] : memref<512x32xf32> to memref<1x32xf32, strided<[32, 1], offset: ?>>


### PR DESCRIPTION
Do not schedule the initialization operation linalg.fill, which is not controllable by the user. 

# Motivation

The default schedule applied can overconstraint lowering passes trying to fuse/optimize it.

# Description

Based on the naming convention of Mlir nodes, skip the scheduling of the node corresponding to the linalg.fill.

# Commits

Single commit

# Discussion

What do you think ?
