### PR TITLE
Add support for aidge integration

### DIFF
--- a/.github/workflows/xtc-tests.yml
+++ b/.github/workflows/xtc-tests.yml
@@ -64,3 +64,16 @@ jobs:
       - name: Run Checks
         run: |
           make check
+      - name: Run Explore One Shot
+        run: |
+          env STRATEGIES=tile8dvr BACKENDS="tvm mlir" ./scripts/explore/run-explore-one-shot.sh artifacts/explore
+      - name: Run Explore Variants
+        run: |
+          env STRATEGIES=tile8dvr BACKENDS="tvm mlir" ./scripts/explore/run-explore-variants.sh artifacts/explore
+          env NOSHOW=1 scripts/explore/display-explore-variants.sh artifacts/explore
+      - name: Publish artifacts
+        if: matrix.python-version == '3.12'
+        uses: actions/upload-artifact@v4
+        with:
+          name: artifacts-os-${{ matrix.os }}
+          path: artifacts/

--- a/docs/tutorials/starting_examples.md
+++ b/docs/tutorials/starting_examples.md
@@ -6,8 +6,10 @@
 from io import StringIO
 from contextlib import redirect_stderr
 import xtc.graphs.xtc.op as O
-import xtc.runtimes.host.runtime as rt
+from xtc.runtimes.host import HostRuntime
 from xtc.backends.mlir import Backend  # Choose between mlir & tvm here
+
+rt = HostRuntime.get()
 
 # Define the operator and the graph
 I, J, K, dtype = 4, 32, 512, "float32"

