### PR TITLE
Update xtc-mlir-extra-tools version

### DIFF
--- a/macos_mlir_requirements.txt
+++ b/macos_mlir_requirements.txt
@@ -1,4 +1,4 @@
 xtc-llvm-tools==21.1.2.6
 xtc-mlir-tools==21.1.2.8
 xtc-mlir-python-bindings==21.1.2.8
-xtc-mlir-extra-tools==21.1.2.10
+xtc-mlir-extra-tools==21.1.2.11

--- a/mlir_requirements.txt
+++ b/mlir_requirements.txt
@@ -1,4 +1,4 @@
 xtc-llvm-tools==21.1.2.6
 xtc-mlir-tools==21.1.2.8
 xtc-mlir-python-bindings==21.1.2.8
-xtc-mlir-extra-tools==21.1.2.10
+xtc-mlir-extra-tools==21.1.2.11


### PR DESCRIPTION

# Motivation

Update to xtc-mlir-extra-tools version 21.1.2.11.

Fixes issue with emit C aligned_alloc which causes a segfault on MacOS with XTC_MLIR_TARGET=c.

Note that it also include other updates to xtc-mlir, in particular:
- added xtc-opt tool and reduce-extract-slices pass
- memref.copy with dynamic memref shapes
