### PR TITLE
test: activate C target for macos

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ check-lit:
 	lit -v tests/filecheck
 
 check-lit-c:
-	[ `uname -s` = Darwin ] || env XTC_MLIR_TARGET=c lit -v tests/filecheck/backends tests/filecheck/mlir_loop
+	env XTC_MLIR_TARGET=c lit -v tests/filecheck/backends tests/filecheck/mlir_loop
 
 check-lit-nvgpu:
 	[ `uname -s` = Darwin ] || env XTC_MLIR_TARGET=nvgpu lit -v tests/filecheck/backends tests/filecheck/mlir_loop tests/filecheck/evaluation

--- a/src/xtc/utils/ext_tools.py
+++ b/src/xtc/utils/ext_tools.py
@@ -60,7 +60,7 @@ llc_opts = [
 
 opt_opts = ["-O3", "--enable-unsafe-fp-math", "--fp-contract=fast"]
 
-target_cc_opts = ["-O3", "-ffast-math", "--fp-contract=fast"]
+target_cc_opts = ["-O3", "-ffast-math", "-ffp-contract=fast"]
 
 cc_opts = ["-O3", "-march=native"]
 


### PR DESCRIPTION
# Motivation

Add test for MLIR emit C on macos. The test was disabled historically as the macos xtc-mlir-extra-tools was not build.

# Description

Remove the macos filter on `Makefile` target `check-lit-c`

Fix `-ffp-contract=fast` option to `cc` (for macos cc may be either gcc or llvm, this option is compatible with both)

# Commits

ref commits.
