### PR TITLE
ci: add tests on all python versions on main

### DIFF
--- a/.github/workflows/xtc-pages.yml
+++ b/.github/workflows/xtc-pages.yml
@@ -27,9 +27,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Set up Python 3.12
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: 3.12
           cache: pip

--- a/.github/workflows/xtc-tests.yml
+++ b/.github/workflows/xtc-tests.yml
@@ -40,7 +40,7 @@ jobs:
           brew install libomp x86_64-linux-gnu-binutils aarch64-elf-binutils
           export DYLD_LIBRARY_PATH="/opt/homebrew/opt/libomp/lib:${DYLD_LIBRARY_PATH}"
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
           cache: pip
@@ -83,7 +83,7 @@ jobs:
           env NOSHOW=1 scripts/explore/display-explore-variants.sh artifacts/explore
       - name: Publish artifacts
         if: matrix.python-version == '3.12'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: artifacts-os-${{ matrix.os }}
           path: artifacts/

--- a/.github/workflows/xtc-tests.yml
+++ b/.github/workflows/xtc-tests.yml
@@ -9,13 +9,14 @@ on:
 
 jobs:
   build:
+    if: github.event_name != 'pull_request'
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-14, macos-15]
-        python-version: ["3.12"]
-    steps:
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+    steps: &build-steps
       - name: Checkout XTC Repository
         uses: actions/checkout@v5
         with:
@@ -23,9 +24,9 @@ jobs:
       - name: Ensure PR has linear history
         if: github.event_name == 'pull_request'
         run: |
-          MERGE_COMMITS="$(git rev-list --merges "$GITHUB_SHA^1..$GITHUB_SHA^2")"
-          if [ -n "$MERGE_COMMITS" ]; then
-            echo "::error::PR contains merges, always use rebase for updating branches: Merge commits: $MERGE_COMMITS" >&2
+          MERGE_COMMITS="$(git rev-list --merges "${GITHUB_SHA}^1..${GITHUB_SHA}^2")"
+          if [ -n "${MERGE_COMMITS}" ]; then
+            echo "::error::PR contains merges, always use rebase for updating branches: Merge commits: ${MERGE_COMMITS}" >&2
             exit 1
           fi
       - name: Install Linux Packages
@@ -37,7 +38,7 @@ jobs:
         if: runner.os == 'macOs'
         run: |
           brew install libomp x86_64-linux-gnu-binutils aarch64-elf-binutils
-          export DYLD_LIBRARY_PATH="/opt/homebrew/opt/libomp/lib:$DYLD_LIBRARY_PATH"
+          export DYLD_LIBRARY_PATH="/opt/homebrew/opt/libomp/lib:${DYLD_LIBRARY_PATH}"
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
         with:
@@ -58,7 +59,7 @@ jobs:
           pip install -r macos_tvm_requirements.txt
       - name: Dump Environment information
         run: |
-          python -c "import sys; print(sys.version)"
+          python -c 'import sys; print(sys.version)'
           pip list
           env | sort
       - name: Run Checks
@@ -95,3 +96,13 @@ jobs:
           name: py${{ matrix.python-version }}-${{ matrix.os }}
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true
+
+  pr-build:
+    if: github.event_name == 'pull_request'
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-15]
+        python-version: ["3.12"]
+    steps: *build-steps

--- a/src/xtc/backends/tvm/TVMCompiler.py
+++ b/src/xtc/backends/tvm/TVMCompiler.py
@@ -360,7 +360,7 @@ class TVMCompiler(itf.comp.Compiler):
             tar_file = tmp_dir_path / f"{cname}.tar"
             built.export_library(tar_file)
             with tarfile.open(tar_file) as tf:
-                tf.extractall(tmp_dir)
+                tf.extractall(tmp_dir, filter="data")
             out_dir.mkdir(parents=True, exist_ok=True)
             shutil.copy(tmp_dir_path / "lib1.c", out_dir / f"{out_base}.c")
 


### PR DESCRIPTION
# Motivation

Add test for python version 3.10 to 3.14 included when on main branch.

For PRs, only run test for python 3.12 and hosts ubuntu-latest and macos-15

# Description

Commonalize steps between `build` (for main branch) and `pr-build` for pull_requests and run `build` on all oses/python-versions.

Limit `pr-build` to `[mac-os15 , ubuntu-latest]` on python `3.12` 

# Commits

In order:
- ci workflow matrixes changes
- fix in test a warning with tarfile module on python `3.14`
- update ci workflow with new versions of actions (remove warnings on github actions)

# Discussion

n/a

