### PR TITLE
Add options to relayout and mark tensors as const

### DIFF
--- a/src/xtc/backends/mlir/MlirGraphBackend.py
+++ b/src/xtc/backends/mlir/MlirGraphBackend.py
@@ -152,12 +152,18 @@ class MlirGraphBackend(MlirBackend):
 
     def _xdsl_type_from_tensortype(self, type: XTCTensorType) -> Any:
         elt_type, shape = self._xdsl_elt_shape_from_tensortype(type)
+        layout = type.layout
+        if layout is not None:
+            shape = [shape[idx] for idx in layout]
         return MemRefType(elt_type, shape)
 
     def _xdsl_attrs_from_tensortype(self, type: XTCTensorType):
+        attrs = {}
         if type.device is not None:
-            return {"memref.on_device": UnitAttr()}
-        return {}
+            attrs["memref.on_device"] = UnitAttr()
+        if type.const:
+            attrs["memref.const"] = UnitAttr()
+        return attrs
 
     def _np_types_spec(
         self, types: list[MemRefType]

--- a/src/xtc/backends/mlir/MlirOps.py
+++ b/src/xtc/backends/mlir/MlirOps.py
@@ -23,6 +23,7 @@ from xdsl.irdl import irdl_op_definition
 from xdsl.builder import ImplicitBuilder
 
 from xtc.itf.graph import Operation
+from xtc.graphs.xtc.data import XTCTensorType
 from xtc.utils.math import mulall
 
 
@@ -33,6 +34,20 @@ __all__ = [
 ]
 
 OpAttrs: TypeAlias = dict[str, Any]
+
+
+def _is_natural_layout(layout: list[int] | None, ndim: int) -> bool:
+    return layout is None or layout == list(range(ndim))
+
+
+def _require_natural_layouts(xtc_op: Operation) -> None:
+    for typ in xtc_op.inputs_types:
+        if isinstance(typ, XTCTensorType) and not _is_natural_layout(
+            typ.layout, typ.ndim
+        ):
+            raise NotImplementedError(
+                "tensor layout is not yet implemented in MLIR backend"
+            )
 
 
 class MlirOperation:
@@ -83,6 +98,7 @@ class MlirOperation:
         dtype = xtc_op.inputs_types[0].dtype  # TODO: currently get dtype from 1st arg
         args = tuple([*dims, dtype])
         attrs = xtc_op.attrs
+        args = MlirOperators.from_name(xtc_op.name).args_from_operation(xtc_op, args)
         return MlirOperation(
             MlirOperators.from_name(xtc_op.name),
             args,
@@ -125,11 +141,27 @@ class MlirOperator(ABC):
             return tuple(self.AXES)
         return tuple([a for a, k in zip(self.AXES, self.KINDS) if k == kind])
 
+    @classmethod
+    def args_from_operation(
+        cls, xtc_op: Operation, args: tuple[Any, ...]
+    ) -> tuple[Any, ...]:
+        _require_natural_layouts(xtc_op)
+        return args
+
 
 class MlirOperatorMatmul(MlirOperator):
     DEFAULT_NAME = "matmul"
     AXES = "ijk"
     KINDS = "PPR"
+
+    @classmethod
+    @override
+    def args_from_operation(
+        cls, xtc_op: Operation, args: tuple[Any, ...]
+    ) -> tuple[Any, ...]:
+        transpose_a = xtc_op.inputs_types[0].layout == [1, 0]
+        transpose_b = xtc_op.inputs_types[1].layout == [1, 0]
+        return (*args, transpose_a, transpose_b)
 
     @override
     def dims(self, kind: str = "") -> tuple[str, ...]:
@@ -137,14 +169,14 @@ class MlirOperatorMatmul(MlirOperator):
 
     @override
     def dims_sizes(self) -> dict[str, int]:
-        i, j, k, _ = self.args
+        i, j, k, _, _, _ = self.args
         return {"i": i, "j": j, "k": k}
 
     @override
     def generate_op(
         self, block: Block | None = None, args: Sequence[BlockArgument] = []
     ) -> tuple[Block, OpAttrs]:
-        Ki, Kj, Kk, dtype = self.args
+        Ki, Kj, Kk, dtype, transpose_a, transpose_b = self.args
         elt_type = {"float32": f32, "float64": f64}[dtype]
         elt_size = {"float32": 32, "float64": 64}[dtype]
         if block is None:
@@ -162,11 +194,43 @@ class MlirOperatorMatmul(MlirOperator):
                 inputs=(cst0.results[0],),
                 outputs=(args[2],),
             )
-            reduce = linalg.MatmulOp(
-                res=(),
-                inputs=(args[0], args[1]),
-                outputs=(args[2],),
-            )
+            if not transpose_a and not transpose_b:
+                reduce = linalg.MatmulOp(
+                    res=(),
+                    inputs=(args[0], args[1]),
+                    outputs=(args[2],),
+                )
+            else:
+                iterator_types = [
+                    StringAttr("parallel"),
+                    StringAttr("parallel"),
+                    StringAttr("reduction"),
+                ]
+                index_map_a = lambda i, j, k: (i, k)
+                index_map_b = lambda i, j, k: (k, j)
+                index_map_c = lambda i, j, k: (i, j)
+                if transpose_a:
+                    index_map_a = lambda i, j, k: (k, i)
+                if transpose_b:
+                    index_map_b = lambda i, j, k: (j, k)
+                elt_type = {"float32": f32, "float64": f64}[dtype]
+                block_in = Block(arg_types=[elt_type, elt_type, elt_type])
+                with ImplicitBuilder(block_in):
+                    mul = arith.MulfOp(block_in.args[0], block_in.args[1])
+                    add = arith.AddfOp(block_in.args[2], mul)
+                    linalg.YieldOp(add)
+                reduce = linalg.GenericOp(
+                    inputs=(args[0], args[1]),
+                    outputs=(args[2],),
+                    body=Region([block_in]),  # type: ignore # mypy issue with dataclass
+                    # ignore typing due to xdsl hints limitation
+                    indexing_maps=[
+                        AffineMapAttr(AffineMap.from_callable(index_map_a)),
+                        AffineMapAttr(AffineMap.from_callable(index_map_b)),
+                        AffineMapAttr(AffineMap.from_callable(index_map_c)),
+                    ],
+                    iterator_types=iterator_types,
+                )
         fill_node_id = f"{self.name}_0"
         reduce_node_id = f"{self.name}"
         fill.attributes[f"__xtc_id_{fill_node_id}_"] = UnitAttr()

--- a/src/xtc/backends/mlir/MlirTarget/MlirLLVMTarget.py
+++ b/src/xtc/backends/mlir/MlirTarget/MlirLLVMTarget.py
@@ -316,6 +316,7 @@ class MlirProgramToLLVMDialectPass:
             "convert-vector-to-llvm{enable-x86vector=true}",
             "convert-index-to-llvm",
             "convert-arith-to-llvm",
+            "convert-ub-to-llvm",
             "canonicalize",
             "cse",
             "sccp",

--- a/src/xtc/backends/tvm/TVMOps.py
+++ b/src/xtc/backends/tvm/TVMOps.py
@@ -11,6 +11,7 @@ from xtc.utils.math import mulall
 from xtc.utils.text import to_cname
 
 from xtc.itf.graph import Operation, Graph, Node
+from xtc.graphs.xtc.data import XTCTensorType
 
 __all__ = [
     "TVMBaseExpr",
@@ -49,6 +50,10 @@ class TVMBaseExpr(ABC):
 
     @classmethod
     def from_operation(cls, xtc_op: Operation, name: str | None) -> "TVMOperation":
+        for typ in xtc_op.inputs_types:
+            if isinstance(typ, XTCTensorType):
+                if typ.layout is not None:
+                    assert False, "tensor layout is not yet implemented in TVM backend"
         dims = xtc_op.dims.values()
         dtype = xtc_op.inputs_types[0].dtype  # TODO: infer dtype form first input
         args = tuple([*dims, dtype])
@@ -145,6 +150,9 @@ class TVMGraph(TVMBaseExpr):
         else:
             assert hasattr(node, "_expr")
             type = node._expr.type  # type: ignore
+        assert isinstance(type, XTCTensorType)
+        if type.layout is not None:
+            assert False, "tensor layout is not yet implemented in TVM backend"
         return type.shape, type.dtype
 
     def _te_tensor_from_node(self, node: Node) -> Any:

--- a/src/xtc/graphs/xtc/data.py
+++ b/src/xtc/graphs/xtc/data.py
@@ -34,10 +34,14 @@ class XTCTensorType(TensorType):
         shape: ShapeType = None,
         dtype: DataType = None,
         device: AcceleratorDevice | None = None,
+        const: bool = False,
+        layout: list[int] | None = None,
     ):
         self._shape = shape
         self._dtype = dtype
         self._device = device
+        self._const = const
+        self._layout = layout
 
     @property
     @override
@@ -53,6 +57,16 @@ class XTCTensorType(TensorType):
     @override
     def device(self) -> AcceleratorDevice | None:
         return self._device
+
+    @property
+    @override
+    def const(self) -> bool:
+        return self._const
+
+    @property
+    @override
+    def layout(self) -> list[int] | None:
+        return self._layout
 
     @property
     @override
@@ -104,6 +118,9 @@ class XTCTensorType(TensorType):
         return XTCConstantTensorType(
             shape=self.constant_shape,
             dtype=self.constant_dtype,
+            device=self.device,
+            const=self.const,
+            layout=self.layout,
         )
 
     @override
@@ -113,13 +130,26 @@ class XTCTensorType(TensorType):
         else:
             dims = "x".join([str(d if d else "?") for d in self._shape])
         dtype = self._dtype if self._dtype else "?"
-        return f"{dims}x{dtype}"
+        const = ", const" if self.const else ""
+        layout = ""
+        if self.layout is not None:
+            assert self._shape is not None
+            layout += (
+                ", <(" + ",".join([str(i) for i in range(len(self._shape))]) + ")->("
+            )
+            layout += ",".join([str(i) for i in self.layout]) + ")>"
+        return f"{dims}x{dtype}{const}{layout}"
 
     @override
     def __eq__(self, other: object) -> bool:
         if not isinstance(other, XTCTensorType):
             return NotImplemented
-        return self.dtype == other.dtype and self.shape == other.shape
+        return (
+            self.dtype == other.dtype
+            and self.shape == other.shape
+            and self.const == other.const
+            and self.layout == other.layout
+        )
 
     @override
     def to_dict(self) -> dict[str, Any]:
@@ -140,9 +170,19 @@ class XTCTensorType(TensorType):
 
 
 class XTCConstantTensorType(XTCTensorType, ConstantTensorType):
-    def __init__(self, shape: ConstantShapeType, dtype: ConstantDataType):
+    def __init__(
+        self,
+        shape: ConstantShapeType,
+        dtype: ConstantDataType,
+        device: AcceleratorDevice | None = None,
+        const: bool = False,
+        layout: list[int] | None = None,
+    ):
         self._shape: ConstantShapeType = shape
         self._dtype: ConstantDataType = dtype
+        self._device = device
+        self._const = const
+        self._layout = layout
 
     @property
     @override

--- a/src/xtc/graphs/xtc/expr.py
+++ b/src/xtc/graphs/xtc/expr.py
@@ -123,26 +123,40 @@ class XTCTensorExpr(XTCValueExpr):
         shape: ShapeType | DataType = None,
         dtype: DataType = None,
         device: AcceleratorDevice | None = None,
+        const: bool = False,
+        layout: list[int] | None = None,
     ) -> None:
         super().__init__()
         if tensor is None:
             assert shape is None or isinstance(shape, tuple)
             assert dtype is None or isinstance(dtype, str)