--- a/docs/tutorials/xtc_101.py
+++ b/docs/tutorials/xtc_101.py
@@ -377,7 +377,9 @@ def _(mo):
     compile_editor = mo.ui.code_editor(
         value='''import xtc.graphs.xtc.op as O
 from xtc.graphs.xtc.graph import XTCGraph
-import xtc.runtimes.host.runtime as rt
+from xtc.runtimes.host import HostRuntime
+
+rt = HostRuntime.get()
 
 # Problem setup
 I, J, K, dtype = 4, 32, 512, "float32"
@@ -481,7 +483,9 @@ def _(mo):
     sched_editor = mo.ui.code_editor(
         value='''import xtc.graphs.xtc.op as O
 from xtc.graphs.xtc.graph import XTCGraph
-import xtc.runtimes.host.runtime as rt
+from xtc.runtimes.host import HostRuntime
+
+rt = HostRuntime.get()
 
 # Problem setup
 I, J, K, dtype = 4, 32, 512, "float32"
@@ -603,7 +607,9 @@ def _(mo):
         value='''import xtc.graphs.xtc.op as O
 from xtc.graphs.xtc.graph import XTCGraph
 from xtc.schedules.descript import descript_scheduler
-import xtc.runtimes.host.runtime as rt
+from xtc.runtimes.host import HostRuntime
+
+rt = HostRuntime.get()
 
 # Problem setup
 I, J, K, dtype = 4, 32, 512, "float32"
@@ -710,10 +716,12 @@ from xtc.graphs.xtc.graph import XTCGraph
 from xtc.backends.tvm import Backend as TVM_Backend
 from xtc.backends.mlir import Backend as MLIR_Backend
 from xtc.schedules.descript import descript_scheduler
-import xtc.runtimes.host.runtime as rt
+from xtc.runtimes.host import HostRuntime
 from io import StringIO
 from contextlib import redirect_stderr
 import itertools
+
+rt = HostRuntime.get()
 
 # Problem setup
 I, J, K, dtype = 4, 32, 512, "float32"
@@ -907,9 +915,11 @@ def _(mo, run_exploration):
 from xtc.graphs.xtc.graph import XTCGraph
 from xtc.backends.mlir import Backend
 from xtc.search.strategies import Strategy_OO
-import xtc.runtimes.host.runtime as rt
+from xtc.runtimes.host import HostRuntime
 from io import StringIO
 from contextlib import redirect_stderr
+
+rt = HostRuntime.get()
 
 # Problem setup
 I, J, K, dtype = 64, 128, 256, "float32"
@@ -1068,7 +1078,9 @@ def _(mo):
 '''# Run numpy matmul and collect elapsed time
 import timeit
 import numpy as np
-import xtc.runtimes.host.runtime as rt
+from xtc.runtimes.host import HostRuntime
+
+rt = HostRuntime.get()
 
 I, J, K, dtype = 1024, 1024, 1024, "float32"
 

--- a/src/xtc/backends/tvm/TVMOps.py
+++ b/src/xtc/backends/tvm/TVMOps.py
@@ -296,6 +296,14 @@ class TVMOperatorMatmul(TVMOperator):
             B = te.placeholder((Kk, Kj), name="B", dtype=dtype)
         else:
             A, B = inputs
+        Ashape = tuple(A.shape)
+        Bshape = tuple(B.shape)
+        Anewshape = (Ashape[0], mulall(list(Ashape[1:])))
+        Bnewshape = (mulall(list(Bshape[:-1])), Bshape[-1])
+        if Ashape != Anewshape:
+            A = topi.reshape(A, newshape=Anewshape)
+        if Bshape != Bnewshape:
+            B = topi.reshape(B, newshape=Bnewshape)
         k = te.reduce_axis((0, Kk), "k")
         O = te.compute(
             (Ki, Kj),

--- a/src/xtc/backends/tvm/TVMScheduler.py
+++ b/src/xtc/backends/tvm/TVMScheduler.py
@@ -249,12 +249,12 @@ class TVMScheduleEmitter:
             if not parent:
                 print(f"{tens} = {obj}['{self._op.name}']", file=outf)
             else:
-                print(f'{tens} = {sch}.cache_write({parent}, "local")', file=outf)
+                print(f'{tens} = {sch}.cache_write({parent}, "global")', file=outf)
             for tile_axis in tiles:
                 if tile_axis in packings:
                     inp_idx, _, _ = packings[tile_axis]
                     print(
-                        f'I_R{inp_idx} = {sch}.cache_read(INPS[{inp_idx}], "local", [{tens}])',
+                        f'I_R{inp_idx} = {sch}.cache_read(INPS[{inp_idx}], "global", [{tens}])',
                         file=outf,
                     )
                 if tile_axis in fuses:
@@ -426,7 +426,7 @@ class TVMScheduler(itf.schd.Scheduler):
     def buffer_at(
         self, axis: str, mtype: str | None = None, root: str = DEFAULT_ROOT
     ) -> None:
-        assert mtype is None or mtype == "local"
+        assert mtype is None or mtype == "global"
         self.write_caches.append(axis)
 
     @override
@@ -438,7 +438,7 @@ class TVMScheduler(itf.schd.Scheduler):
         pad: bool = False,
         root: str = DEFAULT_ROOT,
     ) -> None:
-        assert mtype is None or mtype == "local"
+        assert mtype is None or mtype == "global"
         assert input_idx >= 0 and input_idx < len(self._op.np_inputs_spec())
         self.read_buffers.append((axis, input_idx, pad))
 

--- a/src/xtc/cli/explore.py
+++ b/src/xtc/cli/explore.py
@@ -779,6 +779,8 @@ def optimize(args: NS):
     graph = OPERATORS[args.operator]["operation"](*op_args, name=args.func_name)
     strategy = get_strategy(graph, args)
     write_run_manifest(args, strategy)
+    if args.save_temps:
+        graph.dump(Path(args.save_temps_dir) / f"{graph.name}.graph.yaml")
     if args.test or args.opt_level in [0, 1, 2, 3]:
         schedule = args.test
         if not schedule:

--- a/src/xtc/cli/explore.py
+++ b/src/xtc/cli/explore.py
@@ -48,7 +48,7 @@ from xtc.utils.numpy import (
 )
 from xtc.utils.math import mulall
 from xtc.runtimes.types.ndarray import NDArray
-import xtc.runtimes.host.runtime as runtime
+from xtc.runtimes.host import HostRuntime
 from xtc.artifacts import get_operation, list_operations
 from xtc.search.optimizers import Optimizers
 
@@ -566,7 +566,7 @@ def peak_time(args: NS) -> float:
     flops = args.peak_flops
     if flops is None:
         dtype = DTYPES_MAP[args.dtype]
-        flops = runtime.evaluate_flops(dtype)
+        flops = HostRuntime.get().evaluate_flops(dtype)
         assert flops != 0, f"unable to evaluate machine flops for type {dtype}"
         logger.debug(f"Estimated peak flops: %g", flops)
     dims_names = OPERATORS[args.operator]["dims"]

--- a/src/xtc/csrcs/runtimes/host/evaluate_perf.c
+++ b/src/xtc/csrcs/runtimes/host/evaluate_perf.c
@@ -63,7 +63,7 @@ typedef int (*packed_func_t)(PackedArg *, int *, int, PackedArg *, int *);
 #define define_evaluateN(FUNC, ...)                                     \
 {                                                                       \
   assert(repeat > 0);                                                   \
-  assert(number > 0);                                                   \
+  assert(number >= 0);                                                  \
   assert(min_repeat_ms >= 0);                                           \
                                                                         \
   int fd = -1;                                                          \
@@ -80,9 +80,13 @@ typedef int (*packed_func_t)(PackedArg *, int *, int, PackedArg *, int *);
   }                                                                     \
   OPEN_PERF_EVENTS(events_num, events, perf_fds);                       \
                                                                         \
-  mem_barrier();                                                        \
-  (void)func(__VA_ARGS__);                                              \
-  mem_barrier();                                                        \
+  if (number > 0) {                                                     \
+    mem_barrier();                                                      \
+    (void)func(__VA_ARGS__);                                            \
+    mem_barrier();                                                      \
+  } else {                                                              \
+    number = 1;                                                         \
+  }                                                                     \
                                                                         \
   ENABLE_PERF_EVENTS(events_num, perf_fds);                             \
   for (int r = 0; r < repeat; r++) {                                    \

--- a/src/xtc/graphs/xtc/builder.py
+++ b/src/xtc/graphs/xtc/builder.py
@@ -3,13 +3,13 @@
 # Copyright (c) 2024-2026 The XTC Project Authors
 #
 from typing import Any
+import yaml
 
 from .graph import XTCGraph
 from .context import XTCGraphContext
-from .expr import XTCTensorExpr
+from .expr import XTCTensorExpr, XTCExpr
 from .operators import XTCOperator
 from . import op_factory
-from yaml import safe_load
 
 
 class graph_builder:
@@ -71,9 +71,15 @@ class graph_builder:
 
     @classmethod
     def loads(cls, yaml_str: str) -> None:
-        cls.from_dict(safe_load(yaml_str))
+        cls.from_dict(yaml.safe_load(yaml_str))
 
     @classmethod
     def load(cls, file_name: str) -> None:
         with open(file_name, "r") as f:
-            cls.from_dict(safe_load(f))
+            cls.from_dict(yaml.safe_load(f))
+
+    def set_outputs(self, *outs: XTCExpr) -> None:
+        return XTCGraphContext.current.set_outputs(*outs)
+
+    def set_inputs(self, *inps: XTCExpr) -> None:
+        return XTCGraphContext.current.set_inputs(*inps)

--- a/src/xtc/graphs/xtc/context.py
+++ b/src/xtc/graphs/xtc/context.py
@@ -35,6 +35,12 @@ class XTCGraphScope:
     def add_inputs(self, *inps: XTCExpr) -> None:
         self._inputs.extend(inps)
 
+    def set_outputs(self, *outs: XTCExpr) -> None:
+        self._outputs = list(outs)
+
+    def set_inputs(self, *inps: XTCExpr) -> None:
+        self._inputs = list(inps)
+
     def _infer_inputs(self, inps_seed: list[XTCExpr]) -> list[XTCExpr]:
         defs = set(self._exprs)
         uses = []
@@ -42,7 +48,10 @@ class XTCGraphScope:
             if isinstance(expr, XTCOpExpr):
                 for arg in expr.args:
                     uses.append(arg)
-        inputs = inps_seed + [use for use in uses if use not in defs]
+        inputs = list({use._idx: use for use in uses if use not in defs}.values())
+        # if not order specified for by expr id
+        inputs = sorted(inputs, key=lambda x: x._idx)
+        inputs = inps_seed + inputs
         inputs = list({expr._idx: expr for expr in inputs}.values())
         return inputs
 

--- a/src/xtc/graphs/xtc/graph.py
+++ b/src/xtc/graphs/xtc/graph.py
@@ -5,6 +5,7 @@
 from typing_extensions import override
 from collections.abc import Sequence, Mapping
 from typing import TypeAlias, cast, Any
+from pathlib import Path
 
 from xtc.itf.graph import Graph
 from xtc.itf.data import TensorType, Tensor
@@ -179,6 +180,8 @@ class XTCGraph(Graph):
     def dumps(self) -> str:
         return safe_dump(self.to_dict())
 
-    def dump(self, file_name: str) -> None:
+    def dump(self, file_name: str | Path) -> None:
+        file_name = Path(file_name)
+        file_name.parent.mkdir(exist_ok=True, parents=True)
         with open(file_name, "w") as f:
             yaml_dump(self.to_dict(), f, sort_keys=False)

--- a/src/xtc/graphs/xtc/operation.py
+++ b/src/xtc/graphs/xtc/operation.py
@@ -5,10 +5,13 @@
 from typing_extensions import override
 from collections.abc import Mapping, Sequence
 from typing import Any
+import json
 
 from xtc.itf.graph import Operation
 from xtc.itf.graph.operation import AccessesMaps
 from xtc.itf.data import TensorType
+from xtc.utils.math import mulall
+from .data import XTCTensorType
 
 
 class XTCOperation(Operation):
@@ -16,8 +19,8 @@ class XTCOperation(Operation):
         self,
         name: str,
         attrs: Mapping[str, Any],
-        inputs_types: Sequence[TensorType],
-        outputs_types: Sequence[TensorType],
+        inputs_types: Sequence[XTCTensorType],
+        outputs_types: Sequence[XTCTensorType],
         dims: Mapping[str, int | str],
         kinds: Sequence[str],
         inps_maps: Sequence[Sequence[str]],
@@ -69,3 +72,30 @@ class XTCOperation(Operation):
     @override
     def accesses_maps(self) -> AccessesMaps:
         return self._maps
+
+    @property
+    @override
+    def ops_count(self) -> int:
+        # Assume single output, hence estimate
+        # ops as the product of all dimensions
+        # in the iteration space
+        shape = self._outputs_types[0].constant_shape
+        ops_count = mulall(list(shape))
+        return ops_count
+
+    @property
+    @override
+    def ops_dtype(self) -> str:
+        # Assume single output, hence estimate
+        # dtype as the first output dtype
+        return self._outputs_types[0].constant_dtype
+
+    @property
+    @override
+    def signature(self) -> list[Any]:
+        # Normalize json
+        return json.loads(
+            json.dumps(
+                [self.name, list(self.dims.values()), self.ops_dtype, dict(self.attrs)]
+            )
+        )

--- a/src/xtc/graphs/xtc/operators.py
+++ b/src/xtc/graphs/xtc/operators.py
@@ -11,6 +11,7 @@ import operator
 import numpy as np
 import hashlib
 
+from xtc.utils.math import mulall
 from xtc.itf.operator import Operator
 from xtc.itf.data import Tensor, TensorType
 from xtc.itf.runtime.accelerator import AcceleratorDevice
@@ -167,8 +168,8 @@ class XTCOperMatmul(XTCOperator):
     ) -> XTCOperation:
         inp0_shape = inps_types[0].constant_shape
         inp1_shape = inps_types[1].constant_shape
-        i, k = inp0_shape
-        bk, j = inp1_shape
+        i, k = (inp0_shape[0], mulall(list(inp0_shape[1:])))
+        bk, j = (mulall(list(inp1_shape[:-1])), inp1_shape[-1])
         assert k == bk
         return self._get_operation(
             inps_types,
@@ -190,10 +191,12 @@ class XTCOperMatmul(XTCOperator):
         assert len(inputs_types) == 2
         assert inputs_types[0].shape is not None
         assert inputs_types[1].shape is not None
-        assert len(inputs_types[0].shape) == 2
-        assert len(inputs_types[1].shape) == 2
-        i, k = cast(XTCTensorType, inputs_types[0]).constant_shape
-        bk, j = cast(XTCTensorType, inputs_types[1]).constant_shape
+        assert len(inputs_types[0].shape) >= 2
+        assert len(inputs_types[1].shape) >= 2
+        inp0_shape = cast(XTCTensorType, inputs_types[0]).constant_shape
+        inp1_shape = cast(XTCTensorType, inputs_types[1]).constant_shape
+        i, k = (inp0_shape[0], mulall(list(inp0_shape[1:])))
+        bk, j = (mulall(list(inp1_shape[:-1])), inp1_shape[-1])
         assert k == bk, (
             f"incompatible dimension k for matmul inputs shapes: ({i}, {k}) ({bk}, {j})"
         )
@@ -205,8 +208,12 @@ class XTCOperMatmul(XTCOperator):
 
     @override
     def forward(self, inputs: Sequence[Tensor]) -> Sequence[XTCTensor]:
+        A = inputs[0].numpy()
+        B = inputs[1].numpy()
+        A = A.reshape((A.shape[0], -1))
+        B = B.reshape((-1, B.shape[-1]))
         # Note, use np.dot instead of np.matmul which may be buggy on Mac accelerators
-        matmul = XTCTensor(np.dot(inputs[0].numpy(), inputs[1].numpy()))
+        matmul = XTCTensor(np.dot(A, B))
         expected_type = self.forward_types([inp.type for inp in inputs])[0]
         assert matmul.type == expected_type, (
             f"output type mismatch expect: {matmul.type} != {expected_type}"

--- a/src/xtc/itf/graph/operation.py
+++ b/src/xtc/itf/graph/operation.py
@@ -113,3 +113,45 @@ class Operation(ABC):
             Accesses map for this operation
         """
         ...
+
+    @property
+    @abstractmethod
+    def ops_count(self) -> int:
+        """Returns an estimate of the operation count for
+        the operation. Used for operation weight estimates
+        or peak performance estimations.
+
+        For instance on a matmul with dimensions i, j, k,
+        this returns i*j*k.
+
+        Returns:
+            Estimated ops count
+        """
+        ...
+
+    @property
+    @abstractmethod
+    def ops_dtype(self) -> str:
+        """Returns the datatype string for the estimated
+        ops count.
+
+        This is generally the dtype of the output data.
+
+        Returns:
+            Data type string of the operation
+        """
+        ...
+
+    @property
+    @abstractmethod
+    def signature(self) -> list[Any]:
+        """Returns an unique signature for the operation among
+        all possible operations of the particular instances.
+
+        The signature should be a combination of base types and
+        is used for logs databases.
+
+        Returns:
+            List of fields for unique identification of the operation
+        """
+        ...

--- a/src/xtc/runtimes/host/HostRuntime.py
+++ b/src/xtc/runtimes/host/HostRuntime.py
@@ -9,7 +9,7 @@ from typing_extensions import override
 
 from xtc.runtimes.types.dlpack import DLDevice, DLDataType
 
-from xtc.utils.cfunc import CFunc, _str_list_to_c, _c_ascii_str
+from xtc.utils.cfunc import CFunc, _str_list_to_c
 from xtc.itf.runtime.common import CommonRuntimeInterface
 
 from .runtime import runtime_funcs, resolve_runtime, RuntimeType
@@ -201,8 +201,4 @@ class HostRuntime(CommonRuntimeInterface):
 
     @override
     def evaluate_flops(self, dtype_name: str | bytes) -> float:
-        return float(
-            self.__get_runtime_func("evaluate_flops")(
-                _c_ascii_str.from_param(dtype_name)
-            )
-        )
+        return float(self.__get_runtime_func("evaluate_flops")(dtype_name))

--- a/src/xtc/runtimes/host/__init__.py
+++ b/src/xtc/runtimes/host/__init__.py
@@ -1,0 +1,9 @@
+#
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2024-2026 The XTC Project Authors
+#
+from .HostRuntime import HostRuntime
+
+__all__ = [
+    "HostRuntime",
+]

--- a/tests/filecheck/backends/test_matmul_pack_tvm.py
+++ b/tests/filecheck/backends/test_matmul_pack_tvm.py
@@ -67,8 +67,8 @@ print(f"CODE: {res}")
 # CHECK-NEXT:                  C_1[cse_var_1] = C_1[cse_var_1] + _0_1[cse_var_2 + k] * _1_1[k * 64 + j]
 # CHECK-NEXT:  INPS = list(obj.values())[:-1]
 # CHECK-NEXT:  O = obj['C']
-# CHECK-NEXT:  O_W0 = sch.cache_write(O, "local")
-# CHECK-NEXT:  I_R1 = sch.cache_read(INPS[1], "local", [O_W0])
+# CHECK-NEXT:  O_W0 = sch.cache_write(O, "global")
+# CHECK-NEXT:  I_R1 = sch.cache_read(INPS[1], "global", [O_W0])
 # CHECK-NEXT:  i, j, = O.op.axis
 # CHECK-NEXT:  k, = O.op.reduce_axis
 # CHECK-NEXT:  j, j_ = sch[O].split(j, factor=32)
@@ -95,23 +95,23 @@ print(f"CODE: {res}")
 # CHECK-NEXT:      @T.prim_func
 # CHECK-NEXT:      def main(_0: T.Buffer((64, 64), "float32"), _1: T.Buffer((64, 64), "float32"), C: T.Buffer((64, 64), "float32")):
 # CHECK-NEXT:          T.func_attr({"from_legacy_te_schedule": T.bool(True), "tir.noalias": T.bool(True)})
-# CHECK-NEXT:          C_local = T.allocate([2048], "float32", "local")
-# CHECK-NEXT:          _1_local = T.allocate([16640], "float32", "local")
+# CHECK-NEXT:          C_global = T.allocate([2048], "float32", "global")
+# CHECK-NEXT:          _1_global = T.allocate([16640], "float32", "global")
 # CHECK-NEXT:          for j_outer in range(2):
-# CHECK-NEXT:              C_local_1 = T.Buffer((2048,), data=C_local, scope="local")
+# CHECK-NEXT:              C_global_1 = T.Buffer((2048,), data=C_global)
 # CHECK-NEXT:              for i_c_outer_init, j_c_outer_init, i_c_inner_outer_init, i_c_inner_inner_init in T.grid(8, 2, 2, 4):
-# CHECK-NEXT:                  C_local_1[i_c_outer_init * 256 + i_c_inner_outer_init * 128 + i_c_inner_inner_init * 32 + j_c_outer_init * 16:i_c_outer_init * 256 + i_c_inner_outer_init * 128 + i_c_inner_inner_init * 32 + j_c_outer_init * 16 + 16] = T.Broadcast(T.float32(0.0), 16)
+# CHECK-NEXT:                  C_global_1[i_c_outer_init * 256 + i_c_inner_outer_init * 128 + i_c_inner_inner_init * 32 + j_c_outer_init * 16:i_c_outer_init * 256 + i_c_inner_outer_init * 128 + i_c_inner_inner_init * 32 + j_c_outer_init * 16 + 16] = T.Broadcast(T.float32(0.0), 16)
 # CHECK-NEXT:              for k_outer in range(4):
-# CHECK-NEXT:                  _1_local_1 = T.Buffer((16640,), data=_1_local, scope="local")
+# CHECK-NEXT:                  _1_global_1 = T.Buffer((16640,), data=_1_global)
 # CHECK-NEXT:                  for ax0, ax1 in T.grid(16, 32):
 # CHECK-NEXT:                      _1_1 = T.Buffer((4096,), data=_1.data)
-# CHECK-NEXT:                      _1_local_1[ax0 * 1040 + ax1] = _1_1[k_outer * 1024 + ax0 * 64 + j_outer * 32 + ax1]
+# CHECK-NEXT:                      _1_global_1[ax0 * 1040 + ax1] = _1_1[k_outer * 1024 + ax0 * 64 + j_outer * 32 + ax1]
 # CHECK-NEXT:                  for i_c_outer, j_c_outer, i_c_inner_outer, k_inner, i_c_inner_inner in T.grid(8, 2, 2, 16, 4):
 # CHECK-NEXT:                      cse_var_2: T.int32 = j_c_outer * 16
 # CHECK-NEXT:                      cse_var_1: T.int32 = i_c_outer * 256 + i_c_inner_outer * 128 + i_c_inner_inner * 32 + cse_var_2
 # CHECK-NEXT:                      _0_1 = T.Buffer((4096,), data=_0.data)
-# CHECK-NEXT:                      C_local_1[cse_var_1:cse_var_1 + 16] = C_local_1[cse_var_1:cse_var_1 + 16] + T.Broadcast(_0_1[i_c_outer * 512 + i_c_inner_outer * 256 + i_c_inner_inner * 64 + k_outer * 16 + k_inner], 16) * _1_local_1[k_inner * 1040 + cse_var_2:k_inner * 1040 + cse_var_2 + 16]
+# CHECK-NEXT:                      C_global_1[cse_var_1:cse_var_1 + 16] = C_global_1[cse_var_1:cse_var_1 + 16] + T.Broadcast(_0_1[i_c_outer * 512 + i_c_inner_outer * 256 + i_c_inner_inner * 64 + k_outer * 16 + k_inner], 16) * _1_global_1[k_inner * 1040 + cse_var_2:k_inner * 1040 + cse_var_2 + 16]
 # CHECK-NEXT:              for j_inner, i in T.grid(32, 64):
 # CHECK-NEXT:                  C_1 = T.Buffer((4096,), data=C.data)
-# CHECK-NEXT:                  C_1[i * 64 + j_outer * 32 + j_inner] = C_local_1[i * 32 + j_inner]
+# CHECK-NEXT:                  C_1[i * 64 + j_outer * 32 + j_inner] = C_global_1[i * 32 + j_inner]
 # CHECK-NEXT:  CODE: 0

--- a/tests/filecheck/search/test_conv_ppwrprp.py
+++ b/tests/filecheck/search/test_conv_ppwrprp.py
@@ -73,7 +73,7 @@ utils.print_exhaustive_samples(backend, strategy, 200)
 # CHECK-NEXT:  
 # CHECK-NEXT:  schedule O2: [1, 1, 1, 1, 1, 1, 1, 1, 2, 1, 1, 16, 1, 1, 1, 1]
 # CHECK-NEXT:  O = obj['%2']
-# CHECK-NEXT:  O_W0 = sch.cache_write(O, "local")
+# CHECK-NEXT:  O_W0 = sch.cache_write(O, "global")
 # CHECK-NEXT:  b, h, w, f, = O.op.axis
 # CHECK-NEXT:  r, s, c, = O.op.reduce_axis
 # CHECK-NEXT:  b, b1 = sch[O].split(b, factor=1)
@@ -111,7 +111,7 @@ utils.print_exhaustive_samples(backend, strategy, 200)
 # CHECK-NEXT:  
 # CHECK-NEXT:  schedule O3: [1, 1, 1, 1, 1, 1, 1, 1, 2, 1, 1, 16, 1, 1, 3, 1]
 # CHECK-NEXT:  O = obj['%2']
-# CHECK-NEXT:  O_W0 = sch.cache_write(O, "local")
+# CHECK-NEXT:  O_W0 = sch.cache_write(O, "global")
 # CHECK-NEXT:  b, h, w, f, = O.op.axis
 # CHECK-NEXT:  r, s, c, = O.op.reduce_axis
 # CHECK-NEXT:  b, b1 = sch[O].split(b, factor=1)
@@ -349,7 +349,7 @@ utils.print_exhaustive_samples(backend, strategy, 200)
 # CHECK-NEXT:  sample 199: [1, 1, 1, 1, 1, 1, 1, 1, 1, 2, 1, 16, 1, 1, 3, 1]
 # CHECK-NEXT:  stats {'filtered': 200, 'all': 404}
 # CHECK-NEXT:  O = obj['%2']
-# CHECK-NEXT:  O_W0 = sch.cache_write(O, "local")
+# CHECK-NEXT:  O_W0 = sch.cache_write(O, "global")
 # CHECK-NEXT:  b, h, w, f, = O.op.axis
 # CHECK-NEXT:  r, s, c, = O.op.reduce_axis
 # CHECK-NEXT:  b, b1 = sch[O].split(b, factor=1)

--- a/tests/filecheck/search/test_conv_ppwrprpv.py
+++ b/tests/filecheck/search/test_conv_ppwrprpv.py
@@ -73,7 +73,7 @@ utils.print_exhaustive_samples(backend, strategy, 200)
 # CHECK-NEXT:  
 # CHECK-NEXT:  schedule O2: [1, 1, 1, 1, 1, 1, 1, 1, 2, 1, 1, 16, 1, 1, 1, 1]
 # CHECK-NEXT:  O = obj['%2']
-# CHECK-NEXT:  O_W0 = sch.cache_write(O, "local")
+# CHECK-NEXT:  O_W0 = sch.cache_write(O, "global")
 # CHECK-NEXT:  b, h, w, f, = O.op.axis
 # CHECK-NEXT:  r, s, c, = O.op.reduce_axis
 # CHECK-NEXT:  b, b1 = sch[O].split(b, factor=1)
@@ -111,7 +111,7 @@ utils.print_exhaustive_samples(backend, strategy, 200)
 # CHECK-NEXT:  
 # CHECK-NEXT:  schedule O3: [1, 1, 1, 1, 1, 1, 1, 1, 2, 1, 1, 16, 1, 1, 3, 1]
 # CHECK-NEXT:  O = obj['%2']
-# CHECK-NEXT:  O_W0 = sch.cache_write(O, "local")
+# CHECK-NEXT:  O_W0 = sch.cache_write(O, "global")
 # CHECK-NEXT:  b, h, w, f, = O.op.axis
 # CHECK-NEXT:  r, s, c, = O.op.reduce_axis
 # CHECK-NEXT:  b, b1 = sch[O].split(b, factor=1)
@@ -349,7 +349,7 @@ utils.print_exhaustive_samples(backend, strategy, 200)
 # CHECK-NEXT:  sample 199: [1, 1, 1, 1, 2, 1, 1, 2, 1, 1, 1, 32, 1, 1, 1, 1]
 # CHECK-NEXT:  stats {'filtered_vec': 200, 'filtered': 3040, 'all': 9042}
 # CHECK-NEXT:  O = obj['%2']
-# CHECK-NEXT:  O_W0 = sch.cache_write(O, "local")
+# CHECK-NEXT:  O_W0 = sch.cache_write(O, "global")
 # CHECK-NEXT:  b, h, w, f, = O.op.axis
 # CHECK-NEXT:  r, s, c, = O.op.reduce_axis
 # CHECK-NEXT:  b, b1 = sch[O].split(b, factor=1)

--- a/tests/filecheck/search/test_conv_ppwrprpvr.py
+++ b/tests/filecheck/search/test_conv_ppwrprpvr.py
@@ -80,7 +80,7 @@ utils.print_exhaustive_samples(backend, strategy, 200)
 # CHECK-NEXT:  
 # CHECK-NEXT:  schedule O2: [1, 1, 1, 1, 1, 1, 1, 1, 2, 1, 1, 16, 1, 1, 1, 1]
 # CHECK-NEXT:  O = obj['%2']
-# CHECK-NEXT:  O_W0 = sch.cache_write(O, "local")
+# CHECK-NEXT:  O_W0 = sch.cache_write(O, "global")
 # CHECK-NEXT:  b, h, w, f, = O.op.axis
 # CHECK-NEXT:  r, s, c, = O.op.reduce_axis
 # CHECK-NEXT:  b, b1 = sch[O].split(b, factor=1)
@@ -118,7 +118,7 @@ utils.print_exhaustive_samples(backend, strategy, 200)
 # CHECK-NEXT:  
 # CHECK-NEXT:  schedule O3: [1, 1, 1, 1, 1, 1, 1, 1, 2, 1, 1, 16, 1, 1, 3, 1]
 # CHECK-NEXT:  O = obj['%2']
-# CHECK-NEXT:  O_W0 = sch.cache_write(O, "local")
+# CHECK-NEXT:  O_W0 = sch.cache_write(O, "global")
 # CHECK-NEXT:  b, h, w, f, = O.op.axis
 # CHECK-NEXT:  r, s, c, = O.op.reduce_axis
 # CHECK-NEXT:  b, b1 = sch[O].split(b, factor=1)
@@ -356,7 +356,7 @@ utils.print_exhaustive_samples(backend, strategy, 200)
 # CHECK-NEXT:  sample 199: [1, 1, 1, 1, 1, 2, 2, 1, 1, 1, 1, 32, 1, 1, 3, 1]
 # CHECK-NEXT:  stats {'filtered_l2': 200, 'filtered_l1': 204, 'filtered_reg': 264, 'filtered_vec': 268, 'filtered': 3836, 'all': 6356}
 # CHECK-NEXT:  O = obj['%2']
-# CHECK-NEXT:  O_W0 = sch.cache_write(O, "local")
+# CHECK-NEXT:  O_W0 = sch.cache_write(O, "global")
 # CHECK-NEXT:  b, h, w, f, = O.op.axis
 # CHECK-NEXT:  r, s, c, = O.op.reduce_axis
 # CHECK-NEXT:  b, b1 = sch[O].split(b, factor=1)

--- a/tests/filecheck/search/test_matmul_ppwrprp.py
+++ b/tests/filecheck/search/test_matmul_ppwrprp.py
@@ -49,7 +49,7 @@ utils.print_exhaustive_samples(backend, strategy, 200)
 # CHECK-NEXT:  
 # CHECK-NEXT:  schedule O2: [1, 1, 1, 1, 1, 16, 1, 1]
 # CHECK-NEXT:  O = obj['%2']
-# CHECK-NEXT:  O_W0 = sch.cache_write(O, "local")
+# CHECK-NEXT:  O_W0 = sch.cache_write(O, "global")
 # CHECK-NEXT:  i, j, = O.op.axis
 # CHECK-NEXT:  k, = O.op.reduce_axis
 # CHECK-NEXT:  i, i1 = sch[O].split(i, factor=1)
@@ -73,7 +73,7 @@ utils.print_exhaustive_samples(backend, strategy, 200)
 # CHECK-NEXT:  
 # CHECK-NEXT:  schedule O3: [1, 1, 3, 1, 1, 16, 12, 1]
 # CHECK-NEXT:  O = obj['%2']
-# CHECK-NEXT:  O_W0 = sch.cache_write(O, "local")
+# CHECK-NEXT:  O_W0 = sch.cache_write(O, "global")
 # CHECK-NEXT:  i, j, = O.op.axis
 # CHECK-NEXT:  k, = O.op.reduce_axis
 # CHECK-NEXT:  i, i1 = sch[O].split(i, factor=3)
@@ -297,7 +297,7 @@ utils.print_exhaustive_samples(backend, strategy, 200)
 # CHECK-NEXT:  sample 199: [1, 1, 1, 1, 32, 1, 1, 1]
 # CHECK-NEXT:  stats {'filtered': 200, 'all': 242}
 # CHECK-NEXT:  O = obj['%2']
-# CHECK-NEXT:  O_W0 = sch.cache_write(O, "local")
+# CHECK-NEXT:  O_W0 = sch.cache_write(O, "global")
 # CHECK-NEXT:  i, j, = O.op.axis
 # CHECK-NEXT:  k, = O.op.reduce_axis
 # CHECK-NEXT:  i, i1 = sch[O].split(i, factor=1)

--- a/tests/filecheck/search/test_matmul_ppwrprpv.py
+++ b/tests/filecheck/search/test_matmul_ppwrprpv.py
@@ -49,7 +49,7 @@ utils.print_exhaustive_samples(backend, strategy, 200)
 # CHECK-NEXT:  
 # CHECK-NEXT:  schedule O2: [1, 1, 1, 1, 1, 16, 1, 1]
 # CHECK-NEXT:  O = obj['%2']
-# CHECK-NEXT:  O_W0 = sch.cache_write(O, "local")
+# CHECK-NEXT:  O_W0 = sch.cache_write(O, "global")
 # CHECK-NEXT:  i, j, = O.op.axis
 # CHECK-NEXT:  k, = O.op.reduce_axis
 # CHECK-NEXT:  i, i1 = sch[O].split(i, factor=1)
@@ -73,7 +73,7 @@ utils.print_exhaustive_samples(backend, strategy, 200)
 # CHECK-NEXT:  
 # CHECK-NEXT:  schedule O3: [1, 1, 3, 1, 1, 16, 12, 1]
 # CHECK-NEXT:  O = obj['%2']
-# CHECK-NEXT:  O_W0 = sch.cache_write(O, "local")
+# CHECK-NEXT:  O_W0 = sch.cache_write(O, "global")
 # CHECK-NEXT:  i, j, = O.op.axis
 # CHECK-NEXT:  k, = O.op.reduce_axis
 # CHECK-NEXT:  i, i1 = sch[O].split(i, factor=3)
@@ -297,7 +297,7 @@ utils.print_exhaustive_samples(backend, strategy, 200)
 # CHECK-NEXT:  sample 199: [3, 1, 1, 1, 1, 16, 4, 1]
 # CHECK-NEXT:  stats {'filtered_vec': 200, 'filtered': 2944, 'all': 6104}
 # CHECK-NEXT:  O = obj['%2']
-# CHECK-NEXT:  O_W0 = sch.cache_write(O, "local")
+# CHECK-NEXT:  O_W0 = sch.cache_write(O, "global")
 # CHECK-NEXT:  i, j, = O.op.axis
 # CHECK-NEXT:  k, = O.op.reduce_axis
 # CHECK-NEXT:  i, i1 = sch[O].split(i, factor=3)

--- a/tests/filecheck/search/test_matmul_ppwrprpvr.py
+++ b/tests/filecheck/search/test_matmul_ppwrprpvr.py
@@ -56,7 +56,7 @@ utils.print_exhaustive_samples(backend, strategy, 200)
 # CHECK-NEXT:  
 # CHECK-NEXT:  schedule O2: [1, 1, 1, 1, 1, 16, 1, 1]
 # CHECK-NEXT:  O = obj['%2']
-# CHECK-NEXT:  O_W0 = sch.cache_write(O, "local")
+# CHECK-NEXT:  O_W0 = sch.cache_write(O, "global")
 # CHECK-NEXT:  i, j, = O.op.axis
 # CHECK-NEXT:  k, = O.op.reduce_axis
 # CHECK-NEXT:  i, i1 = sch[O].split(i, factor=1)
@@ -80,7 +80,7 @@ utils.print_exhaustive_samples(backend, strategy, 200)
 # CHECK-NEXT:  
 # CHECK-NEXT:  schedule O3: [1, 1, 3, 1, 1, 16, 12, 1]
 # CHECK-NEXT:  O = obj['%2']
-# CHECK-NEXT:  O_W0 = sch.cache_write(O, "local")
+# CHECK-NEXT:  O_W0 = sch.cache_write(O, "global")
 # CHECK-NEXT:  i, j, = O.op.axis
 # CHECK-NEXT:  k, = O.op.reduce_axis
 # CHECK-NEXT:  i, i1 = sch[O].split(i, factor=3)
@@ -304,7 +304,7 @@ utils.print_exhaustive_samples(backend, strategy, 200)
 # CHECK-NEXT:  sample 199: [1, 21, 1, 1, 2, 16, 1, 1]
 # CHECK-NEXT:  stats {'filtered_l2': 200, 'filtered_l1': 210, 'filtered_reg': 230, 'filtered_vec': 308, 'filtered': 4252, 'all': 5498}
 # CHECK-NEXT:  O = obj['%2']
-# CHECK-NEXT:  O_W0 = sch.cache_write(O, "local")
+# CHECK-NEXT:  O_W0 = sch.cache_write(O, "global")
 # CHECK-NEXT:  i, j, = O.op.axis
 # CHECK-NEXT:  k, = O.op.reduce_axis
 # CHECK-NEXT:  i, i1 = sch[O].split(i, factor=21)


### PR DESCRIPTION
# Motivation

Bring some functionalities for better integration with Aidge

# Description

Add capacity to define graph inputs orders.

Add additional operation interfaces to define the operation type and estimated flops count.

Fix issues with tvm, loop explore and host runtime.

Add support for cold evalutation with number == 0 and min_repeat_ms == 0 (evaluate_perf).

Add test for loop explore in workflow

# Commits

Ref to commit description.

# Discussion

n/a

