### PR TITLE
docs: added loop explore marimo tutorial

### DIFF
--- a/docs/tutorials/cli_tools.md
+++ b/docs/tutorials/cli_tools.md
@@ -109,3 +109,35 @@ func.func @myfun(
 Under the hood, this declarative "loop" attributes dialect is
 translated into the corresponding MLIR ```transform``` dialect
 command sequence through XTC API calls.
+
+## Iterative Search
+
+An iterative search can take advantage of a model to try to learn better tile sizes as loop explore is ran.
+Setting the batch determines the number of guesses the model has per iteration.
+
+    loop-explore --search iterative --batch 5 --trials 100 --strategy tile_goto --output results.random.csv
+
+You can specify an optimizer preset to determine how aggressive the model converges.
+
+    loop-explore --backends mlir --batch 5 --search iterative --optimizer random-forest-explore --operator conv2d --op-name AlexNet_02 --strategy tile_ppwrprp_vr --output output.csv
+
+To specify your own model parameters you can pass a yaml file.
+
+For example lets say you have config.yaml containing:
+
+```
+batch_candidates: 5000
+beta: 2.5
+alpha: 0.7
+update_first: null
+update_period: null
+n_estimators: 300
+max_depth: 10
+min_samples_leaf: 4
+max_features: 0.8
+```
+
+You can use those parameters to set the model behavior
+
+    loop-explore --backends mlir --batch 5 --search iterative --optimizer-config config.yaml --strategy tile_goto --output output.csv
+

--- a/docs/tutorials/explore_optimizers.py
+++ b/docs/tutorials/explore_optimizers.py
@@ -1,0 +1,325 @@
+import marimo
+
+__generated_with = "0.19.6"
+app = marimo.App(width="medium")
+
+
+@app.cell
+def _():
+    import marimo as mo
+    import subprocess
+    from pathlib import Path
+    import numpy as np
+    import random
+    import xtc.cli.explore as explore
+    OPERATORS = explore.OPERATORS
+    STRATEGIES_ALIASES = explore.STRATEGIES_ALIASES
+    return OPERATORS, STRATEGIES_ALIASES, explore, mo, np, random
+
+
+@app.cell
+def _(OPERATORS, explore, np, random):
+    import multiprocessing
+
+    class Args:
+        def __init__(self, **overrides):
+            self.operator = "matmul"
+            self.op_name = None
+            self.ops_list = False
+            self.func_name = None
+            self.strategy = None
+            self.search = "random"
+            self.backends = ["mlir"]
+            self.optimizer = "random-forest-default"
+            self.data = None
+            self.dims = None
+            self.huge_pages = True
+            self.test = []
+            self.opt_level = 4
+            self.dtype = None
+            self.trials = 100
+            self.threads = 1
+            self.max_unroll = 512
+            self.seed = 0
+            self.output = "results.csv"
+            self.resume = False
+            self.append = False
+            self.eval = "eval"
+            self.repeat = 1
+            self.number = 1
+            self.min_repeat_ms = 100
+            self.validate = None
+            self.save_temps = None
+            self.save_temps_dir = "./save_temps_dir"
+            self.explore_dir = "."
+            self.optimizer_config = None
+            self.child = True
+            self.bare_ptr = False
+            self.jobs = max(1, multiprocessing.cpu_count() // 2)
+            self.execute = True
+            self.peak_flops = None
+            self.mlir_prefix = None
+            self.batch = 1
+            self.debug = None
+            self.debug_compile = None
+            self.debug_xtc = None
+            self.debug_optimizer = None
+            self.quiet = None
+            self.dump = None
+
+            self.__dict__.update(overrides)
+
+            if not self.func_name:
+                self.func_name = self.operator
+
+            if not self.strategy:
+                self.strategy = OPERATORS[self.operator]["default_strategy"]
+
+            if not self.dims:
+                self.dims = OPERATORS[self.operator]["default_dims"]
+
+            if not self.dtype:
+                self.dtype = OPERATORS[self.operator]["default_type"]
+
+            if self.op_name:
+                self.dims = explore.get_operation_dims(self.operator, self.op_name)
+
+            # backend validation
+            for backend in self.backends:
+                assert backend in OPERATORS[self.operator]["backends"], (
+                    f"backend {backend} not available for operator {self.operator}"
+                )
+
+            if self.seed >= 0:
+                np.random.seed(self.seed)
+                random.seed(self.seed)
+
+            explore.setup_args(self)
+    return (Args,)
+
+
+@app.cell
+def _(STRATEGIES_ALIASES, mo):
+    from xtc.artifacts import list_operations 
+    from xtc.search.strategies import Strategies
+    from xtc.search.optimizers import Optimizers
+
+    operators = ["matmul","conv2d"]
+    backends = ["mlir","tvm","jir"]
+    strategies = list(STRATEGIES_ALIASES.keys()) + list(Strategies.names()) 
+    backend_ui = mo.ui.multiselect(options=backends,value=["mlir"],label="backends:")
+    operator_ui = mo.ui.radio(options=operators,value="matmul",label="operator:")
+    def op_names(operator):
+        ops_list = [op[1] for op in list_operations(operator)]
+        return mo.ui.dropdown(
+            options = ops_list,
+            value=ops_list[0],
+            label="operator name:",
+        )
+    strategy_ui = mo.ui.dropdown(
+        options=strategies,
+        value=strategies[-1],
+        label="strategy:"
+    )
+    seed_ui = mo.ui.number(start=0,stop=200,label="seed:")
+    trials_ui = mo.ui.number(start=0,stop=5000,value=100,label="trials:")
+
+    search_types = ["random","iterative","exhaustive"]
+    search_select = mo.ui.radio(search_types,value=search_types[0],label="search:")
+    batch_ui = mo.ui.number(start=1,stop=50,value=5,label="batch size:")
+
+
+
+    def presets_to_marimo(presets, batch_size):
+        widgets = {}
+        for key, value in presets.items():
+            # cheesy fallback
+            if value is None:
+                value = batch_size
+
+            if isinstance(value, int):
+                widgets[key] = mo.ui.number(value=value, step=1)
+            elif isinstance(value, float):
+                widgets[key] = mo.ui.number(value=value, step=0.1)
+            else:
+                raise TypeError(f"Unsupported type: {type(value)}")
+        return mo.ui.dictionary(widgets)
+
+    opt_names = Optimizers.names()
+    opt_presets = {name: dict(Optimizers.from_name(name).PRESET) if hasattr(Optimizers.from_name(name),"PRESET") else None for name in opt_names}
+    def get_optimizer_config_ui(opt_name, batch_size):
+        print(opt_name)
+        if opt_presets[opt_name] == None:
+            return mo.md("")
+        # have a temp config file with the dict contents 
+        ui = presets_to_marimo(opt_presets[opt_name], batch_size)
+        print("hello")
+        return ui
+
+    optimizer_ui = mo.ui.radio(options=opt_names,value=opt_names[0],label="model type:")
+    return (
+        backend_ui,
+        batch_ui,
+        get_optimizer_config_ui,
+        op_names,
+        operator_ui,
+        optimizer_ui,
+        search_select,
+        seed_ui,
+        strategy_ui,
+        trials_ui,
+    )
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md(r"""
+    ## Loop Explore
+
+    This is an exploration script that attempts to find good parameterizations of select tiling strategies using autotuning. For each operator you can choose the problem size from operators in specific models.
+    """)
+    return
+
+
+@app.cell
+def _(
+    backend_ui,
+    batch_ui,
+    get_optimizer_config_ui,
+    mo,
+    op_names,
+    operator_ui,
+    optimizer_ui,
+    search_select,
+    seed_ui,
+    strategy_ui,
+    trials_ui,
+):
+    search_ui = [search_select]
+    optimizer_config_ui = mo.md("")
+    if search_select.value == "iterative":
+        #search_ui += [mo.vstack([batch_ui,optimizer_ui]), optimizer_config_ui(optimizer_ui.value, batch_ui.value)]
+        optimizer_config_ui = get_optimizer_config_ui(optimizer_ui.value, batch_ui.value)
+        search_ui += [mo.vstack([batch_ui,optimizer_ui]), optimizer_config_ui]
+
+    vstack_elements = [backend_ui,operator_ui, op_names(operator_ui.value),strategy_ui,trials_ui,seed_ui]
+    mo.vstack(vstack_elements, justify="start")
+    return optimizer_config_ui, search_ui
+
+
+@app.cell
+def _(mo):
+    mo.md(r"""
+    Select a search strategy. For iterative searches you have the option to pick a preset and tweak the hyperparameters.
+    """)
+    return
+
+
+@app.cell
+def _(mo, search_ui):
+    mo.hstack(search_ui,widths="equal",justify="start")
+    return
+
+
+@app.cell
+def _(
+    Args,
+    backend_ui,
+    batch_ui,
+    explore,
+    operator_ui,
+    optimizer_config_ui,
+    optimizer_ui,
+    search_select,
+    seed_ui,
+    strategy_ui,
+    trials_ui,
+):
+    import tempfile
+    import os
+    import csv
+    import yaml
+
+    def extract_config_yaml_from_ui(tmpdir, ui, filename="config.yaml"):
+        if not (hasattr(ui, "value") and isinstance(ui.value, dict)):
+            return None
+        config = ui.value
+        path = os.path.join(tmpdir, filename)
+        with open(path, "w") as f:
+            yaml.dump(config, f, default_flow_style=False, sort_keys=False)
+        return path
+
+    def config_used(ui):
+        pass
+
+    def set_explore_args(config_path):
+        args = Args(
+            operator = operator_ui.value,
+            backends = backend_ui.value,
+            strategy = strategy_ui.value,
+            search = search_select.value,
+            seed = seed_ui.value,
+            batch = batch_ui.value,
+            optimizer = optimizer_ui.value,
+            optimizer_config = config_path,
+            trials = trials_ui.value
+        )
+        return args
+
+    def loop_explore():
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output_path = os.path.join(tmpdir, "out.csv")
+
+            config_path = extract_config_yaml_from_ui(
+                tmpdir,
+                optimizer_config_ui,
+            )
+            args = set_explore_args(config_path)
+            args.output = output_path
+
+            #mo.output.append("optimizing...")
+            explore.optimize(args)
+
+            best = 0
+            best_info = ""
+            with open(output_path, newline="") as f:
+                reader = csv.reader(f)
+                next(reader, None)  # skip header
+                for row in reader:
+                    try:
+                        val = float(row[-2])
+                    except (ValueError, IndexError):
+                        continue
+                    if val > best:
+                        best_info = str(row[-4]) + " " + row[-1]
+                        best = val
+            return best, best_info
+
+    def run_loop_explore():
+        best, best_info = loop_explore()
+        #mo.output.append(f"best peak perf was {best}")
+        return f"best peak perf was {best}\n\n{best_info}"
+        #return mo.md(f"best peak perf was {best}")
+    return (run_loop_explore,)
+
+
+@app.cell
+def _(mo):
+    button = mo.ui.run_button(
+        label="run loop explore",
+    )
+    button
+    return (button,)
+
+
+@app.cell
+def _(button, mo, run_loop_explore):
+    mo.stop(not button.value)
+    with mo.status.spinner():
+        explore_out = run_loop_explore()
+    mo.md(explore_out)
+    return
+
+
+if __name__ == "__main__":
+    app.run()

--- a/src/xtc/cli/explore.py
+++ b/src/xtc/cli/explore.py
@@ -507,7 +507,7 @@ def evaluate_iterative(
     if args.optimizer == "random-forest-custom":
         opt = optimizer(strategy.sample, args.batch, args.seed, args.optimizer_config)
     else:
-        opt = optimizer(strategy.sample, args.batch, args.seed)
+        opt = optimizer(strategy.sample, args.batch, args.seed, args.optimizer_config)
     callbacks["search"].iterations_start(args.trials * len(args.backends))
     for step in range(0, args.trials, args.batch):
         in_x = opt.suggest()
@@ -1182,7 +1182,7 @@ def main():
     if args.debug_xtc:
         logging.getLogger("xtc").setLevel(logging.DEBUG)
     if args.debug_optimizer:
-        logging.getLogger("xtc.utils.optimizers").setLevel(logging.INFO)
+        logging.getLogger("xtc.search.optimizers").setLevel(logging.INFO)
 
     if not args.child:
         launch_child(sys.argv, args)

--- a/src/xtc/search/optimizers.py
+++ b/src/xtc/search/optimizers.py
@@ -8,7 +8,7 @@ import logging
 import yaml
 from collections.abc import Sequence, Iterator
 from sklearn.ensemble import RandomForestRegressor
-from typing import Callable, TypeAlias, cast, Any, ClassVar
+from typing import Callable, TypeAlias, Any, ClassVar
 from typing_extensions import override
 from xtc.itf.search.optimizer import Optimizer
 
@@ -158,67 +158,61 @@ class RandomForestOptimizer(BaseOptimizer):
         logger.info(self.log_str)
 
 
-class RandomForestOptimizer_Explore(RandomForestOptimizer):
+class RandomForestPreset_Default(RandomForestOptimizer):
+    PRESET: dict[str, Any] = {
+        "batch_candidates": 1000,
+        "beta": 2.5,
+        "alpha": 0.7,
+        "update_first": None,
+        "update_period": None,
+        "n_estimators": 300,
+        "max_depth": 12,
+        "min_samples_leaf": 5,
+        "max_features": 0.8,
+    }
+
     def __init__(
         self,
         sample_fn: Callable[[int, int], Iterator[VecSample]],
         batch: int,
         seed: int,
+        config_file: str = "",
     ):
-        preset = {
-            "batch_candidates": 1000,
-            "beta": 5,
-            "alpha": 0.6,
-            "update_first": None,
-            "update_period": None,
-            "n_estimators": 300,
-            "max_depth": 8,
-            "min_samples_leaf": 3,
-            "max_features": 0.9,
-        }
-        super().__init__(sample_fn, batch, seed, **cast(dict[str, Any], preset))
+        config = dict(self.PRESET)
+        if config_file:
+            with open(config_file, "r") as f:
+                logger.info("loaded custom config")
+                config.update(yaml.safe_load(f))
+        logger.info("\n%s", yaml.dump(config, sort_keys=False))
+        super().__init__(sample_fn, batch, seed, **config)
 
 
-class RandomForestOptimizer_Default(RandomForestOptimizer):
-    def __init__(
-        self,
-        sample_fn: Callable[[int, int], Iterator[VecSample]],
-        batch: int,
-        seed: int,
-    ):
-        preset = {
-            "batch_candidates": 1000,
-            "beta": 2.5,
-            "alpha": 0.7,
-            "update_first": None,
-            "update_period": None,
-            "n_estimators": 300,
-            "max_depth": 12,
-            "min_samples_leaf": 5,
-            "max_features": 0.8,
-        }
-        super().__init__(sample_fn, batch, seed, **cast(dict[str, Any], preset))
+class RandomForestPreset_Explore(RandomForestPreset_Default):
+    PRESET: dict[str, Any] = {
+        "batch_candidates": 1000,
+        "beta": 5,
+        "alpha": 0.6,
+        "update_first": None,
+        "update_period": None,
+        "n_estimators": 300,
+        "max_depth": 10,
+        "min_samples_leaf": 3,
+        "max_features": 0.9,
+    }
 
 
-class RandomForestOptimizer_Aggressive(RandomForestOptimizer):
-    def __init__(
-        self,
-        sample_fn: Callable[[int, int], Iterator[VecSample]],
-        batch: int,
-        seed: int,
-    ):
-        preset = {
-            "batch_candidates": 1000,
-            "beta": 2,
-            "alpha": 0.8,
-            "update_first": None,
-            "update_period": None,
-            "n_estimators": 200,
-            "max_depth": 8,
-            "min_samples_leaf": 5,
-            "max_features": 0.7,
-        }
-        super().__init__(sample_fn, batch, seed, **cast(dict[str, Any], preset))
+class RandomForestPreset_Aggressive(RandomForestPreset_Default):
+    PRESET: dict[str, Any] = {
+        "batch_candidates": 1000,
+        "beta": 2,
+        "alpha": 0.8,
+        "update_first": None,
+        "update_period": None,
+        "n_estimators": 200,
+        "max_depth": 8,
+        "min_samples_leaf": 5,
+        "max_features": 0.7,
+    }
 
 
 class RandomForestOptimizer_Custom(RandomForestOptimizer):
@@ -247,8 +241,7 @@ class Optimizers:
 
     _map: ClassVar[dict[str, type[BaseOptimizer]]] = {
         "random": RandomOptimizer,
-        "random-forest-explore": RandomForestOptimizer_Explore,
-        "random-forest-default": RandomForestOptimizer_Default,
-        "random-forest-aggressive": RandomForestOptimizer_Aggressive,
-        "random-forest-custom": RandomForestOptimizer_Custom,
+        "random-forest-explore": RandomForestPreset_Explore,
+        "random-forest-default": RandomForestPreset_Default,
+        "random-forest-aggressive": RandomForestPreset_Aggressive,
     }


### PR DESCRIPTION
# Motivation

Added a marimo tutorial to interact with loop explore more intuitively.

# Description

The tutorial uses ui elements to run loop-explore, including customizing model hyperparameters. Some small changes to loop-explore and optimizers were made to make the custom config file override model presets instead of needing to use a specific `random-forest-custom` preset.