-            type = XTCTensorType(shape=shape, dtype=dtype, device=device)
+            type = XTCTensorType(
+                shape=shape, dtype=dtype, device=device, const=const, layout=layout
+            )
             value = XTCTensor(type=type)
         elif isinstance(tensor, XTCTensorType):
-            assert shape is None and dtype is None
+            assert shape is None and dtype is None and layout is None
+            assert not const, (
+                "const cannot be set when tensor type is provided directly"
+            )
             value = XTCTensor(type=tensor)
         elif isinstance(tensor, XTCTensor):
-            assert shape is None and dtype is None
+            assert shape is None and dtype is None and layout is None
+            assert not const, (
+                "const cannot be set when tensor value is provided directly"
+            )
             value = tensor
         elif isinstance(tensor, tuple):
             if shape is not None:
                 assert isinstance(shape, str)
                 assert dtype is None
-                type = XTCTensorType(shape=tensor, dtype=shape, device=device)
+                type = XTCTensorType(
+                    shape=tensor, dtype=shape, device=device, const=const, layout=layout
+                )
             else:
-                type = XTCTensorType(shape=tensor, dtype=dtype, device=device)
+                type = XTCTensorType(
+                    shape=tensor, dtype=dtype, device=device, const=const, layout=layout
+                )
             value = XTCTensor(type=type)
         self._value = value
         self._device = device

