### PR TITLE
tvm: reorganize code generation for aidge integration

### DIFF
--- a/src/xtc/backends/tvm/TVMCompiler.py
+++ b/src/xtc/backends/tvm/TVMCompiler.py
@@ -4,19 +4,28 @@
 #
 from typing import Any, cast
 from typing_extensions import override
+from collections.abc import Sequence
 import tempfile
 from pathlib import Path
+import tarfile
+import shutil
 import subprocess
 import shlex
+import sys
+from functools import partial
 
 from xtc.targets.host import HostModule
 
 import xtc.backends.tvm as backend
 import xtc.itf as itf
+from xtc.utils.text import jinja_generate_file
 
-from xtc.utils.host_tools import disassemble
+from xtc.utils.host_tools import disassemble, target_triple
 
-from .TVMOps import TVMBaseExpr
+from .TVMOps import TVMBaseExpr, TESchedule, TETensor
+
+import tvm
+
 
 __all__ = [
     "TVMCompiler",
@@ -39,12 +48,24 @@ class TVMCompiler(itf.comp.Compiler):
         self.print_source_ir = kwargs.get("print_source_ir", False)
         self.print_transformed_ir = kwargs.get("print_transformed_ir", False)
         self.print_assembly = kwargs.get("print_assembly", False)
+        self.print_file = kwargs.get("print_file", sys.stdout)
         self.color = kwargs.get("color", False)
         self.shared_lib = kwargs.get("shared_lib", False)
+        self.ar_lib = kwargs.get("ar_lib", False)
         self.executable = kwargs.get("executable", False)
         self.emit_c = kwargs.get("emit_c", False)
+        self.target = kwargs.get("target", "native")
+        self.arch = kwargs.get("arch", "native")
+        self.tvm_target_options = self._get_tvm_target_options(self.target, self.arch)
+        self.tvm_target = "llvm"
+        self.tvm_tgt = f"{self.tvm_target} {self.tvm_target_options}"
         assert not self.executable, f"executable generation not supported yet for TVM"
-        assert self.shared_lib, f"shared_lib generation is mandatory for TVM"
+        assert self.shared_lib or self.emit_c or self.ar_lib, (
+            f"shared_lib/ar_lib or C generation is mandatory for TVM"
+        )
+        assert not (self.shared_lib and self.ar_lib), (
+            f"cannot have both shlib and arlib"
+        )
 
     @property
     @override
@@ -67,77 +88,308 @@ class TVMCompiler(itf.comp.Compiler):
         func_name = self.payload_name
         packed_func_name = f"packed_{func_name}" if self.bare_ptr else func_name
 
-        dump_base = Path(self.dump_file).name
+        if self.shared_lib:
+            type = "shlib"
+        elif self.ar_lib:
+            type = "arlib"
+        else:
+            # May emit c in addition to lib
+            assert self.emit_c
+            type = "csrc"
+
+        Path(self.dump_file).parent.mkdir(parents=True, exist_ok=True)
+        dump_base = Path(self.dump_file).stem
         lib_path = self.dump_file
-        packed_lib_path = f"{lib_path}_packed" if self.bare_ptr else lib_path
+        if type in ["arlib", "shlib"]:
+            emit_c_base = f"{lib_path}.export_c"
+        else:
+            emit_c_base = lib_path
+        if self.bare_ptr:
+            packed_lib_path = f"{lib_path}_packed"
+            emit_c_packed_base = f"{emit_c_base}_packed"
+        else:
+            packed_lib_path = lib_path
+            emit_c_packed_base = emit_c_base
         operation = op.generate()
         if self.print_source_ir or self.save_temps:
             sch = op.schedule(operation)
             lowered = str(op.lower(operation, sch))
             if self.print_source_ir:
-                print(lowered, flush=True)
+                self._print(lowered)
             save_temp(f"{dump_base}.initial.txt", lowered)
         schedule = cast(backend.TVMSchedule, schedule)
         save_temp(f"{dump_base}.sched.txt", str(schedule))
         if self.print_transformed_ir:
-            print(schedule, flush=True)
+            self._print(schedule)
         sch = op.schedule(operation, schedule)
         if self.print_transformed_ir or self.save_temps:
             lowered = str(op.lower(operation, sch))
             if self.print_transformed_ir:
-                print(lowered, flush=True)
+                self._print(lowered)
             save_temp(f"{dump_base}.scheduled.txt", lowered)
         if self.emit_c:
-            op.emit_c(
-                operation, sch, func_name=packed_func_name, dir=f"{lib_path}.export_c"
+            self._build_te_c(
+                op, operation, sch, func_name=packed_func_name, fname=emit_c_packed_base
             )
-        built = op.build(operation, sch, func_name=packed_func_name)
-        if self.save_temps:
-            for idx, mod in enumerate(built._collect_dso_modules()):
-                llvm_ir = str(mod.get_source("ll"))
-                save_temp(f"{dump_base}.lib{idx}.ll", llvm_ir)
-            # This will generate a .tar with the .o files
-            # built.export_library(f"{save_temps_dir}/{packed_lib_path}.tar")
-        if self.print_assembly:
-            with tempfile.TemporaryDirectory() as tdir:
-                soname = f"{tdir}/built.so"
-                fname = f"{packed_func_name}_compute_"
-                built.export_library(soname)
-                disassembly = disassemble(
-                    soname,
-                    function=fname,
-                    section=".text",
-                    color=self.color,
-                )
-                print(disassembly, flush=True)
-        built.export_library(f"{packed_lib_path}.so")
+        if type in ["shlib", "arlib"]:
+            built = self._build_te(op, operation, sch, func_name=packed_func_name)
+            if self.save_temps:
+                for idx, mod in enumerate(built._collect_dso_modules()):
+                    llvm_ir = str(mod.get_source("ll"))
+                    save_temp(f"{dump_base}.lib{idx}.ll", llvm_ir)
+                    # This will generate a .tar with the .o files
+                    # built.export_library(f"{save_temps_dir}/{packed_lib_path}.tar")
+            if self.print_assembly:
+                with tempfile.TemporaryDirectory() as tdir:
+                    tmpname = f"{tdir}/built"
+                    fname = f"{packed_func_name}_compute_"
+                    self._export_library(built, tmpname, type="shlib")
+                    ext = ".dylib" if sys.platform == "darwin" else ".so"
+                    disassembly = disassemble(
+                        f"{tmpname}{ext}",
+                        function=fname,
+                        section=".text",
+                        color=self.color,
+                    )
+                    print(disassembly, flush=True)
+            self._export_library(built, packed_lib_path, type=type)
+
+        csrcs, shlibs, arlibs, headers = [], [], [], []
+        tvm_prefix = Path(tvm.__path__[0])
         if self.bare_ptr:
             wrapper = PackedOperatorWrapper(
-                op, func_name, packed_func_name, f"{packed_lib_path}.so"
+                op,
+                func_name,
+                packed_func_name,
+                cc_prefix=self._cc_prefix(),
             )
-            wrapper.build(lib_path)
-
+            if type == "shlib":
+                ext = ".dylib" if sys.platform == "darwin" else ".so"
+                wrapper.build(lib_path, packed_lib_path, type=type)
+                shlibs = [f"{packed_lib_path}{ext}"]
+            elif type == "arlib":
+                wrapper.build(lib_path, packed_lib_path, type=type)
+                arlibs = [f"{packed_lib_path}.a"]
+            if self.emit_c:
+                wrapper.build(emit_c_base, emit_c_packed_base, type="csrc")
+                csrcs = [f"{emit_c_packed_base}.c"]
+        if Path(f"{lib_path}.h").exists():
+            headers = [f"{lib_path}.h"]
+        if type in ["shlib", "arlib"]:
+            ext = ".dylib" if sys.platform == "darwin" else ".so"
+            shlibs += [f"{tvm_prefix}/libtvm_runtime{ext}"]
+            # As of now shared_lib/ar_lib takes priority over emit_c
+            return HostModule(
+                dump_base,
+                func_name,
+                f"{lib_path}{ext}" if type == "shlib" else f"{lib_path}.a",
+                type,
+                shlibs=shlibs,
+                arlibs=arlibs,
+                headers=headers,
+                bare_ptr=self.bare_ptr,
+                graph=self._backend._graph,
+            )
+        assert type == "csrc"
+        headers_path = [
+            str(path)
+            for path in [
+                tvm_prefix / "include",
+                tvm_prefix / "3rdparty" / "dlpack" / "include",
+            ]
+        ]
         return HostModule(
             dump_base,
             func_name,
-            f"{lib_path}.so",
-            "shlib",
+            f"{lib_path}.c",
+            "csrc",
             bare_ptr=self.bare_ptr,
+            csrcs=csrcs,
+            headers=headers,
+            headers_path=headers_path,
             graph=self._backend._graph,
         )
 
+    def _print(self, *content: Any) -> None:
+        print(*content, flush=True, file=self.print_file)
 
-def jinja_generate_file(fname: str, template_fname: str, **kwargs: Any) -> None:
-    from jinja2 import Environment, FileSystemLoader
+    def _build_te(
+        self,
+        op: TVMBaseExpr,
+        tensors: Sequence[TETensor],
+        sch: TESchedule,
+        func_name: str | None = None,
+    ) -> Any:
+        if func_name is None:
+            func_name = op.name
+        return self._tvm_build_crt(
+            sch,
+            tensors,
+            cname=func_name,
+            target=self.tvm_tgt,
+        )
 
-    file_path = Path(fname)
-    template_path = Path(template_fname)
-    file_path.parent.mkdir(parents=True, exist_ok=True)
-    template = Environment(loader=FileSystemLoader(template_path.parent)).get_template(
-        template_path.name
-    )
-    with open(file_path, mode="w", encoding="utf-8") as file:
-        file.write(template.render(kwargs))
+    def _build_te_c(
+        self,
+        op: TVMBaseExpr,
+        tensors: Sequence[TETensor],
+        sch: TESchedule,
+        func_name: str | None = None,
+        fname: str | None = None,
+    ) -> None:
+        if func_name is None:
+            func_name = op.name
+        if fname is None:
+            fname = func_name
+        self._tvm_emit_c(sch, tensors, self.tvm_tgt, func_name, fname)
+
+    @classmethod
+    def _get_tvm_target_options(cls, target: str, arch: str) -> str:
+        """
+        Returm the tvm target options given the target and arch
+        """
+        if target == "native":
+            assert arch in ["native", ""]
+            return cls._get_tvm_native_target_options()
+        else:
+            assert arch != "native", f"can't pass native arch for non native target"
+        tvm_cpu = ""
+        tvm_attrs = ""
+        tvm_triple = target_triple(target)
+        if target in ["x86_64"]:
+            if arch == "avx512":
+                tvm_cpu = "skylake-avx512"
+            elif arch == "avx2":
+                tvm_cpu = "core-avx2"
+        elif target in ["aarch64"]:
+            if arch == "neon":
+                tvm_cpu = "cortex-a72"
+                tvm_attrs = "+neon"
+        target_options = []
+        if tvm_triple:
+            target_options.append(f"-mtriple={tvm_triple}")
+        if tvm_cpu:
+            target_options.append(f"-mcpu={tvm_cpu}")
+        if tvm_attrs:
+            target_options.append(f"-mattr={tvm_attrs}")
+        return " ".join(target_options)
+
+    @classmethod
+    def _get_tvm_native_target_options(cls) -> str:
+        """
+        Returm the tvm target options to pass to llvm.
+        """
+        from cpuinfo import get_cpu_info
+
+        info = get_cpu_info()
+        arch = info["arch_string_raw"]
+        flags = info.get("flags", [])
+        triple = target_triple(arch)
+        cpu, attrs = "", ""
+        if arch == "x86_64":
+            if "avx512f" in flags:
+                cpu = "skylake-avx512"
+            elif "avx2" in flags:
+                cpu = "core-avx2"
+        elif arch == "aarch64":
+            if "asimd" in flags:
+                cpu = "cortex-a72"
+                attrs = "+neon"
+        target_options = []
+        if triple:
+            target_options.append(f"-mtriple={triple}")
+        if cpu:
+            target_options.append(f"-mcpu={cpu}")
+        if attrs:
+            target_options.append(f"-mattr={attrs}")
+        return " ".join(target_options)
+
+    @classmethod
+    def _tvm_build_crt_args(cls, target: str) -> dict[str, Any]:
+        # We use system-lib with crt runtime such that DSO loading works
+        # The generated .so can then be used:
+        # - for static compilation as soon as the tvm runtime is provided
+        # - for dynamic loading from python
+        # Recent version of tvm (i.e. 0.19) have a Runtime object
+        # Older version (i.e. 0.16) support passing runtime options in target
+        try:
+            from tvm.relay.backend import Runtime
+
+            runtime_kwargs = {
+                "runtime": Runtime("crt", {"system-lib": True}),
+            }
+        except:
+            runtime_kwargs = {}
+            target = f"{target} --system-lib --runtime=c"
+        return {
+            "target": target,
+            **runtime_kwargs,
+        }
+
+    @classmethod
+    def _tvm_build_crt(
+        cls, sch: Any, tensors: Sequence[TETensor], target: str, cname: str
+    ) -> Any:
+        build_kwargs = cls._tvm_build_crt_args(target)
+        config = {}
+        if target.startswith("c "):
+            config.update(
+                {
+                    "tir.disable_vectorize": True,
+                }
+            )
+        with tvm.transform.PassContext(opt_level=3, config=config):
+            return tvm.build(sch, list(tensors), name=cname, **build_kwargs)
+
+    @classmethod
+    def _tvm_emit_c(
+        cls,
+        sch: TESchedule,
+        tensors: Sequence[TETensor],
+        target: str,
+        cname: str,
+        fname: str,
+    ) -> Any:
+        # Ignore initial target as of now and generate target agnostic C
+        target = "c -keys=arch -march=generic -mcpu=generic"
+        built = cls._tvm_build_crt(sch, tensors, target, cname)
+        out_dir = Path(fname).parent
+        out_base = Path(fname).stem
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp_dir_path = Path(tmp_dir)
+            tar_file = tmp_dir_path / f"{cname}.tar"
+            built.export_library(tar_file)
+            with tarfile.open(tar_file) as tf:
+                tf.extractall(tmp_dir)
+            out_dir.mkdir(parents=True, exist_ok=True)
+            shutil.copy(tmp_dir_path / "lib1.c", out_dir / f"{out_base}.c")
+
+    def _cc_prefix(self) -> str:
+        map = {
+            "x86_64": "x86_64-linux-gnu-",
+            "aarch64": "aarch64-linux-gnu-",
+            "native": "",
+        }
+        assert self.target in map, (
+            f"unsupported target for cross compilation: {self.target}"
+        )
+        return map[self.target]
+
+    def _export_library(self, mod: Any, basename: str, type: str):
+        from tvm.contrib import cc
+
+        prefix = self._cc_prefix()
+        if type == "arlib":
+            fcompile = partial(cc.create_staticlib, ar=f"{prefix}ar")
+            mod.export_library(f"{basename}.a", fcompile=fcompile)
+            assert Path(f"{basename}.a").exists()
+        else:
+            fcompile = None
+            if prefix != "":
+                fcompile = cc.cross_compiler(f"{prefix}g++")
+            assert type == "shlib"
+            ext = ".dylib" if sys.platform == "darwin" else ".so"
+            mod.export_library(f"{basename}{ext}", fcompile=fcompile)
 
 
 class PackedOperatorWrapper:
@@ -148,14 +400,14 @@ class PackedOperatorWrapper:
         operation: TVMBaseExpr,
         func_name: str,
         packed_func_name: str,
-        packed_lib_fname: str,
+        cc_prefix: str = "",
     ) -> None:
         self.operation = operation
         self.func_name = func_name
         self.packed_func_name = packed_func_name
-        self.packed_lib_path = Path(packed_lib_fname)
+        self._cc_prefix = cc_prefix
 
-    def generate_c(self, output_c_fname: str) -> None:
+    def generate_c(self, output_base: str) -> None:
         config = {
             "inputs": self.operation.np_inputs_spec(),
             "outputs": self.operation.np_outputs_spec(),
@@ -163,25 +415,75 @@ class PackedOperatorWrapper:
             "packed_func_name": self.packed_func_name,
         }
         jinja_generate_file(
-            output_c_fname,
+            f"{output_base}.c",
             str(self.TEMPLATES_DIR / "packed_op_wrapper.c.jinja"),
             **config,
         )
+        jinja_generate_file(
+            f"{output_base}.h",
+            str(self.TEMPLATES_DIR / "unpacked_op.h.jinja"),
+            **config,
+        )
 
-    def build(self, lib_fname: str) -> None:
-        output_dir = Path(lib_fname).parent
-        output_so = f"{Path(lib_fname).stem}.so"
-        packed_lib_dir = self.packed_lib_path.parent
-        packed_lib_name = self.packed_lib_path.name
-        assert packed_lib_dir == output_dir, (
+    def build(self, lib_fname: str, packed_lib_fname: str, type: str) -> None:
+        unpacked_lib_dir = Path(lib_fname).parent
+        unpacked_lib_base = Path(lib_fname).stem
+        packed_lib_dir = Path(packed_lib_fname).parent
+        packed_lib_name = Path(packed_lib_fname).stem
+        assert packed_lib_dir == unpacked_lib_dir, (
             f"must generate wrapper at the same location as packed lib"
         )
         with tempfile.TemporaryDirectory() as tdir:
-            output_c = f"{Path(tdir) / Path(lib_fname).stem}.c"
-            self.generate_c(output_c)
-            cmd = f"gcc --shared -fPIC -O2 {output_c} -o {output_so} {packed_lib_name} -Wl,-rpath,$ORIGIN"
-            p = subprocess.run(
-                shlex.split(cmd), text=True, capture_output=True, cwd=output_dir
-            )
-        if p.returncode != 0:
-            raise RuntimeError(f"Failed command {cmd}:\n{p.stdout}\n{p.stderr}\n")
+            output_base = str(Path(tdir) / Path(lib_fname).stem)
+            self.generate_c(output_base)
+            shutil.copy(f"{output_base}.h", unpacked_lib_dir / f"{unpacked_lib_base}.h")
+            if type == "csrc":
+                shutil.copy(
+                    f"{output_base}.c", unpacked_lib_dir / f"{unpacked_lib_base}.c"
+                )
+            elif type == "shlib":
+                ext = ".dylib" if sys.platform == "darwin" else ".so"
+                cmd = (
+                    f"{self._cc_prefix}gcc --shared -fPIC -O2 {output_base}.c "
+                    f"-o {unpacked_lib_base}{ext} "
+                    f"{packed_lib_name}{ext} -Wl,--rpath,$ORIGIN"
+                )
+                p = subprocess.run(
+                    shlex.split(cmd),
+                    text=True,
+                    capture_output=True,
+                    cwd=unpacked_lib_dir,
+                )
+                if p.returncode != 0:
+                    raise RuntimeError(
+                        f"Failed command {cmd}:\n{p.stdout}\n{p.stderr}\n"
+                    )
+            elif type == "arlib":
+                cmd = (
+                    f"{self._cc_prefix}gcc -c -O2 {output_base}.c "
+                    f"-o {unpacked_lib_base}.o"
+                )
+                p = subprocess.run(
+                    shlex.split(cmd),
+                    text=True,
+                    capture_output=True,
+                    cwd=unpacked_lib_dir,
+                )
+                if p.returncode != 0:
+                    raise RuntimeError(
+                        f"Failed command {cmd}:\n{p.stdout}\n{p.stderr}\n"
+                    )
+                cmd = (
+                    f"{self._cc_prefix}ar -crs {unpacked_lib_base}.a "
+                    f"{unpacked_lib_base}.o"
+                )
+                p = subprocess.run(
+                    shlex.split(cmd),
+                    text=True,
+                    capture_output=True,
+                    cwd=unpacked_lib_dir,
+                )
+                if p.returncode != 0:
+                    raise RuntimeError(
+                        f"Failed command {cmd}:\n{p.stdout}\n{p.stderr}\n"
+                    )

--- a/src/xtc/backends/tvm/TVMOps.py
+++ b/src/xtc/backends/tvm/TVMOps.py
@@ -6,11 +6,9 @@ from abc import ABC, abstractmethod
 from collections.abc import Sequence
 from typing_extensions import override
 from typing import Any, Type, TypeAlias
-import tarfile
-import shutil
 
 from xtc.utils.math import mulall
-from xtc.utils.host_tools import target_triple
+from xtc.utils.text import to_cname
 
 from xtc.itf.graph import Operation, Graph, Node
 
@@ -28,100 +26,12 @@ import tvm.topi as topi
 
 TETensor: TypeAlias = Any  # Use instead of te.Tensor to avoids type errors
 TEIndexVar: TypeAlias = Any
-
-
-def get_tvm_native_target_options() -> str:
-    """
-    Returm the tvm target options to pass to llvm.
-    """
-    from cpuinfo import get_cpu_info
-
-    info = get_cpu_info()
-    arch = info["arch_string_raw"]
-    flags = info["flags"] if "flags" in info else []
-    triple = target_triple(arch)
-    cpu, attrs = "", ""
-    if arch == "x86_64":
-        if "avx512f" in flags:
-            cpu = "skylake-avx512"
-        elif "avx2" in flags:
-            cpu = "core-avx2"
-    elif arch == "aarch64":
-        if "asimd" in flags:
-            cpu = "cortex-a72"
-            attrs = "+neon"
-    target_options = []
-    if triple:
-        target_options.append(f"-mtriple={triple}")
-    if cpu:
-        target_options.append(f"-mcpu={cpu}")
-    if attrs:
-        target_options.append(f"-mattr={attrs}")
-    return " ".join(target_options)
-
-
-def tvm_build_crt_args(target: str) -> dict[str, Any]:
-    # We use system-lib with crt runtime such that DSO loading works
-    # The generated .so can then be used:
-    # - for static compilation as soon as the tvm runtime is provided
-    # - for dynamic loading from python
-    # Recent version of tvm (i.e. 0.19) have a Runtime object
-    # Older version (i.e. 0.16) support passing runtime options in target
-    try:
-        from tvm.relay.backend import Runtime
-
-        runtime_kwargs = {
-            "runtime": Runtime("crt", {"system-lib": True}),
-        }
-    except:
-        runtime_kwargs = {}
-        target = f"{target} --system-lib --runtime=c"
-    return {
-        "target": target,
-        **runtime_kwargs,
-    }
-
-
-def tvm_build_crt(
-    sch: Any, operation: Any, target: str, name: str | None = None
-) -> Any:
-    build_kwargs = tvm_build_crt_args(target)
-    return tvm.build(sch, operation, name=name, **build_kwargs)
-
-
-def tvm_emit_c(
-    sch: te.Schedule, tensors: Sequence[TETensor], target: str, dir: str, name: str
-) -> Any:
-    target = "c -keys=arch -march=generic -mcpu=generic"
-    build_kwargs = tvm_build_crt_args(target)
-    config = {
-        "tir.disable_vectorize": True,
-    }
-    with tvm.transform.PassContext(opt_level=3, config=config):
-        built = tvm.build(
-            sch,
-            list(tensors),
-            name=name,
-            **build_kwargs,
-        )
-    tar_file = f"{dir}.tar"
-    built.export_library(tar_file)
-    shutil.rmtree(dir, ignore_errors=True)
-    with tarfile.open(tar_file) as tf:
-        tf.extractall(dir)
+TESchedule: TypeAlias = te.Schedule
 
 
 class TVMBaseExpr(ABC):
-    def __init__(self, name: str, target: str | None = None) -> None:
+    def __init__(self, name: str) -> None:
         self.name = name
-        if target is not None:
-            self.target_options = ""
-            self.target = target
-        else:
-            self.target_options = get_tvm_native_target_options()
-            self.target = "llvm"
-        self.tgt = tvm.target.Target(target=f"{self.target} {self.target_options}")
-        self.dev = tvm.device(self.tgt.kind.name, 0)
 
     @abstractmethod
     def generate(self) -> tuple[TETensor, ...]: ...
@@ -133,32 +43,6 @@ class TVMBaseExpr(ABC):
     def np_outputs_spec(self) -> list[dict[str, Any]]: ...
     @abstractmethod
     def np_inputs_spec(self) -> list[dict[str, Any]]: ...
-
-    def build(
-        self,
-        tensors: Sequence[TETensor],
-        sch: te.Schedule,
-        func_name: str | None = None,
-    ) -> Any:
-        if func_name is None:
-            func_name = self.name
-        return tvm_build_crt(
-            sch,
-            tensors,
-            name=func_name,
-            target=self.tgt,
-        )
-
-    def emit_c(
-        self,
-        tensors: Sequence[TETensor],
-        sch: te.Schedule,
-        dir: str,
-        func_name: str | None = None,
-    ) -> None:
-        if func_name is None:
-            func_name = self.name
-        tvm_emit_c(sch, tensors, self.tgt, dir, func_name)
 
     def lower(self, tensors: Sequence[TETensor], sch: te.Schedule) -> str:
         return tvm.lower(sch, list(tensors), simple_mode=True)
@@ -191,13 +75,12 @@ class TVMOperation(TVMBaseExpr):
         args: tuple[Any, ...],
         attrs: dict[str, Any] = {},
         name: str | None = None,
-        target: str | None = None,
     ) -> None:
         self.args = args
         self.attrs = attrs
         self.operator = operator(args, attrs, name=name)
         super().__init__(
-            name=self.operator.name if name is None else name, target=target
+            name=self.operator.name if name is None else name,
         )
 
     @override
@@ -246,8 +129,8 @@ class TVMOperation(TVMBaseExpr):
 
 
 class TVMGraph(TVMBaseExpr):
-    def __init__(self, graph: Graph, target: str | None = None):
-        super().__init__(name=graph.name, target=target)
+    def __init__(self, graph: Graph):
+        super().__init__(name=graph.name)
         self._graph = graph
         self._operations = {
             node.name: TVMOperation.from_operation(node.operation, node.name)
@@ -268,7 +151,7 @@ class TVMGraph(TVMBaseExpr):
         shape, dtype = self._te_shape_dtype_from_node(node)
         return te.placeholder(
             shape,
-            name=node.name,
+            name=to_cname(node.name),
             dtype=dtype,
         )
 
@@ -280,14 +163,18 @@ class TVMGraph(TVMBaseExpr):
         variables: dict[str, Any],
     ) -> tuple[TETensor, ...]:
         assert len(outputs) == 1
-        in_outs = operation.operator.generate_op([variables[name] for name in inputs])
-        variables[outputs[0]] = in_outs[-1]
+        in_outs = operation.operator.generate_op(
+            [variables[to_cname(name)] for name in inputs]
+        )
+        variables[to_cname(outputs[0])] = in_outs[-1]
         return in_outs
 
     def _te_expr_from_graph(self) -> tuple[dict[str, TETensor], dict[str, TETensor]]:
         inputs = {
-            node.name: self._te_tensor_from_node(node)
-            for node in self._graph.inputs_nodes
+            te.name: te
+            for te in [
+                self._te_tensor_from_node(node) for node in self._graph.inputs_nodes
+            ]
         }
         variables = {**inputs}
         for node, operation in zip(
@@ -296,7 +183,9 @@ class TVMGraph(TVMBaseExpr):
             self._te_op_from_op(node.inputs, node.outputs, operation, variables)
         params = {
             name: variables[name]
-            for name in [*self._graph.inputs, *self._graph.outputs]
+            for name in [
+                to_cname(name) for name in [*self._graph.inputs, *self._graph.outputs]
+            ]
         }
         return variables, params
 

--- a/src/xtc/targets/host/HostAREvaluator.py
+++ b/src/xtc/targets/host/HostAREvaluator.py
@@ -1,0 +1,107 @@
+#
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2024-2026 The XTC Project Authors
+#
+from typing import Any
+from typing_extensions import override
+import tempfile
+from pathlib import Path
+import subprocess
+import shlex
+import shutil
+import sys
+
+import xtc.itf as itf
+import xtc.targets.host as host
+
+
+__all__ = [
+    "HostAREvaluator",
+    "HostARExecutor",
+]
+
+
+class HostAREvaluator(itf.exec.Evaluator):
+    def __init__(self, module: "host.HostModule", **kwargs: Any) -> None:
+        assert module.file_type == "arlib", (
+            "must pass a arlib module to a HostAREvaluator"
+        )
+        self._module = module
+        self._build_shlib_module()
+        self._shlib_evaluator = host.HostEvaluator(self._shlib_module, **kwargs)
+
+    @override
+    def evaluate(self) -> tuple[list[float], int, str]:
+        return self._shlib_evaluator.evaluate()
+
+    @property
+    @override
+    def module(self) -> itf.comp.Module:
+        return self._module
+
+    def _compile_to_shlib(self, shlib_base: str):
+        cwd_dir = Path(shlib_base).parent
+        shlib_name = Path(shlib_base).stem
+        opts = "-O3 -march=native -mtune=native"
+        sh_opts = "--shared -fPIC"
+        arlibs = [
+            str(Path(fname).absolute())
+            for fname in [self._module.file_name] + self._module.arlibs
+        ]
+        opt_whole, opt_no_whole = "-Wl,--whole-archive", "-Wl,--no-whole-archive"
+        ext = ".so"
+        if sys.platform == "darwin":
+            sh_opts += " -undefined dynamic_lookup"
+            opt_whole, opt_no_whole = "-Wl,-all_load", ""
+            ext = ".dylib"
+        cmd = (
+            f"cc {sh_opts} {opts} "
+            f"{opt_whole}  "
+            f"{' '.join(arlibs)} "
+            f"{opt_no_whole}  "
+            f"-o {shlib_name}{ext}"
+        )
+        p = subprocess.run(
+            shlex.split(cmd), text=True, capture_output=True, cwd=cwd_dir
+        )
+        if p.returncode != 0:
+            raise RuntimeError(f"Failed command {cmd}:\n{p.stdout}\n{p.stderr}\n")
+
+    def _build_shlib_module(self) -> None:
+        self.tmp_dir = tempfile.TemporaryDirectory(ignore_cleanup_errors=True)
+        c_stem = Path(self._module.file_name).stem
+        shlib_base = str(Path(self.tmp_dir.name) / f"{c_stem}_eval")
+        self._compile_to_shlib(shlib_base)
+        ext = ".dylib" if sys.platform == "darwin" else ".so"
+        self._shlib_module = host.HostModule(
+            shlib_base,
+            self._module.payload_name,
+            f"{shlib_base}{ext}",
+            "shlib",
+            bare_ptr=self._module._bare_ptr,
+            graph=self._module._graph,
+        )
+
+    def __del__(self):
+        shutil.rmtree(self.tmp_dir.name, ignore_errors=True)
+
+
+class HostARExecutor(itf.exec.Executor):
+    def __init__(self, module: "host.HostModule", **kwargs: Any) -> None:
+        self._evaluator = HostAREvaluator(
+            module=module,
+            repeat=1,
+            min_repeat_ms=0,
+            number=1,
+            **kwargs,
+        )
+
+    @override
+    def execute(self) -> int:
+        _, code, _ = self._evaluator.evaluate()
+        return code
+
+    @property
+    @override
+    def module(self) -> itf.comp.Module:
+        return self._evaluator.module

--- a/src/xtc/targets/host/HostCEvaluator.py
+++ b/src/xtc/targets/host/HostCEvaluator.py
@@ -1,0 +1,103 @@
+#
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2024-2026 The XTC Project Authors
+#
+from typing import Any
+from typing_extensions import override
+import tempfile
+from pathlib import Path
+import subprocess
+import shlex
+import shutil
+import sys
+
+import xtc.itf as itf
+import xtc.targets.host as host
+
+
+__all__ = [
+    "HostCEvaluator",
+    "HostCExecutor",
+]
+
+
+class HostCEvaluator(itf.exec.Evaluator):
+    def __init__(self, module: "host.HostModule", **kwargs: Any) -> None:
+        assert module.file_type == "csrc", "must pass a csrc module to a HostCEvaluator"
+        self._module = module
+        self._build_shlib_module()
+        self._shlib_evaluator = host.HostEvaluator(self._shlib_module, **kwargs)
+
+    @override
+    def evaluate(self) -> tuple[list[float], int, str]:
+        return self._shlib_evaluator.evaluate()
+
+    @property
+    @override
+    def module(self) -> itf.comp.Module:
+        return self._module
+
+    def _compile_to_shlib(self, shlib_base: str):
+        cwd_dir = Path(shlib_base).parent
+        shlib_name = Path(shlib_base).stem
+        opts = "-O3 -march=native -mtune=native"
+        sh_opts = "--shared -fPIC"
+        csrcs = [
+            str(Path(fname).absolute())
+            for fname in [self._module.file_name] + self._module.csrcs
+        ]
+        hdrs_path = [
+            str(Path(header).absolute().parent) for header in self._module.headers
+        ]
+        hdrs_path += self._module.headers_path
+        hdrs_path = list(dict.fromkeys(hdrs_path))
+        hdrs_opts = [f"-I{path}" for path in hdrs_path]
+        ext = ".dylib" if sys.platform == "darwin" else ".so"
+        cmd = (
+            f"cc {sh_opts} {opts} {' '.join(hdrs_opts)} {' '.join(csrcs)} "
+            f"-o {shlib_name}{ext}"
+        )
+        p = subprocess.run(
+            shlex.split(cmd), text=True, capture_output=True, cwd=cwd_dir
+        )
+        if p.returncode != 0:
+            raise RuntimeError(f"Failed command {cmd}:\n{p.stdout}\n{p.stderr}\n")
+
+    def _build_shlib_module(self) -> None:
+        self.tmp_dir = tempfile.TemporaryDirectory(ignore_cleanup_errors=True)
+        c_stem = Path(self._module.file_name).stem
+        shlib_base = str(Path(self.tmp_dir.name) / f"{c_stem}_eval")
+        self._compile_to_shlib(shlib_base)
+        ext = ".dylib" if sys.platform == "darwin" else ".so"
+        self._shlib_module = host.HostModule(
+            shlib_base,
+            self._module.payload_name,
+            f"{shlib_base}{ext}",
+            "shlib",
+            bare_ptr=self._module._bare_ptr,
+            graph=self._module._graph,
+        )
+
+    def __del__(self):
+        shutil.rmtree(self.tmp_dir.name, ignore_errors=True)
+
+
+class HostCExecutor(itf.exec.Executor):
+    def __init__(self, module: "host.HostModule", **kwargs: Any) -> None:
+        self._evaluator = HostCEvaluator(
+            module=module,
+            repeat=1,
+            min_repeat_ms=0,
+            number=1,
+            **kwargs,
+        )
+
+    @override
+    def execute(self) -> int:
+        _, code, _ = self._evaluator.evaluate()
+        return code
+
+    @property
+    @override
+    def module(self) -> itf.comp.Module:
+        return self._evaluator.module

--- a/src/xtc/targets/host/HostEvaluator.py
+++ b/src/xtc/targets/host/HostEvaluator.py
@@ -4,13 +4,7 @@
 #
 from typing import Any
 from typing_extensions import override
-import numpy as np
 from pathlib import Path
-
-from xtc.runtimes.types.ndarray import NDArray
-from xtc.utils.numpy import (
-    np_init,
-)
 
 from xtc.runtimes.host.HostRuntime import HostRuntime
 

--- a/src/xtc/targets/host/HostModule.py
+++ b/src/xtc/targets/host/HostModule.py
@@ -2,8 +2,8 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2024-2026 The XTC Project Authors
 #
-from typing import Any, cast
 from typing_extensions import override
+from typing import Any
 
 import xtc.itf as itf
 from xtc.itf.graph import Graph
@@ -14,6 +14,8 @@ from xtc.utils.evaluation import (
 )
 
 from .HostEvaluator import HostExecutor, HostEvaluator
+from .HostCEvaluator import HostCExecutor, HostCEvaluator
+from .HostAREvaluator import HostARExecutor, HostAREvaluator
 
 
 __all__ = [
@@ -29,17 +31,35 @@ class HostModule(itf.comp.Module):
         file_name: str,
         file_type: str,
         graph: Graph | None = None,
+        headers: list[str] = [],
+        headers_path: list[str] = [],
+        shlibs: list[str] = [],
+        arlibs: list[str] = [],
+        csrcs: list[str] = [],
         **kwargs: Any,
     ) -> None:
         self._name = name
         self._payload_name = payload_name
         self._file_name = file_name
         self._file_type = file_type
-        assert self._file_type == "shlib", "only support shlib for JIR Module"
-        lib_suffixes = ("so", "dylib")
-        assert self._file_name.endswith(lib_suffixes), (
-            f"file name {self._file_name} is not a shlib"
+        shlib_suffixes = ("so", "dylib")
+        assert self._file_type in ["shlib", "csrc", "arlib"], (
+            "only support shlib/csrc/arlib Module"
         )
+        assert self._file_type != "shlib" or self._file_name.endswith(shlib_suffixes), (
+            "file name is not a shlib"
+        )
+        assert self._file_type != "csrc" or self._file_name.endswith(".c"), (
+            "file name is not c file"
+        )
+        assert self._file_type != "arlib" or self._file_name.endswith(".a"), (
+            "file name is not an archive"
+        )
+        self._shlibs = shlibs
+        self._arlibs = arlibs
+        self._headers = headers
+        self._headers_path = headers_path
+        self._csrcs = csrcs
         self._bare_ptr = kwargs.get("bare_ptr", True)
         self._graph = graph
         if self._graph is not None:
@@ -77,14 +97,44 @@ class HostModule(itf.comp.Module):
 
     @override
     def get_evaluator(self, **kwargs: Any) -> itf.exec.Evaluator:
-        return HostEvaluator(
+        cls = {
+            "shlib": HostEvaluator,
+            "csrc": HostCEvaluator,
+            "arlib": HostAREvaluator,
+        }[self.file_type]
+        return cls(
             self,
             **kwargs,
         )
 
     @override
     def get_executor(self, **kwargs: Any) -> itf.exec.Executor:
-        return HostExecutor(
+        cls = {
+            "shlib": HostExecutor,
+            "csrc": HostCExecutor,
+            "arlib": HostARExecutor,
+        }[self.file_type]
+        return cls(
             self,
             **kwargs,
         )
+
+    @property
+    def shlibs(self) -> list[str]:
+        return self._shlibs
+
+    @property
+    def arlibs(self) -> list[str]:
+        return self._arlibs
+
+    @property
+    def csrcs(self) -> list[str]:
+        return self._csrcs
+
+    @property
+    def headers(self) -> list[str]:
+        return self._headers
+
+    @property
+    def headers_path(self) -> list[str]:
+        return self._headers_path

--- a/src/xtc/targets/host/__init__.py
+++ b/src/xtc/targets/host/__init__.py
@@ -4,3 +4,15 @@
 #
 from .HostModule import HostModule
 from .HostEvaluator import HostEvaluator, HostExecutor
+from .HostCEvaluator import HostCEvaluator, HostCExecutor
+from .HostAREvaluator import HostAREvaluator, HostARExecutor
+
+__all__ = [
+    "HostModule",
+    "HostEvaluator",
+    "HostExecutor",
+    "HostCEvaluator",
+    "HostCExecutor",
+    "HostAREvaluator",
+    "HostARExecutor",
+]

--- a/src/xtc/templates/tvm/packed_op_wrapper.c.jinja
+++ b/src/xtc/templates/tvm/packed_op_wrapper.c.jinja
@@ -31,21 +31,29 @@ typedef struct {
 } DLTensor;
 
 /* Bridge bare pointers to TVM packed function with DLTensor objects */
-extern void {{packed_func_name}}(void *args, int32_t *args_types, int32_t num_args, void *res, int32_t *res_types, void *resource_manager);
+#ifdef __cplusplus
+extern "C"
+#else
+extern
+#endif
+void {{packed_func_name}}(void *args[], const int32_t *args_types, int32_t num_args, void *res, const int32_t *res_types, void *resource_manager);
 
+#ifdef __cplusplus
+extern "C"
+#endif
 void {{func_name}}({% for idx in range(inputs|length) %}{% if idx > 0 %}, {% endif %}const float *input{{idx}}{% endfor %}{% for idx in range(outputs|length) %}, float *output{{idx}}{% endfor %}) {
-    DLDataType dtype = { kDLFloat, 32, 1 };
-    DLDevice dev = { kDLCPU, 0 };
+    static const DLDataType dtype = { kDLFloat, 32, 1 };
+    static const DLDevice dev = { kDLCPU, 0 };
 {% for idx in range(inputs|length) %}
-    int64_t DL_input{{idx}}_shape[] = { {% for dim in inputs[idx].shape %}{{dim}}, {% endfor %} };
-    DLTensor DL_input{{idx}} = { (void *)input{{idx}}, dev, {{inputs[idx].shape|length}}, dtype, DL_input{{idx}}_shape, NULL, 0 };
+    static const int64_t DL_input{{idx}}_shape[{{inputs[idx].shape|length}}] = { {% for dim in inputs[idx].shape %}{{dim}}, {% endfor %} };
+    DLTensor DL_input{{idx}} = { (void *)input{{idx}}, dev, {{inputs[idx].shape|length}}, dtype, (int64_t *)DL_input{{idx}}_shape, NULL, 0 };
 {% endfor %}
 {% for idx in range(outputs|length) %}
-    int64_t DL_output{{idx}}_shape[] = { {% for dim in outputs[idx].shape %}{{dim}}, {% endfor %} };
-    DLTensor DL_output{{idx}} = { (void *)output{{idx}}, dev, {{outputs[idx].shape|length}}, dtype, DL_output{{idx}}_shape, NULL, 0 };
+    static const int64_t DL_output{{idx}}_shape[{{outputs[idx].shape|length}}] = { {% for dim in outputs[idx].shape %}{{dim}}, {% endfor %} };
+    DLTensor DL_output{{idx}} = { (void *)output{{idx}}, dev, {{outputs[idx].shape|length}}, dtype, (int64_t *)DL_output{{idx}}_shape, NULL, 0 };
 {% endfor %}
-    void *args[] = { {% for idx in range(inputs|length) %}&DL_input{{idx}}, {% endfor %}{% for idx in range(outputs|length) %}&DL_output{{idx}}, {% endfor %} };
-    int32_t types[] = { {% for idx in range(inputs|length) %}kTVMDLTensorHandle, {% endfor %}{% for idx in range(outputs|length) %}kTVMDLTensorHandle, {% endfor %} };
+    void *args[{{inputs|length}} + {{outputs|length}}] = { {% for idx in range(inputs|length) %}&DL_input{{idx}}, {% endfor %}{% for idx in range(outputs|length) %}&DL_output{{idx}}, {% endfor %} };
+    const int32_t types[{{inputs|length}} + {{outputs|length}}] = { {% for idx in range(inputs|length) %}kTVMDLTensorHandle, {% endfor %}{% for idx in range(outputs|length) %}kTVMDLTensorHandle, {% endfor %} };
     int64_t res;
     int32_t res_type = kTVMArgInt;
     {{packed_func_name}}(args, types, {{inputs|length}} + {{outputs|length}}, &res, &res_type, NULL);

--- a/src/xtc/templates/tvm/unpacked_op.h.jinja
+++ b/src/xtc/templates/tvm/unpacked_op.h.jinja
@@ -1,0 +1,11 @@
+#ifndef _XTC_OP_{{func_name}}_H
+#define _XTC_OP_{{func_name}}_H
+
+#ifdef __cplusplus
+extern "C"
+#else
+extern
+#endif
+void {{func_name}}({% for idx in range(inputs|length) %}{% if idx > 0 %}, {% endif %}const float *input{{idx}}{% endfor %}{% for idx in range(outputs|length) %}, float *output{{idx}}{% endfor %});
+
+#endif /* _XTC_OP_{{func_name}}_H */

--- a/src/xtc/utils/text.py
+++ b/src/xtc/utils/text.py
@@ -2,7 +2,10 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2024-2026 The XTC Project Authors
 #
+from typing import Any
+from pathlib import Path
 import re
+import jinja2
 
 
 class Replace:
@@ -16,3 +19,46 @@ class Replace:
     def replace(self, text, **replaces):
         rep = dict((re.escape("{{" + k + "}}"), v) for k, v in replaces.items())
         return self.pattern.sub(lambda m: rep[re.escape(m.group(0))], text)
+
+
+_ALPHANUM_RE = None
+
+
+def to_cname(name: str) -> str:
+    """
+    Convert a string to a C identifier compatible name.
+    This may be of use to generate either function names,
+    or tensor names from input graphs.
+    Rules are:
+    - empty -> "_"
+    - replace any non-alpha and non-"_" to "_"
+    - add leading "_" when starting with number
+    - add trailing "_" if len without leading "_" is >= 2
+    Note that this last rule is to avoid C keywords.
+    """
+    global _ALPHANUM_RE
+    if _ALPHANUM_RE is None:
+        _ALPHANUM_RE = re.compile(r"[^a-zA-Z0-9_]")
+    if name == "":
+        name = "_"
+    name = _ALPHANUM_RE.sub("_", name)
+    if name[0] in "0123456789":
+        name = "_" + name
+    if name[-1] != "_":
+        if name[0] == "_" and len(name) >= 3 or name[0] != "_" and len(name) >= 2:
+            name = name + "_"
+    return name
+
+
+def jinja_generate_file(fname: str, template_fname: str, **kwargs: Any) -> None:
+    """
+    Generates into fname from the jinja2 template_fname given kwargs.
+    """
+    file_path = Path(fname)
+    template_path = Path(template_fname)
+    file_path.parent.mkdir(parents=True, exist_ok=True)
+    template = jinja2.Environment(
+        loader=jinja2.FileSystemLoader(template_path.parent)
+    ).get_template(template_path.name)
+    with open(file_path, mode="w", encoding="utf-8") as file:
+        file.write(template.render(kwargs))

--- a/tests/pytest/tvm/test_tvm_impl.py
+++ b/tests/pytest/tvm/test_tvm_impl.py
@@ -1,4 +1,5 @@
-
+import pytest
+from pathlib import Path
 from tvm_utils import requires_tvm, matmul_impl
 
 I, J, K, DTYPE = 128, 256, 91, "float32"
@@ -25,11 +26,11 @@ def sched_tile2(sch):
 
 def sched_tile2p(sch):
     sch.tile("i", {"i1": 64, "i2": 4})
-    sch.tile("j", {"j1": 64, "j2": 64})
+    sch.tile("j", {"j1": 64, "j2": 16})
     sch.tile("k", {"k1": 13})
     sch.interchange(["i", "i1", "j", "k", "j1", "k1", "i2", "j2"])
     sch.parallelize(["i", "i1"])
-    sch.unroll({"j2": 64, "k1": 13, "i2": 4})
+    sch.unroll({"j2": 64, "i2": 4})
     sch.vectorize(["j2"])
     # Expected in TVM schedule
     print(sch)
@@ -127,3 +128,42 @@ def test_sched_tile_unroll_vec():
     print(impl.graph)
     schedule = check_schedule(impl, sched_tile_unroll_vec)
     check_evaluate(impl, schedule)
+
+def check_compile_evaluate(imp, schedule, compiler_args, evaluate_args):
+    compiler = imp.get_compiler(
+        **compiler_args,
+    )
+    module = compiler.compile(schedule)
+    evaluator = module.get_evaluator(
+        **evaluate_args,
+    )
+    results, code, error_msg = evaluator.evaluate()
+    assert code == 0, f"failed to evaluate: {error_msg}"
+    print(f"Results: {results}")
+    assert isinstance(results[0], float) and float(results[0]) > 0
+
+@requires_tvm
+@pytest.mark.parametrize(
+    "compiler_args",
+    (
+        {"shared_lib": True},
+        {"emit_c": True},
+        {"ar_lib": True},
+    )
+)
+def test_backend_variant(tmpdir, compiler_args):
+    impl = matmul_impl(*MATMUL_ARGS, "matmul", emit_c=True)
+    print(impl.graph)
+    libpath = Path(tmpdir) / impl.graph.name
+    schedule = check_schedule(impl, sched_tile2p)
+    check_compile_evaluate(
+        impl,
+        schedule,
+        {
+            "dump_file": str(libpath),
+            **compiler_args,
+        },
+        {
+            "validate": True,
+        }
+    )

--- a/tests/pytest/tvm/tvm_utils.py
+++ b/tests/pytest/tvm/tvm_utils.py
@@ -10,7 +10,7 @@ def requires_tvm(*arg):
     return pytest.mark.skipif(not has_tvm(), reason="requires TVM")(*arg)
 
 
-def matmul_impl(i, j, k, dtype, name):
+def matmul_impl(i, j, k, dtype, name, **kwargs):
     import xtc.graphs.xtc.op as O
     from xtc.backends.tvm import TVMBackend
 
@@ -20,4 +20,4 @@ def matmul_impl(i, j, k, dtype, name):
     with O.graph(name=name) as gb:
         O.matmul(a, b, name="C")
 
-    return TVMBackend(gb.graph)
+    return TVMBackend(gb.graph, **kwargs)


### PR DESCRIPTION
Rework TVMCompiler and TVMOps to support cross compilation and arlib/csrc modules.

Add support for arlib/csrc in HostModule and add Host{C|AR}Evaluator.

# Motivation

Work done while performing Integration of XTC as a Aidge exporter, adding support for:
- multiple cross targets in tvm backend: aarch64/x86_64
- support for arlib and csrc export
- support for csrc and arlib host module evaluator
- support for generating C in presence of special symbols (to_cname() util function)

# Description

Changes in `targets/host` for supporting execution of C/AR host modules.

Changes in the `backends/tvm` part for TVM code gen.

# Commits

Ref to single commit.

# Discussion

n/a.

