### PR TITLE
Update MLIR package with fix for performance improvement of one-shot-bufferize

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 ![logo.png](logo.png)
 
+[![codecov](https://codecov.io/github/xtc-tools/xtc/graph/badge.svg)](https://codecov.io/github/xtc-tools/xtc)
+
 # XTC
 
 ## Links

--- a/jir_requirements.txt
+++ b/jir_requirements.txt
@@ -1,6 +1,6 @@
 --index-url https://gitlab.inria.fr/api/v4/groups/corse/-/packages/pypi/simple
 xtc-llvm-tools==21.1.2.6
-xtc-mlir-tools==21.1.2.7
-xtc-mlir-python-bindings==21.1.2.7
+xtc-mlir-tools==21.1.2.8
+xtc-mlir-python-bindings==21.1.2.8
 polygeist==18.0.0.2024042201
 jir==0.3.5

--- a/macos_mlir_requirements.txt
+++ b/macos_mlir_requirements.txt
@@ -1,4 +1,4 @@
 xtc-llvm-tools==21.1.2.6
-xtc-mlir-tools==21.1.2.7
-xtc-mlir-python-bindings==21.1.2.7
-xtc-mlir-extra-tools==21.1.2.7
+xtc-mlir-tools==21.1.2.8
+xtc-mlir-python-bindings==21.1.2.8
+xtc-mlir-extra-tools==21.1.2.10

--- a/mlir_requirements.txt
+++ b/mlir_requirements.txt
@@ -1,4 +1,4 @@
 xtc-llvm-tools==21.1.2.6
-xtc-mlir-tools==21.1.2.7
-xtc-mlir-python-bindings==21.1.2.7
-xtc-mlir-extra-tools==21.1.2.9
+xtc-mlir-tools==21.1.2.8
+xtc-mlir-python-bindings==21.1.2.8
+xtc-mlir-extra-tools==21.1.2.10


### PR DESCRIPTION
# Motivation

Update dependencies to last xtc-mlir packages which include the performance improvement for one-shot-bufferize.

The slow implementation of bufferization was oberved by @liamsemeria related to the PR #45.

Actually a fix was contributed to upstream MLIR with this PR https://github.com/llvm/llvm-project/pull/189895

We integrated the modification as a patch on the currently packaged xtc-mlir-wheels on top of LLVM/MLIR revision 21.1.2: https://github.com/xtc-tools/xtc-mlir-wheels/commit/0471d95515e0758968662fd1b079c10e70d5b313

# Description

Simply update package revisions to the corresponding xtc-mlir pypi package versions.

# Commits

Note that there is also an unrelated commit to add the covergae badge to the XTC Readme.

# Discussion

To be validated in term of performance improvement in PR #45 

# TODO

- [x] Validate performance improvement on top of PR #45