--- a/src/xtc/itf/data/tensor.py
+++ b/src/xtc/itf/data/tensor.py
@@ -56,6 +56,26 @@ class TensorType(ABC):
 
     @property
     @abstractmethod
+    def const(self) -> bool:
+        """Returns if the tensor contains constant data.
+
+        Returns:
+            If the tensor contains constant data.
+        """
+        ...
+
+    @property
+    @abstractmethod
+    def layout(self) -> list[int] | None:
+        """Returns the layout of the tensor.
+
+        Returns:
+            The layout of the tensor
+        """
+        ...
+
+    @property
+    @abstractmethod
     def ndim(self) -> int:
         """Returns the number of dimensions in the tensor.
 

--- a/src/xtc/runtimes/types/ndarray.py
+++ b/src/xtc/runtimes/types/ndarray.py
@@ -40,7 +40,10 @@ class NDArray:
     rev_np_dtype_map: dict[tuple[int, int], str] = {}
 
     def __init__(
-        self, array: Any, runtime: CommonRuntimeInterface | None = None
+        self,
+        array: Any,
+        runtime: CommonRuntimeInterface | None = None,
+        layout: list[int] | None = None,
     ) -> None:
         if not self.rev_np_dtype_map:
             self.rev_np_dtype_map.update(
@@ -53,6 +56,7 @@ class NDArray:
         if self.runtime is None:
             self.runtime = HostRuntime()
         self.location = NDArrayLocation.HOST
+        self.layout = layout
         if isinstance(array, NDArray):
             raise RuntimeError("TODO: copy from CNDArray not supported yet")
         elif isinstance(array, np.ndarray):
@@ -63,6 +67,11 @@ class NDArray:
             self._to_device()
 
     def _from_numpy(self, nparray: np.ndarray) -> None:
+        if self.is_transposed():
+            transposed_shape = [nparray.shape[1], nparray.shape[0]]
+            transposed_array = np.empty(transposed_shape, dtype=nparray.dtype)
+            np.copyto(transposed_array, np.transpose(nparray))
+            nparray = transposed_array
         assert nparray.flags["C_CONTIGUOUS"]
         self.handle = self._new(nparray.shape, str(nparray.dtype))
         self._copy_from(self.handle, nparray.ctypes.data_as(ctypes.c_voidp))
@@ -72,6 +81,11 @@ class NDArray:
         np_dtype = self.dtype_str
         nparray = np.empty(shape=shape, dtype=np_dtype)
         self._copy_to(self.handle, nparray.ctypes.data_as(ctypes.c_voidp))
+        if self.is_transposed():
+            transposed_shape = [nparray.shape[1], nparray.shape[0]]
+            transposed_array = np.empty(transposed_shape, dtype=nparray.dtype)
+            np.copyto(transposed_array, np.transpose(nparray))
+            nparray = transposed_array
         return nparray
 
     def _copy_to_numpy(self, out: np.ndarray) -> np.ndarray:
@@ -80,6 +94,12 @@ class NDArray:
         assert out.size == self.size
         self._copy_to(self.handle, out.ctypes.data_as(ctypes.c_voidp))
         return out
+
+    def is_transposed(self) -> bool:
+        if self.layout is None:
+            return False
+        assert len(self.layout) == 2, "Only 2D reshape is implemented"
+        return self.layout == [1, 0]
 
     def numpy(self, out: np.ndarray | None = None) -> np.ndarray:
         if self.is_on_device():
@@ -92,6 +112,7 @@ class NDArray:
         if out is None:
             return self._to_numpy()
         else:
+            assert not self.is_transposed()
             return self._copy_to_numpy(out)
 
     def _to_device(self) -> None:

--- a/src/xtc/utils/evaluation.py
+++ b/src/xtc/utils/evaluation.py
@@ -36,6 +36,7 @@ def graph_np_inputs_spec(graph: Graph) -> Callable[[], list[dict[str, Any]]]:
                 "shape": type.constant_shape,
                 "dtype": type.constant_dtype,
                 "device": type.device,
+                "layout": type.layout,
             }
             for type in inputs_types
         ]
@@ -88,13 +89,18 @@ def ensure_ndarray_parameters(
         out_init = np.zeros if init_zero else np.empty
         inputs = [
             (
-                np_init(**{k: v for k, v in spec.items() if k != "device"}),
+                np_init(
+                    **{k: v for k, v in spec.items() if k != "device" and k != "layout"}
+                ),
                 spec["device"] if "device" in spec else HostRuntime.get(),
+                spec["layout"] if "layout" in spec else None,
             )
             for spec in inputs_spec
         ]
         outputs = [
-            out_init(**{k: v for k, v in spec.items() if k != "device"})
+            out_init(
+                **{k: v for k, v in spec.items() if k != "device" and k != "layout"}
+            )
             for spec in outputs_spec
         ]
         parameters = (

--- a/tests/filecheck/backends/invalid/test_matmul_tvm_layout.py
+++ b/tests/filecheck/backends/invalid/test_matmul_tvm_layout.py
@@ -1,0 +1,32 @@
+# RUN: python %s 2>&1 | filecheck %s
+# REQUIRES: module_tvm
+
+import xtc.graphs.xtc.op as O
+from xtc.backends.tvm import Backend
+
+I, J, K, dtype = 4, 32, 512, "float32"
+a = O.tensor((I, K), dtype, name="A", layout=[1, 0])
+b = O.tensor((K, J), dtype, name="B")
+
+with O.graph(name="matmul_layout") as gb:
+    O.matmul(a, b, name="C")
+
+graph = gb.graph
+print(graph)
+
+impl = Backend(graph)
+
+sch = impl.get_scheduler()
+sched = sch.schedule()
+
+comp = impl.get_compiler(
+    shared_lib=True,
+    dump_file="matmul_tvm_layout",
+    print_source_ir=True,
+    print_transformed_ir=False,
+)
+module = comp.compile(sched)
+executor = module.get_executor(validate=True)
+res = executor.execute()
+print(f"CODE: {res}")
+# XFAIL: *

--- a/tests/filecheck/backends/invalid/test_relu_mlir_layout.py
+++ b/tests/filecheck/backends/invalid/test_relu_mlir_layout.py
@@ -1,0 +1,17 @@
+# RUN: python %s 2>&1 | filecheck %s
+# REQUIRES: module_mlir
+
+import xtc.graphs.xtc.op as O
+from xtc.backends.mlir import Backend
+
+I, J, dtype = 4, 32, "float32"
+a = O.tensor((I, J), dtype, name="A", layout=[1, 0])
+
+with O.graph(name="relu_layout") as gb:
+    O.relu(a, name="relu")
+
+graph = gb.graph
+Backend(graph)
+
+# CHECK: NotImplementedError: tensor layout is not yet implemented in MLIR backend
+# XFAIL: *

--- a/tests/filecheck/backends/test_matmul_mlir_const.py
+++ b/tests/filecheck/backends/test_matmul_mlir_const.py
@@ -1,0 +1,70 @@
+# RUN: python %s 2>&1 | filecheck %s
+
+import xtc.graphs.xtc.op as O
+from xtc.backends.mlir import Backend
+
+I, J, K, dtype = 4, 32, 512, "float32"
+a = O.tensor((I, K), dtype, name="A", const=True)
+b = O.tensor((K, J), dtype, name="B")
+
+with O.graph(name="matmul_const") as gb:
+    O.matmul(a, b, name="C")
+
+graph = gb.graph
+print(graph)
+
+impl = Backend(graph)
+
+sch = impl.get_scheduler()
+sched = sch.schedule()
+
+comp = impl.get_compiler(
+    shared_lib=True,
+    dump_file="matmul_mlir_const",
+    print_source_ir=True,
+    print_transformed_ir=False,
+)
+module = comp.compile(sched)
+executor = module.get_executor(validate=True)
+res = executor.execute()
+print(f"CODE: {res}")
+# CHECK:       // -----// IR Dump Before transform //----- //
+# CHECK-NEXT:  module attributes {transform.with_named_sequence} {
+# CHECK-NEXT:    func.func @matmul_const(%arg0: memref<4x512xf32> {llvm.noalias, memref.const}, %arg1: memref<512x32xf32> {llvm.noalias}, %arg2: memref<4x32xf32> {llvm.noalias}) {
+# CHECK-NEXT:      %cst = arith.constant 0.000000e+00 : f32
+# CHECK-NEXT:      linalg.fill {__xtc_id_C_0_} ins(%cst : f32) outs(%arg2 : memref<4x32xf32>)
+# CHECK-NEXT:      linalg.matmul {__xtc_id_C_} ins(%arg0, %arg1 : memref<4x512xf32>, memref<512x32xf32>) outs(%arg2 : memref<4x32xf32>)
+# CHECK-NEXT:      return
+# CHECK-NEXT:    }
+# CHECK-NEXT:    transform.named_sequence @_vecto(%arg0: !transform.any_op {transform.consumed}) {
+# CHECK-NEXT:      transform.structured.vectorize %arg0 : !transform.any_op
+# CHECK-NEXT:      transform.yield
+# CHECK-NEXT:    }
+# CHECK-NEXT:    transform.named_sequence @__transform_main(%arg0: !transform.any_op {transform.readonly}) {
+# CHECK-NEXT:      %0 = transform.structured.match attributes {__xtc_id_C_0_} in %arg0 : (!transform.any_op) -> !transform.any_op
+# CHECK-NEXT:      %tiled_linalg_op, %loops = transform.structured.tile_using_for %0 tile_sizes [1, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      transform.annotate %loops "./i" : !transform.any_op
+# CHECK-NEXT:      %tiled_linalg_op_0, %loops_1 = transform.structured.tile_using_for %tiled_linalg_op tile_sizes [0, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      transform.annotate %loops_1 "./j" : !transform.any_op
+# CHECK-NEXT:      %1 = transform.structured.match attributes {__xtc_id_C_} in %arg0 : (!transform.any_op) -> !transform.any_op
+# CHECK-NEXT:      %tiled_linalg_op_2, %loops_3 = transform.structured.tile_using_for %1 tile_sizes [1, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      transform.annotate %loops_3 "./i" : !transform.any_op
+# CHECK-NEXT:      %tiled_linalg_op_4, %loops_5 = transform.structured.tile_using_for %tiled_linalg_op_2 tile_sizes [0, 1, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      transform.annotate %loops_5 "./j" : !transform.any_op
+# CHECK-NEXT:      %tiled_linalg_op_6, %loops_7 = transform.structured.tile_using_for %tiled_linalg_op_4 tile_sizes [0, 0, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      transform.annotate %loops_7 "./k" : !transform.any_op
+# CHECK-NEXT:      transform.yield
+# CHECK-NEXT:    }
+# CHECK-NEXT:  }
+# CHECK-NEXT:  
+# CHECK-NEXT:  graph:
+# CHECK-NEXT:    name: matmul_const
+# CHECK-NEXT:    inputs:
+# CHECK-NEXT:    - %0 : 4x512xfloat32, const
+# CHECK-NEXT:    - %1 : 512x32xfloat32
+# CHECK-NEXT:    outputs:
+# CHECK-NEXT:    - %2 : 4x32xfloat32
+# CHECK-NEXT:    nodes:
+# CHECK-NEXT:    - %2: matmul(%0, %1) {name = 'C'} : [4x512xfloat32, const, 512x32xfloat32] -> [4x32xfloat32]
+# CHECK-NEXT:  
+# CHECK-NEXT:  CODE: 0

--- a/tests/filecheck/backends/test_matmul_mlir_layout.py
+++ b/tests/filecheck/backends/test_matmul_mlir_layout.py
@@ -1,0 +1,78 @@
+# RUN: python %s 2>&1 | filecheck %s
+
+import xtc.graphs.xtc.op as O
+from xtc.backends.mlir import Backend
+
+I, J, K, dtype = 4, 32, 512, "float32"
+a = O.tensor((I, K), dtype, name="A", layout=[1, 0])
+b = O.tensor((K, J), dtype, name="B")
+
+with O.graph(name="matmul_layout") as gb:
+    O.matmul(a, b, name="C")
+
+graph = gb.graph
+print(graph)
+
+impl = Backend(graph)
+
+sch = impl.get_scheduler()
+sched = sch.schedule()
+
+comp = impl.get_compiler(
+    shared_lib=True,
+    dump_file="matmul_mlir_layout",
+    print_source_ir=True,
+    print_transformed_ir=False,
+)
+module = comp.compile(sched)
+executor = module.get_executor(validate=True)
+res = executor.execute()
+print(f"CODE: {res}")
+# CHECK:       // -----// IR Dump Before transform //----- //
+# CHECK-NEXT:  #map = affine_map<(d0, d1, d2) -> (d2, d0)>
+# CHECK-NEXT:  #map1 = affine_map<(d0, d1, d2) -> (d2, d1)>
+# CHECK-NEXT:  #map2 = affine_map<(d0, d1, d2) -> (d0, d1)>
+# CHECK-NEXT:  module attributes {transform.with_named_sequence} {
+# CHECK-NEXT:    func.func @matmul_layout(%arg0: memref<512x4xf32> {llvm.noalias}, %arg1: memref<512x32xf32> {llvm.noalias}, %arg2: memref<4x32xf32> {llvm.noalias}) {
+# CHECK-NEXT:      %cst = arith.constant 0.000000e+00 : f32
+# CHECK-NEXT:      linalg.fill {__xtc_id_C_0_} ins(%cst : f32) outs(%arg2 : memref<4x32xf32>)
+# CHECK-NEXT:      linalg.generic {indexing_maps = [#map, #map1, #map2], iterator_types = ["parallel", "parallel", "reduction"]} ins(%arg0, %arg1 : memref<512x4xf32>, memref<512x32xf32>) outs(%arg2 : memref<4x32xf32>) attrs =  {__xtc_id_C_} {
+# CHECK-NEXT:      ^bb0(%in: f32, %in_0: f32, %out: f32):
+# CHECK-NEXT:        %0 = arith.mulf %in, %in_0 : f32
+# CHECK-NEXT:        %1 = arith.addf %out, %0 : f32
+# CHECK-NEXT:        linalg.yield %1 : f32
+# CHECK-NEXT:      }
+# CHECK-NEXT:      return
+# CHECK-NEXT:    }
+# CHECK-NEXT:    transform.named_sequence @_vecto(%arg0: !transform.any_op {transform.consumed}) {
+# CHECK-NEXT:      transform.structured.vectorize %arg0 : !transform.any_op
+# CHECK-NEXT:      transform.yield
+# CHECK-NEXT:    }
+# CHECK-NEXT:    transform.named_sequence @__transform_main(%arg0: !transform.any_op {transform.readonly}) {
+# CHECK-NEXT:      %0 = transform.structured.match attributes {__xtc_id_C_0_} in %arg0 : (!transform.any_op) -> !transform.any_op
+# CHECK-NEXT:      %tiled_linalg_op, %loops = transform.structured.tile_using_for %0 tile_sizes [1, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      transform.annotate %loops "./i" : !transform.any_op
+# CHECK-NEXT:      %tiled_linalg_op_0, %loops_1 = transform.structured.tile_using_for %tiled_linalg_op tile_sizes [0, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      transform.annotate %loops_1 "./j" : !transform.any_op
+# CHECK-NEXT:      %1 = transform.structured.match attributes {__xtc_id_C_} in %arg0 : (!transform.any_op) -> !transform.any_op
+# CHECK-NEXT:      %tiled_linalg_op_2, %loops_3 = transform.structured.tile_using_for %1 tile_sizes [1, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      transform.annotate %loops_3 "./i" : !transform.any_op
+# CHECK-NEXT:      %tiled_linalg_op_4, %loops_5 = transform.structured.tile_using_for %tiled_linalg_op_2 tile_sizes [0, 1, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      transform.annotate %loops_5 "./j" : !transform.any_op
+# CHECK-NEXT:      %tiled_linalg_op_6, %loops_7 = transform.structured.tile_using_for %tiled_linalg_op_4 tile_sizes [0, 0, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+# CHECK-NEXT:      transform.annotate %loops_7 "./k" : !transform.any_op
+# CHECK-NEXT:      transform.yield
+# CHECK-NEXT:    }
+# CHECK-NEXT:  }
+# CHECK-NEXT:  
+# CHECK-NEXT:  graph:
+# CHECK-NEXT:    name: matmul_layout
+# CHECK-NEXT:    inputs:
+# CHECK-NEXT:    - %0 : 4x512xfloat32, <(0,1)->(1,0)>
+# CHECK-NEXT:    - %1 : 512x32xfloat32
+# CHECK-NEXT:    outputs:
+# CHECK-NEXT:    - %2 : 4x32xfloat32
+# CHECK-NEXT:    nodes:
+# CHECK-NEXT:    - %2: matmul(%0, %1) {name = 'C'} : [4x512xfloat32, <(0,1)->(1,0)>, 512x32xfloat32] -> [4x32xfloat32]
+# CHECK-NEXT:  
+# CHECK-NEXT:  CODE: 0


### PR DESCRIPTION
# Motivation

In some cases we may want to compile and evaluate with tensors being not naturally strided.

# Description

This PR adds options when creating tensor to specify an different layout.
An other option allows the user to specify if a tensor has constant data, meaning that the compiler can modify the layout ahead of time with zero cost.

# Commits

This PR has two commits:
1) Fix a missing lowering pass in the LLVMIR pipeline (which is need to run some relayouted tests)
2) Implementation of the `layout` and `const` options.

# Discussion

For now only the MLIR backend implements different layout on the matmul op.
The const option is also not really used (only emits an attribute when building the IR with MLIR backend).

