### PR TITLE
test: fix issue with tarfile on macos/python 3.10

### DIFF
--- a/src/xtc/backends/tvm/TVMCompiler.py
+++ b/src/xtc/backends/tvm/TVMCompiler.py
@@ -7,7 +7,6 @@ from typing_extensions import override
 from collections.abc import Sequence
 import tempfile
 from pathlib import Path
-import tarfile
 import shutil
 import subprocess
 import shlex
@@ -19,6 +18,7 @@ from xtc.targets.host import HostModule
 import xtc.backends.tvm as backend
 import xtc.itf as itf
 from xtc.utils.text import jinja_generate_file
+from xtc.utils.tarfile import TarFile
 
 from xtc.utils.host_tools import disassemble, target_triple
 
@@ -359,8 +359,9 @@ class TVMCompiler(itf.comp.Compiler):
             tmp_dir_path = Path(tmp_dir)
             tar_file = tmp_dir_path / f"{cname}.tar"
             built.export_library(tar_file)
-            with tarfile.open(tar_file) as tf:
-                tf.extractall(tmp_dir, filter="data")
+            with TarFile.open(tar_file) as tf:
+                members = [info for info in tf.getmembers() if info.name.endswith(".c")]
+                tf.extractall(tmp_dir, members=members, filter="data")
             out_dir.mkdir(parents=True, exist_ok=True)
             shutil.copy(tmp_dir_path / "lib1.c", out_dir / f"{out_base}.c")
 

--- a/src/xtc/utils/tarfile.py
+++ b/src/xtc/utils/tarfile.py
@@ -1,0 +1,44 @@
+#
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2024-2026 The XTC Project Authors
+#
+import tarfile
+from typing import Any
+from typing_extensions import override
+
+
+class TarFile(tarfile.TarFile):
+    """Default TarFile class interface is not compatible anymore with
+    python 3.10 due to new filter argument.
+    This is a wrapper class to make it work for python 3.10-3.14+.
+
+    Use it as:
+
+        from xtc.utils.tar import TarFile
+        with TarFile.open(fname) as tf:
+            tf.extractall(tmpdir, filter="data")
+    """
+
+    @override
+    def extractall(  # type: ignore
+        self, *args: Any, **kwargs: Any
+    ):
+        if kwargs.get("filter") is None:
+            kwargs["filter"] = "data"
+        try:
+            return super().extractall(*args, **kwargs)
+        except TypeError:
+            del kwargs["filter"]
+            super().extractall(*args, **kwargs)
+
+    @override
+    def extract(  # type: ignore
+        self, *args: Any, **kwargs: Any
+    ):
+        if kwargs.get("filter") is None:
+            kwargs["filter"] = "data"
+        try:
+            return super().extract(*args, **kwargs)
+        except TypeError:
+            del kwargs["filter"]
+            super().extract(*args, **kwargs)


### PR DESCRIPTION
# Motivation

Fix an issue introduced with PR #84 on macos/python 3.10

TarFile interface does not support filter argument for python 3.10.

# Description

Implement wrapper for TarFile in `xtc.utils.tarfile` which tentatively forces `format="data"` or falls back to no format argument.
