### PR TITLE
tvm: fix spurious warning on some cpus

### DIFF
--- a/tvm_requirements.txt
+++ b/tvm_requirements.txt
@@ -1,2 +1,2 @@
 xtc-llvm-tools==21.1.2.6
-xtc-tvm-python-bindings==0.19.0.9
+xtc-tvm-python-bindings==0.19.0.10


### PR DESCRIPTION
# Motivation

Update to TVM version which remove spurious warning in case of multi frequency cores.

This fixes issues in tests when the CPU cores have more than 2 distinct max frequencies.

# Description

Update TVM package to version 0.19.0.10

It simply removes the warning as the fall back is well managed.
