### PR TITLE
mlir: updated extra-tools version

### DIFF
--- a/mlir_requirements.txt
+++ b/mlir_requirements.txt
@@ -1,4 +1,4 @@
 xtc-llvm-tools==21.1.2.6
 xtc-mlir-tools==21.1.2.7
 xtc-mlir-python-bindings==21.1.2.7
-xtc-mlir-extra-tools==21.1.2.7
+xtc-mlir-extra-tools==21.1.2.9


### PR DESCRIPTION
## Motivation

This new version adds to the emitc backend to support bools and partial dynamic dims. The bools are needed for padding in the tensor dialect with C target.
