### PR TITLE
Refactor Explore

### DIFF
--- a/.github/workflows/xtc-tests.yml
+++ b/.github/workflows/xtc-tests.yml
@@ -69,12 +69,16 @@ jobs:
       - name: Run Explore One Shot
         run: |
           COV=scripts/coverage/coverage_run.sh
-          env STRATEGIES=tile8dvr BACKENDS="tvm mlir" $COV ./scripts/explore/run-explore-one-shot.sh artifacts/explore
+          env STRATEGIES=tile8dvr BACKENDS="tvm mlir" $COV ./scripts/explore/run-explore-one-shot.sh artifacts/explore-one-shot
       - name: Run Explore Variants
         run: |
           COV=scripts/coverage/coverage_run.sh
-          env STRATEGIES=tile8dvr BACKENDS="tvm mlir" $COV ./scripts/explore/run-explore-variants.sh artifacts/explore
+          env STRATEGIES=tile8dvr BACKENDS="tvm mlir" $COV ./scripts/explore/run-explore-variants.sh artifacts/explore-variants
           env NOSHOW=1 scripts/explore/display-explore-variants.sh artifacts/explore
+      - name: Run Explore Optimizers
+        run: |
+          COV=scripts/coverage/coverage_run.sh
+          env TRIALS=20 BATCH=4 SEEDS="1 2 3" scripts/explore/run-explore-optimizers.sh artifacts/explore-optimizers
       - name: Generate Coverage Reports
         run: |
           coverage combine >/dev/null

--- a/.github/workflows/xtc-tests.yml
+++ b/.github/workflows/xtc-tests.yml
@@ -97,6 +97,7 @@ jobs:
           flags: py${{ matrix.python-version }}-${{ matrix.os }}
           name: py${{ matrix.python-version }}-${{ matrix.os }}
           token: ${{ secrets.CODECOV_TOKEN }}
+          skip_validation: true
           fail_ci_if_error: true
 
   pr-build:

--- a/.github/workflows/xtc-tests.yml
+++ b/.github/workflows/xtc-tests.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Ensure PR has linear history
         if: github.event_name == 'pull_request'
         run: |
-          MERGE_COMMITS="$(git rev-list --merges "${GITHUB_SHA}^1..${GITHUB_SHA}^2")"
+          MERGE_COMMITS="$(git rev-list --merges "${GITHUB_SHA}"^1.."${GITHUB_SHA}"^2)"
           if [ -n "${MERGE_COMMITS}" ]; then
             echo "::error::PR contains merges, always use rebase for updating branches: Merge commits: ${MERGE_COMMITS}" >&2
             exit 1
@@ -66,6 +66,15 @@ jobs:
         run: |
           COV=scripts/coverage/coverage_run.sh
           $COV make check
+      - name: Run Explore One Shot
+        run: |
+          COV=scripts/coverage/coverage_run.sh
+          env STRATEGIES=tile8dvr BACKENDS="tvm mlir" $COV ./scripts/explore/run-explore-one-shot.sh artifacts/explore
+      - name: Run Explore Variants
+        run: |
+          COV=scripts/coverage/coverage_run.sh
+          env STRATEGIES=tile8dvr BACKENDS="tvm mlir" $COV ./scripts/explore/run-explore-variants.sh artifacts/explore
+          env NOSHOW=1 scripts/explore/display-explore-variants.sh artifacts/explore
       - name: Generate Coverage Reports
         run: |
           coverage combine >/dev/null
@@ -74,13 +83,6 @@ jobs:
           coverage xml -o artifacts/coverage/coverage.xml
           coverage report --format=markdown >artifacts/coverage/coverage.md
           coverage html -d artifacts/coverage/html
-      - name: Run Explore One Shot
-        run: |
-          env STRATEGIES=tile8dvr BACKENDS="tvm mlir" ./scripts/explore/run-explore-one-shot.sh artifacts/explore
-      - name: Run Explore Variants
-        run: |
-          env STRATEGIES=tile8dvr BACKENDS="tvm mlir" ./scripts/explore/run-explore-variants.sh artifacts/explore
-          env NOSHOW=1 scripts/explore/display-explore-variants.sh artifacts/explore
       - name: Publish artifacts
         if: matrix.python-version == '3.12'
         uses: actions/upload-artifact@v5

--- a/docs/tutorials/explore_optimizers.py
+++ b/docs/tutorials/explore_optimizers.py
@@ -15,6 +15,7 @@ def _():
         search_type="random",
         batch=8,
         opt_name="random-forest-default",
+        progress_cls="mo",
     )
     if not mo.running_in_notebook():
         parser = argparse.ArgumentParser("Test notebook from CLI")
@@ -23,6 +24,7 @@ def _():
         parser.add_argument("--opt-name", type=str, default=args.opt_name)
         parser.add_argument("--batch", type=int, default=args.batch)
         args = parser.parse_args()
+        args.progress_cls = "tqdm"
 
     return explore, mo, args
 
@@ -159,6 +161,7 @@ def _(mo, search_ui):
 
 @app.cell
 def _(
+    args,
     backend_ui,
     batch_ui,
     explore,
@@ -188,13 +191,13 @@ def _(
     def config_used(ui):
         pass
 
-    def set_explore_args(config_path):
+    def get_explore_config(**kwargs):
         strategy_param = strategy_param_ui.value if strategy_ui.value == "prt" else ""
         if strategy_param:
             strategy = f"{strategy_ui.value}:{strategy_param}"
         else:
             strategy = strategy_ui.value
-        args = explore.default_exploration_config(
+        return explore.ExplorationConfig(
             operator = operator_ui.value,
             backends = backend_ui.value,
             strategy = strategy,
@@ -202,10 +205,10 @@ def _(
             seed = seed_ui.value,
             batch = batch_ui.value,
             optimizer = optimizer_ui.value,
-            optimizer_config = config_path,
-            trials = trials_ui.value
+            trials = trials_ui.value,
+            progress_cls = args.progress_cls,
+            **kwargs,
         )
-        return args
 
     def loop_explore():
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -215,11 +218,13 @@ def _(
                 tmpdir,
                 optimizer_config_ui,
             )
-            args = set_explore_args(config_path)
-            args.output = output_path
+            config = get_explore_config(
+                output=output_path,
+                optimizer_config=config_path,
+            )
 
             #mo.output.append("optimizing...")
-            exploration = explore.Exploration(args)
+            exploration = explore.Exploration(config)
             exploration()
 
             best = 0
@@ -257,11 +262,11 @@ def _(mo):
 def _(button, mo, run_loop_explore):
     if mo.running_in_notebook():
         mo.stop(not button.value)
-        with mo.status.spinner():
+        with mo.redirect_stdout(), mo.redirect_stderr():
             explore_out = run_loop_explore()
     else:
         explore_out = run_loop_explore()
-    mo.md(explore_out)
+    #mo.md(explore_out)
     return
 
 if __name__ == "__main__":

--- a/scripts/explore/run-explore-one-shot.sh
+++ b/scripts/explore/run-explore-one-shot.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+dir="$(dirname "$0")"
+
 outdir="${1-.}"
 BACKENDS="${BACKENDS:-mlir tvm jir}"
 OPTS="${OPTS:-1 2 3}"
@@ -9,16 +11,25 @@ STRATEGIES="${STRATEGIES:-" \
           "tile4d tile4dv " \
           "tile7d tile7dv tile7dvr " \
           "}"
+OPS="matmul conv2d"
+
+graph_dir="$dir"/../../tests/graphs
 
 mkdir -p "$outdir"
 rm -f "$outdir/*.csv"
+rm -f "$outdir/*.json"
 
-for s in $STRATEGIES; do
-    for b in $BACKENDS; do
-        for o in $OPTS; do
-            echo "Testing backend $b with tiling strategy $s for opt level $o..."
-            (set -x && loop-explore --backends "$b" --opt-level "$o" --jobs 1 --strategy "$s" --output "$outdir/results.b$b.s$s.o$o.csv")
+db_file="$outdir/results-variants-db.json"
+for op in $OPS; do
+    for s in $STRATEGIES; do
+        for b in $BACKENDS; do
+            for o in $OPTS; do
+                echo "Testing operator $op on backend $b with tiling strategy $s for opt level $o..."
+                (set -x && loop-explore --graph "$graph_dir"/"$op".graph.yaml --backends "$b" --opt-level "$o" --jobs 1 --strategy "$s" --output "$outdir/results.$op.b$b.s$s.o$o.csv" --db-file "$db_file")
+            done
         done
     done
 done
-
+for op in $OPS; do
+    (set -x && loop-results --graph "$graph_dir"/"$op".graph.yaml --db-file "$db_file")
+done

--- a/scripts/explore/run-explore-optimizers.sh
+++ b/scripts/explore/run-explore-optimizers.sh
@@ -4,16 +4,18 @@ set -euo pipefail
 outdir="${1-.}"
 BACKENDS="${BACKENDS:-tvm}"
 TRIALS="${TRIALS:-100}"
-SEEDS="${SEEDS:- 1 2 3 4 5}"
+SEEDS="${SEEDS:-1 2 3 4 5}"
 STRATEGY="${STRATEGY:-tile_ppwrprp}"
 OPTIMIZERS="${OPTIMIZERS:-random random-forest-aggressive}"
 PROBLEM="${PROBLEM:-ResNet18_01}"
 OPERATOR="${OPERATOR:-conv2d}"
 JOBS="${JOBS:-1}"
 BATCH="${BATCH:-1}"
+TRIALS="${TRIALS:-100}"
 
 mkdir -p "$outdir"
 rm -f "$outdir/*.csv"
+rm -f "$outdir/*.json"
 
 for b in $BACKENDS; do
     echo "using backend $b"
@@ -30,7 +32,8 @@ for b in $BACKENDS; do
               --op-name "$PROBLEM" \
               --jobs "$JOBS" \
               --batch "$BATCH" \
-              --seed $s \
+              --trials "$TRIALS" \
+              --seed "$s" \
               --strategy "$STRATEGY" \
               --output "$outdir/results.b$b.prob$PROBLEM.strat$STRATEGY.seed$s.csv"
             )

--- a/scripts/explore/run-explore-variants.sh
+++ b/scripts/explore/run-explore-variants.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+dir="$(dirname "$0")"
+
 outdir="${1-.}"
 BACKENDS="${BACKENDS:-mlir tvm jir}"
 TRIALS="${TRIALS:-20}"
@@ -9,15 +11,25 @@ STRATEGIES="${STRATEGIES:-" \
           "tile4d tile4dv " \
           "tile7d tile7dv tile7dvr " \
           "}"
+OPS="matmul conv2d"
+
+graph_dir="$dir"/../../tests/graphs
 
 mkdir -p "$outdir"
 rm -f "$outdir/*.csv"
+rm -f "$outdir/*.json"
 
+db_file="$outdir/results-variants-db.json"
 t="$TRIALS"
-for s in $STRATEGIES; do
-    for b in $BACKENDS; do
-        echo "Testing backend $b with tiling strategy $s for $t trials..."
-        (set -x && loop-explore --backends "$b" --trials "$t" --jobs 1 --strategy "$s" --output "$outdir/results.b$b.s$s.t$t.csv")
+for op in $OPS; do
+    for s in $STRATEGIES; do
+        for b in $BACKENDS; do
+            echo "Testing backend $b with tiling strategy $s for $t trials..."
+            (set -x && loop-explore --graph "$graph_dir"/"$op".graph.yaml --backends "$b" --trials "$t" --jobs 1 --strategy "$s" --output "$outdir/results.b$b.s$s.t$t.csv" --db-file "$db_file")
+        done
     done
+done
+for op in $OPS; do
+    (set -x && loop-results --graph "$graph_dir"/"$op".graph.yaml --db-file "$db_file")
 done
 

--- a/src/xtc/cli/explore.py
+++ b/src/xtc/cli/explore.py
@@ -8,7 +8,347 @@
 The exploration API lives in :mod:`xtc.search.explore`.
 """
 
-from xtc.search.explore import main
+import sys
+import argparse
+import logging
+import subprocess
+from typing import Sequence
+
+from xtc.search.explore import logger, ExplorationConfig, Exploration
+
+
+def launch_child(argv: Sequence[str], args: argparse.Namespace):
+    env = {}
+    if "tvm" in args.backends:
+        # Force number of threads for TVM
+        env.update({"TVM_NUM_THREADS": str(args.threads)})
+    cmd = [
+        "env",
+        *(f"{k}={v}" for k, v in env.items()),
+        "setarch",
+        "-R",
+        "--",
+        argv[0],
+        "--child",
+        *argv[1:],
+    ]
+    logger.debug("Executing child command: %s", " ".join(cmd))
+    proc = subprocess.run(
+        args=cmd,
+    )
+    if proc.returncode != 0:
+        logger.debug(
+            f"ERROR: running subprocess: exit code: %s, command: %s",
+            proc.returncode,
+            " ".join(cmd),
+        )
+    raise SystemExit(proc.returncode)
+
+
+def main():
+    defaults = ExplorationConfig()
+    parser = argparse.ArgumentParser(
+        description="Autotune Operator",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    parser.add_argument(
+        "--operator",
+        type=str,
+        default=defaults.operator,
+        help="operator to optimize, use --operator-list for available operators",
+    )
+    parser.add_argument(
+        "--operator-list",
+        action="store_true",
+        help="print available operators",
+    )
+    parser.add_argument(
+        "--graph-file",
+        type=str,
+        help="Input gaph serialized yaml file",
+    )
+    parser.add_argument(
+        "--op-name",
+        type=str,
+        help="operation to optimize, use --op-name-list for available operations",
+    )
+    parser.add_argument(
+        "--op-name-list",
+        action="store_true",
+        help="print available operations names for the given operator",
+    )
+    parser.add_argument(
+        "--func-name", type=str, help="function name to generate, default to operator"
+    )
+    parser.add_argument(
+        "--strategy",
+        type=str,
+        default=defaults.strategy,
+        help=f"tile strategy to use, use --strategy-list for list of strategies",
+    )
+    parser.add_argument(
+        "--strategy-list",
+        action="store_true",
+        help=f"print available strategies",
+    )
+    parser.add_argument(
+        "--descript",
+        type=str,
+        help="path to a descript yaml specification. Ignores --strategy if used.",
+    )
+    parser.add_argument(
+        "--search",
+        type=str,
+        choices=["random", "exhaustive", "data", "iterative"],
+        default=defaults.search,
+        help="search strategy",
+    )
+    parser.add_argument(
+        "--backends",
+        type=str,
+        nargs="+",
+        choices=["mlir", "tvm", "jir"],
+        default=defaults.backends,
+        help="backends to use",
+    )
+    parser.add_argument(
+        "--optimizer",
+        type=str,
+        default=defaults.optimizer,
+        help=f"optimizer to use, use --optimizer-list for list.",
+    )
+    parser.add_argument(
+        "--optimizer-list",
+        action="store_true",
+        help=f"print list of optimizers",
+    )
+    parser.add_argument(
+        "--data", type=str, help="data CSV file for input to data search"
+    )
+    parser.add_argument(
+        "--dims", nargs="+", type=int, help="dimensions, default to operators's default"
+    )
+    parser.add_argument(
+        "--huge-pages",
+        action=argparse.BooleanOptionalAction,
+        default=defaults.huge_pages,
+        help="alloc at huge page boundaries",
+    )
+    parser.add_argument(
+        "--test",
+        nargs="+",
+        type=int,
+        default=defaults.test,
+        help="test this input only",
+    )
+    parser.add_argument(
+        "--opt-level",
+        type=int,
+        default=defaults.opt_level,
+        help="opt level, 0-3 one-shot, 4 search",
+    )
+    parser.add_argument(
+        "--dtype",
+        type=str,
+        default=defaults.dtype,
+        choices=["float32", "float64"],
+        help="data type, default to operator's default",
+    )
+    parser.add_argument(
+        "--trials", type=int, default=defaults.trials, help="num trials"
+    )
+    parser.add_argument(
+        "--threads",
+        type=int,
+        default=defaults.threads,
+        help="number of execution threads",
+    )
+    parser.add_argument(
+        "--max-unroll",
+        type=int,
+        help="max unroll in tiling strategies, or strategy default",
+    )
+    parser.add_argument("--seed", type=int, default=defaults.seed, help="seed")
+    parser.add_argument(
+        "--output", type=str, default=defaults.output, help="output csv file for search"
+    )
+    parser.add_argument(
+        "--db-file",
+        type=str,
+        help="output json db, for instance: xtc-graphs-db.json",
+    )
+    parser.add_argument(
+        "--resume",
+        action=argparse.BooleanOptionalAction,
+        default=defaults.resume,
+        help="resume from an existing output file and skip already recorded samples",
+    )
+    parser.add_argument(
+        "--append",
+        action=argparse.BooleanOptionalAction,
+        default=defaults.append,
+        help="append new results to output file without deduplication",
+    )
+    parser.add_argument(
+        "--eval",
+        type=str,
+        choices=["eval"],
+        default=defaults.eval,
+        help="evaluation method",
+    )
+    parser.add_argument(
+        "--repeat", type=int, default=defaults.repeat, help="evaluation repeat"
+    )
+    parser.add_argument(
+        "--number", type=int, default=defaults.number, help="evaluation number"
+    )
+    parser.add_argument(
+        "--min-repeat-ms",
+        type=int,
+        default=defaults.min_repeat_ms,
+        help="evaluation min repeat ms",
+    )
+    parser.add_argument(
+        "--validate",
+        action=argparse.BooleanOptionalAction,
+        default=defaults.validate,
+        help="validate results",
+    )
+    parser.add_argument(
+        "--save-temps",
+        action=argparse.BooleanOptionalAction,
+        default=defaults.save_temps,
+        help="save temps to save temps dir",
+    )
+    parser.add_argument(
+        "--save-temps-dir",
+        type=str,
+        default=defaults.save_temps_dir,
+        help="save temps dir",
+    )
+    parser.add_argument(
+        "--explore-dir",
+        type=str,
+        default=defaults.explore_dir,
+        help="exploration results .so dir",
+    )
+    parser.add_argument(
+        "--optimizer-config",
+        type=str,
+        default=defaults.optimizer_config,
+        help="config yaml file for optimizer",
+    )
+    parser.add_argument(
+        "--child",
+        action=argparse.BooleanOptionalAction,
+        default=False,
+        help="internal flag for marking child execution (obsolete)",
+    )
+    parser.add_argument(
+        "--bare-ptr",
+        action=argparse.BooleanOptionalAction,
+        default=defaults.bare_ptr,
+        help="use bare pointer interface (for TVM backend)",
+    )
+    parser.add_argument(
+        "--jobs", type=int, default=defaults.jobs, help="parallel compile jobs"
+    )
+    parser.add_argument(
+        "--execute",
+        action=argparse.BooleanOptionalAction,
+        default=defaults.execute,
+        help="do not execute, only compile",
+    )
+    parser.add_argument(
+        "--peak-flops",
+        type=float,
+        help="machine peak flops (flop/sec) for the dtype, or estimated",
+    )
+    parser.add_argument(
+        "--mlir-prefix", type=str, help="MLIR install prefix, defaults to mlir package"
+    )
+    parser.add_argument(
+        "--use-tensors",
+        action=argparse.BooleanOptionalAction,
+        default=defaults.use_tensors,
+        help="use tensors instead of memref for the mlir backend",
+    )
+    parser.add_argument(
+        "--batch", type=int, default=defaults.batch, help="batch size for optimizer"
+    )
+    parser.add_argument(
+        "--debug",
+        action=argparse.BooleanOptionalAction,
+        default=False,
+        help="debug mode",
+    )
+    parser.add_argument(
+        "--debug-compile",
+        action=argparse.BooleanOptionalAction,
+        default=defaults.debug_compile,
+        help="debug compile commands",
+    )
+    parser.add_argument(
+        "--debug-xtc",
+        action=argparse.BooleanOptionalAction,
+        default=False,
+        help="debug xtc modules",
+    )
+    parser.add_argument(
+        "--debug-optimizer",
+        action=argparse.BooleanOptionalAction,
+        default=False,
+        help="debug optimizer",
+    )
+    parser.add_argument(
+        "--quiet",
+        action=argparse.BooleanOptionalAction,
+        default=defaults.quiet,
+        help="quiet optional output and progress bar",
+    )
+    parser.add_argument(
+        "--dump",
+        action=argparse.BooleanOptionalAction,
+        default=defaults.dump,
+        help="dump IR while generating",
+    )
+    args = parser.parse_args()
+
+    if args.resume and args.append:
+        parser.error("--resume and --append cannot be used together")
+
+    logging.basicConfig()
+    logger.setLevel(logging.INFO)
+    if args.debug:
+        logger.setLevel(logging.DEBUG)
+    if args.debug_xtc:
+        logging.getLogger("xtc").setLevel(logging.DEBUG)
+    if args.debug_optimizer:
+        logging.getLogger("xtc.search.optimizers").setLevel(logging.INFO)
+
+    if not args.child:
+        launch_child(sys.argv, args)
+
+    if args.operator_list:
+        Exploration.list_operators()
+        raise SystemExit()
+
+    if args.op_name_list:
+        assert args.operator is not None
+        Exploration.list_operations_dims(args.operator)
+        raise SystemExit()
+
+    if args.strategy_list:
+        Exploration.list_strategies()
+        raise SystemExit()
+
+    if args.optimizer_list:
+        Exploration.list_optimizers()
+        raise SystemExit()
+
+    config = ExplorationConfig.from_args(args)
+    exploration = Exploration(config)
+    exploration.run()
 
 
 if __name__ == "__main__":

--- a/src/xtc/cli/explore.py
+++ b/src/xtc/cli/explore.py
@@ -22,12 +22,16 @@ def launch_child(argv: Sequence[str], args: argparse.Namespace):
     if "tvm" in args.backends:
         # Force number of threads for TVM
         env.update({"TVM_NUM_THREADS": str(args.threads)})
-    cmd = [
+    env_args = [
         "env",
         *(f"{k}={v}" for k, v in env.items()),
-        "setarch",
-        "-R",
-        "--",
+    ]
+    setarch_args = []
+    if sys.platform.startswith("linux"):
+        setarch_args = ["setarch", "-R", "--"]
+    cmd = [
+        *env_args,
+        *setarch_args,
         argv[0],
         "--child",
         *argv[1:],

--- a/src/xtc/graphs/xtc/builder.py
+++ b/src/xtc/graphs/xtc/builder.py
@@ -4,6 +4,7 @@
 #
 from typing import Any
 import yaml
+from pathlib import Path
 
 from .graph import XTCGraph
 from .context import XTCGraphContext
@@ -75,7 +76,7 @@ class graph_builder:
         cls.from_dict(yaml.safe_load(yaml_str))
 
     @classmethod
-    def load(cls, file_name: str) -> None:
+    def load(cls, file_name: str | Path) -> None:
         with open(file_name, "r") as f:
             cls.from_dict(yaml.safe_load(f))
 

--- a/src/xtc/search/callback.py
+++ b/src/xtc/search/callback.py
@@ -1,0 +1,172 @@
+#
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2024-2026 The XTC Project Authors
+#
+from abc import ABC, abstractmethod
+from typing_extensions import override
+from collections.abc import Sequence
+from typing import Any
+import json
+import csv
+from pathlib import Path
+import logging
+import os
+
+from xtc.itf.graph import Graph
+from xtc.itf.search import Sample
+from xtc.cli.query_results import ResultsDB
+
+logger = logging.getLogger(__name__)
+
+
+class ResultCallBack(ABC):
+    @abstractmethod
+    def __call__(self, result: Sequence) -> None: ...
+
+
+class DBCallback(ResultCallBack):
+    def __init__(
+        self,
+        dbfile: str,
+        target: str,
+        threads: int,
+        strategy: str,
+    ) -> None:
+        self._dbfile = dbfile
+        self._target = target
+        self._threads = threads
+        self._version = ResultsDB.get_version()
+        self._platform = ResultsDB.get_native_platform()
+        self._operator: list[Any] | None = None
+        self._strategy = ResultsDB.get_strategy(strategy)
+
+    def set_graph(self, graph: Graph):
+        # assert len(graph.nodes) == 1, f"Only support recording of single node graph"
+        # self._operator = ["xtc.operator", *signature]
+        self._operator = ResultsDB.get_operator(graph)
+
+    def _write_result(self, result: Sequence) -> None:
+        x, code, time, backend = result
+        if code != 0:
+            time = 0
+        compiler = ResultsDB.get_compiler(self._target, self._threads, backend)
+        log = dict(
+            version=self._version,
+            platform=self._platform,
+            compiler=compiler,
+            operator=self._operator,
+            strategy=self._strategy,
+            schedule=list(x),
+            results=[int(code), [float(time)]],
+        )
+        log_json = json.dumps(log)
+        with open(self._dbfile, "a") as outf:
+            print(log_json, flush=True, file=outf)
+
+    @override
+    def __call__(self, result: Sequence) -> None:
+        self._write_result(result)
+
+
+class MemoryCallback(ResultCallBack):
+    def __init__(self) -> None:
+        self.results: list[Sequence] = []
+
+    @override
+    def __call__(self, result: Sequence) -> None:
+        self.results.append(result)
+
+
+class CSVCallback(ResultCallBack):
+    def __init__(
+        self,
+        fname: str,
+        peak_time: float,
+        sample_names: list[str],
+        *,
+        resume: bool = False,
+        append: bool = False,
+    ) -> None:
+        self._fname = fname
+        self._peak_time = peak_time
+        self._sample_names = sample_names
+        self._header = sample_names + ["X", "time", "peak", "backend"]
+        self._results: list[Sequence] = []
+        self._rows: list[Sequence] = []
+        self._seen_keys: set[tuple[str, tuple[int, ...]]] = set()
+        self._resume = resume
+        self._append = append
+
+        out_path = Path(fname)
+        has_existing_file = out_path.exists() and out_path.stat().st_size > 0
+        if resume:
+            self._load_existing_rows()
+            mode = "a"
+        elif append:
+            mode = "a"
+        else:
+            mode = "w"
+
+        self._outf = open(fname, mode, newline="")
+        self._writer = csv.writer(self._outf, delimiter=",")
+
+        should_write_header = (not has_existing_file) or (mode == "w")
+        if should_write_header:
+            self._write_header()
+
+    def _load_existing_rows(self) -> None:
+        in_path = Path(self._fname)
+        if not in_path.exists() or in_path.stat().st_size == 0:
+            return
+        with open(in_path, newline="") as infile:
+            reader = csv.DictReader(infile, delimiter=",")
+            for row in reader:
+                backend = row.get("backend")
+                if backend is None:
+                    continue
+                try:
+                    sample = tuple(int(row[name]) for name in self._sample_names)
+                except (TypeError, ValueError, KeyError):
+                    continue
+                self._seen_keys.add((backend, sample))
+
+    def _sample_key(self, x: Sample, backend: str) -> tuple[str, tuple[int, ...]]:
+        return backend, tuple(int(v) for v in x)
+
+    def _write_header(self) -> None:
+        self._writer.writerow(self._header)
+        self._outf.flush()
+
+    def _write_row(self, row: Sequence) -> None:
+        self._rows.append(row)
+        self._writer.writerow(row)
+        self._outf.flush()
+        try:
+            os.fsync(self._outf.fileno())
+        except OSError:
+            logger.debug("Unable to fsync output file %s", self._fname)
+
+    def _write_result(self, result: Sequence) -> None:
+        self._results.append(result)
+        x, error, time, backend = result
+        if error != 0:
+            logger.debug(f"Skip recording error for: {backend}: {x}")
+            return
+        key = self._sample_key(x, backend)
+        if self._resume and key in self._seen_keys:
+            logger.debug("Skip already recorded sample for resume mode: %s", key)
+            return
+        peak = self._peak_time / time
+        s = str(x).replace(",", ";")
+        row = [s, time, peak, backend]
+        row = x + row
+        logger.debug(f"Record row: {row}")
+        self._write_row(row)
+        self._seen_keys.add(key)
+
+    @override
+    def __call__(self, result: Sequence) -> None:
+        self._write_result(result)
+
+    def __del__(self) -> None:
+        self._outf.close()

--- a/src/xtc/search/explore.py
+++ b/src/xtc/search/explore.py
@@ -27,7 +27,6 @@ from datetime import datetime, timezone
 import numpy as np
 import numpy.typing
 import subprocess
-from concurrent.futures import ThreadPoolExecutor, Future
 import multiprocessing
 from pathlib import Path
 from collections.abc import Sequence, Mapping
@@ -53,6 +52,7 @@ from xtc.search.optimizers import Optimizers
 
 from .progress import SearchProgress, SearchProgressTQDM, SearchProgressMO
 from .callback import ResultCallBack, CSVCallback, DBCallback, MemoryCallback
+from .pipeline import CompileExecutePipeline
 
 logger = logging.getLogger(__name__)
 
@@ -444,76 +444,73 @@ class Exploration:
         graph: Graph,
         callbacks: CallBacks = {},
     ):
-        args = self.config
-        jobs = args.jobs
+        jobs = self.config.jobs
+        ntasks = len(all_in_x)
+        batch_ntasks = ntasks * len(self.config.backends)
 
-        def do_compile(idx: int, in_x: Sample):
-            return idx, self.compile_one_all_backends(
+        def compile_func(idx_sample: Any) -> Any:
+            idx, in_x = idx_sample
+            if idx % jobs == 0:
+                search_callback.compile_batch_start()
+            search_callback.compile_job_start()
+            res = self.compile_one_all_backends(
                 ident=f"{idx:04}",
                 graph=graph,
                 strategy=strategy,
                 in_x=in_x,
                 callbacks=callbacks,
             )
+            search_callback.compile_job_end()
+            if idx == ntasks - 1 or idx + jobs - 1 % jobs == 0:
+                search_callback.compile_batch_end()
+            return idx, res
 
-        batch_ntasks = len(all_in_x) * len(args.backends)
+        def execute_func(idx_comp_result: Any) -> Any:
+            if not self.config.execute:
+                return None
+            idx, comp_result = idx_comp_result
+            if idx % jobs == 0:
+                search_callback.execute_batch_start()
+            search_callback.execute_job_start()
+            exec_results = []
+            for compiled in comp_result:
+                search_callback.execute_job_start()
+                ident, backend, module, dump_file, in_x = compiled
+                exec_results.append(
+                    self.load_and_evaluate_sample(
+                        ident,
+                        backend,
+                        module,
+                        in_x,
+                        callbacks=callbacks,
+                    )
+                )
+                search_callback.execute_job_end()
+            if idx == ntasks - 1 or idx + jobs - 1 % jobs == 0:
+                search_callback.execute_batch_end()
+            return exec_results
+
+        pipeline = CompileExecutePipeline(
+            compile_func,
+            execute_func,
+            jobs,
+        )
         search_callback = cast(
             SearchProgress,
             callbacks["search"] if "search" in callbacks else SearchProgress(),
         )
         search_callback.batch_start(batch_ntasks)
-        results = []
-        for job_idx, job_in_x in enumerate(
-            np.array_split(all_in_x, np.ceil(len(all_in_x) / jobs), axis=0)
-        ):
-            search_callback.compile_batch_start()
-            job_compiled = []
-            if jobs == 1:
-                search_callback.compile_job_start()
-                job_compiled.append(do_compile(idx=job_idx, in_x=job_in_x[0].tolist()))
-                search_callback.compile_job_end()
-            else:
-
-                def future_callback(future: Future):
-                    job_compiled.append(future.result())
-                    search_callback.compile_job_end()
-
-                with ThreadPoolExecutor(max_workers=jobs) as executor:
-                    futures = []
-                    for idx, in_x in enumerate(job_in_x):
-                        search_callback.compile_job_start()
-                        future = executor.submit(
-                            do_compile,
-                            idx=job_idx * jobs + idx,
-                            in_x=in_x.tolist(),
-                        )
-                        future.add_done_callback(future_callback)
-                        futures.append(future)
-                if len(job_compiled) < len(job_in_x):
-                    raise RuntimeError("compilation error in some compile job(s)")
-            search_callback.compile_batch_end()
-            if args.execute:
-                compiled_results = [
-                    x[1] for x in sorted(job_compiled, key=lambda x: x[0])
-                ]
-                search_callback.execute_batch_start()
-                for compiled_list in compiled_results:
-                    for compiled in compiled_list:
-                        search_callback.execute_job_start()
-                        ident, backend, module, dump_file, in_x = compiled
-                        results.append(
-                            self.load_and_evaluate_sample(
-                                ident,
-                                backend,
-                                module,
-                                in_x,
-                                callbacks=callbacks,
-                            )
-                        )
-                        search_callback.execute_job_end()
-                search_callback.execute_batch_end()
-            search_callback.compile_batch_end()
-        return results
+        results = pipeline.run(enumerate(x.tolist() for x in all_in_x))
+        search_callback.batch_end()
+        if self.config.execute:
+            exec_results = [
+                x
+                for x in itertools.chain(*[res.exec_result for res in results])
+                if x is not None
+            ]
+        else:
+            exec_results = []
+        return exec_results
 
     def evaluate_iterative(
         self,
@@ -621,9 +618,9 @@ class Exploration:
 
     def peak_time(self, graph: Graph) -> float:
         args = self.config
-        assert args.peak_flops is not None
         if not args.execute:
             return 0
+        assert args.peak_flops is not None
         ops_count = graph.ops_count()
         return ops_count / args.peak_flops / args.threads
 

--- a/src/xtc/search/explore.py
+++ b/src/xtc/search/explore.py
@@ -14,11 +14,9 @@ Though most strategies are supported for all backends for matmult.
 
 """
 
-from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 import sys
 import os
-import argparse
 from argparse import Namespace as NS
 import logging
 import itertools
@@ -28,14 +26,12 @@ import random
 from datetime import datetime, timezone
 import numpy as np
 import numpy.typing
-from tqdm import tqdm
 import subprocess
 from concurrent.futures import ThreadPoolExecutor, Future
 import multiprocessing
 from pathlib import Path
 from collections.abc import Sequence, Mapping
 from typing import Any, TypeAlias, cast
-from typing_extensions import override
 from importlib import import_module
 
 from xtc.itf.back import Backend
@@ -55,12 +51,15 @@ from xtc.runtimes.host import HostRuntime
 from xtc.artifacts import get_operation, list_operations
 from xtc.search.optimizers import Optimizers
 
+from .progress import SearchProgress, SearchProgressTQDM, SearchProgressMO
+from .callback import ResultCallBack, CSVCallback, DBCallback, MemoryCallback
+
 logger = logging.getLogger(__name__)
 
 NPSamples: TypeAlias = numpy.typing.NDArray[np.int64]
 CallBacks: TypeAlias = Mapping[str, Any]
 
-__all__ = ["ExplorationConfig", "default_exploration_config", "Exploration"]
+__all__ = ["ExplorationConfig", "Exploration"]
 
 
 @dataclass
@@ -68,9 +67,8 @@ class ExplorationConfig:
     operator: str | None = "matmul"
     graph_file: str | None = None
     op_name: str | None = None
-    ops_list: bool = False
     func_name: str | None = None
-    strategy: str | None = None
+    strategy: str = "tile_oo"
     search: str = "random"
     backends: list[str] = field(default_factory=lambda: ["mlir"])
     optimizer: str = "random-forest-default"
@@ -92,24 +90,20 @@ class ExplorationConfig:
     repeat: int = 1
     number: int = 1
     min_repeat_ms: int = 100
-    validate: bool | None = None
-    save_temps: bool | None = None
+    validate: bool = False
+    save_temps: bool = False
     save_temps_dir: str = "./save_temps_dir"
     explore_dir: str = "."
-    optimizer_config: str | None = None
-    child: bool = True
+    optimizer_config: str = ""
     bare_ptr: bool = False
     jobs: int = field(default_factory=lambda: max(1, multiprocessing.cpu_count() // 2))
     execute: bool = True
     peak_flops: float | None = None
     mlir_prefix: str | None = None
     batch: int = 1
-    debug: bool | None = None
-    debug_compile: bool | None = None
-    debug_xtc: bool | None = None
-    debug_optimizer: bool | None = None
-    quiet: bool | None = None
-    dump: bool | None = None
+    debug_compile: bool = False
+    quiet: bool = False
+    dump: bool = False
     eval_parameters: Any = None
     memory_callback: Any = None
     csv_callback: Any = None
@@ -117,333 +111,41 @@ class ExplorationConfig:
     results: list[Sequence] = field(default_factory=list)
     descript: str | None = None
     use_tensors: bool = False
+    progress_cls: str = "tqdm"
 
+    def __post_init__(self):
+        if self.graph_file is not None:
+            self.operator = None
+            self.func_name = None
 
-def default_exploration_config(
-    config: ExplorationConfig | NS | None = None,
-    **overrides: Any,
-) -> ExplorationConfig:
-    """Return a complete, normalized exploration configuration.
+        # Workaround to ensure that TVM backend is after MLIR backends,
+        # otherwise the import of tvm breaks the MLIR python bindings
+        self.backends = sorted(self.backends)
 
-    The returned object can be passed directly to :class:`Exploration` and
-    customized further by user scripts and notebooks before running.
-    """
-    normalized = ExplorationConfig()
-    if config is not None:
-        for key, value in vars(config).items():
-            if hasattr(normalized, key):
-                setattr(normalized, key, value)
-    for key, value in overrides.items():
-        if not hasattr(normalized, key):
-            raise TypeError(f"unknown exploration configuration option: {key}")
-        setattr(normalized, key, value)
-    setup_args(normalized)
-    return normalized
+        if self.operator:
+            if not self.func_name:
+                self.func_name = self.operator
+            for backend in self.backends:
+                assert backend in cast(list, OPERATORS[self.operator]["backends"]), (
+                    f"backend {backend} not available for operator {self.operator}"
+                )
 
-
-class SearchProgress:
-    def search_start(self, ntasks: int):
-        pass
-
-    def compile_batch_start(self):
-        pass
-
-    def compile_job_start(self):
-        pass
-
-    def compile_job_end(self):
-        pass
-
-    def compile_batch_end(self):
-        pass
-
-    def execute_batch_start(self):
-        pass
-
-    def execute_job_start(self):
-        pass
-
-    def execute_job_end(self):
-        pass
-
-    def execute_batch_end(self):
-        pass
-
-    def search_end(self):
-        pass
-
-
-class SearchProgressTQDM(SearchProgress):
-    def __init__(
-        self,
-        ncomp_per_job: int = 1,
-        nexec_per_job: int = 1,
-        quiet: bool = False,
-        prefix: str = "",
-        position: int = 0,
+    @staticmethod
+    def from_args(
+        args: NS | None = None,
+        **overrides: Any,
     ):
-        self.ncomp_per_job = ncomp_per_job
-        self.nexec_per_job = nexec_per_job
-        self.quiet = quiet
-        self.prefix = prefix
-        self.position = position
-        self.allbar: Any = None
-        self.compbar: Any = None
-        self.evalbar: Any = None
-        self.ntasks = 0
-
-    @override
-    def search_start(self, ntasks: int):
-        self.ntasks = ntasks
-        tqdm_args = dict(
-            total=self.ntasks,
-            miniters=0,
-            mininterval=0,
-            smoothing=0,
-            disable=self.quiet,
-        )
-        self.allbar = tqdm(
-            desc=f"{self.prefix} evaluate".strip(),
-            colour="red",
-            position=self.position + 0,
-            **tqdm_args,  # type: ignore
-        )
-        self.compbar = tqdm(
-            desc=f"{self.prefix} compile".strip(),
-            colour="blue",
-            position=self.position + 1,
-            **tqdm_args,  # type: ignore
-        )
-        if self.nexec_per_job > 0:
-            self.evalbar = tqdm(
-                desc=f"{self.prefix} execute".strip(),
-                colour="green",
-                position=self.position + 2,
-                **tqdm_args,  # type: ignore
-            )
-
-    @override
-    def compile_batch_start(self):
-        self.compbar.unpause()
-
-    @override
-    def compile_job_start(self):
-        pass
-
-    @override
-    def compile_job_end(self):
-        self.compbar.update(self.ncomp_per_job)
-        if self.nexec_per_job == 0:
-            self.allbar.update(self.ncomp_per_job)
-
-    @override
-    def compile_batch_end(self):
-        self.compbar.update(0)
-        self.allbar.update(0)
-
-    @override
-    def execute_batch_start(self):
-        if self.nexec_per_job > 0:
-            self.evalbar.unpause()
-
-    @override
-    def execute_job_start(self):
-        pass
-
-    @override
-    def execute_job_end(self):
-        if self.nexec_per_job > 0:
-            self.evalbar.update(self.nexec_per_job)
-            self.allbar.update(self.nexec_per_job)
-
-    @override
-    def execute_batch_end(self):
-        pass
-
-    @override
-    def search_end(self):
-        self.compbar.unpause()
-        if self.nexec_per_job > 0:
-            self.evalbar.unpause()
-        self.allbar.close()
-        self.compbar.close()
-        if self.nexec_per_job > 0:
-            self.evalbar.close()
-
-
-class IterativeProgressTQDM(SearchProgressTQDM):
-    def __init__(self, *args: Any):
-        super().__init__(*args)
-
-    @override
-    def search_start(self, ntasks: int):
-        pass
-
-    @override
-    def search_end(self):
-        pass
-
-    def iterations_start(self, ntasks: int):
-        super().search_start(ntasks)
-
-    def iterations_end(self):
-        super().search_end()
-
-
-class ResultCallBack(ABC):
-    @abstractmethod
-    def __call__(self, result: Sequence) -> None: ...
-
-
-from xtc.cli.query_results import ResultsDB
-
-
-class DBCallback(ResultCallBack):
-    def __init__(
-        self,
-        dbfile: str,
-        target: str,
-        threads: int,
-        strategy: str,
-    ) -> None:
-        self._dbfile = dbfile
-        self._target = target
-        self._threads = threads
-        self._version = ResultsDB.get_version()
-        self._platform = ResultsDB.get_native_platform()
-        self._operator: list[Any] | None = None
-        self._strategy = ResultsDB.get_strategy(strategy)
-
-    def set_graph(self, graph: Graph):
-        # assert len(graph.nodes) == 1, f"Only support recording of single node graph"
-        # self._operator = ["xtc.operator", *signature]
-        self._operator = ResultsDB.get_operator(graph)
-
-    def _write_result(self, result: Sequence) -> None:
-        x, code, time, backend = result
-        if code != 0:
-            time = 0
-        compiler = ResultsDB.get_compiler(self._target, self._threads, backend)
-        log = dict(
-            version=self._version,
-            platform=self._platform,
-            compiler=compiler,
-            operator=self._operator,
-            strategy=self._strategy,
-            schedule=list(x),
-            results=[int(code), [float(time)]],
-        )
-        log_json = json.dumps(log)
-        with open(self._dbfile, "a") as outf:
-            print(log_json, flush=True, file=outf)
-
-    @override
-    def __call__(self, result: Sequence) -> None:
-        self._write_result(result)
-
-
-class MemoryCallback(ResultCallBack):
-    def __init__(self) -> None:
-        self.results: list[Sequence] = []
-
-    @override
-    def __call__(self, result: Sequence) -> None:
-        self.results.append(result)
-
-
-class CSVCallback(ResultCallBack):
-    def __init__(
-        self,
-        fname: str,
-        peak_time: float,
-        sample_names: list[str],
-        *,
-        resume: bool = False,
-        append: bool = False,
-    ) -> None:
-        self._fname = fname
-        self._peak_time = peak_time
-        self._sample_names = sample_names
-        self._header = sample_names + ["X", "time", "peak", "backend"]
-        self._results: list[Sequence] = []
-        self._rows: list[Sequence] = []
-        self._seen_keys: set[tuple[str, tuple[int, ...]]] = set()
-        self._resume = resume
-        self._append = append
-
-        out_path = Path(fname)
-        has_existing_file = out_path.exists() and out_path.stat().st_size > 0
-        if resume:
-            self._load_existing_rows()
-            mode = "a"
-        elif append:
-            mode = "a"
-        else:
-            mode = "w"
-
-        self._outf = open(fname, mode, newline="")
-        self._writer = csv.writer(self._outf, delimiter=",")
-
-        should_write_header = (not has_existing_file) or (mode == "w")
-        if should_write_header:
-            self._write_header()
-
-    def _load_existing_rows(self) -> None:
-        in_path = Path(self._fname)
-        if not in_path.exists() or in_path.stat().st_size == 0:
-            return
-        with open(in_path, newline="") as infile:
-            reader = csv.DictReader(infile, delimiter=",")
-            for row in reader:
-                backend = row.get("backend")
-                if backend is None:
-                    continue
-                try:
-                    sample = tuple(int(row[name]) for name in self._sample_names)
-                except (TypeError, ValueError, KeyError):
-                    continue
-                self._seen_keys.add((backend, sample))
-
-    def _sample_key(self, x: Sample, backend: str) -> tuple[str, tuple[int, ...]]:
-        return backend, tuple(int(v) for v in x)
-
-    def _write_header(self) -> None:
-        self._writer.writerow(self._header)
-        self._outf.flush()
-
-    def _write_row(self, row: Sequence) -> None:
-        self._rows.append(row)
-        self._writer.writerow(row)
-        self._outf.flush()
-        try:
-            os.fsync(self._outf.fileno())
-        except OSError:
-            logger.debug("Unable to fsync output file %s", self._fname)
-
-    def _write_result(self, result: Sequence) -> None:
-        self._results.append(result)
-        x, error, time, backend = result
-        if error != 0:
-            logger.debug(f"Skip recording error for: {backend}: {x}")
-            return
-        key = self._sample_key(x, backend)
-        if self._resume and key in self._seen_keys:
-            logger.debug("Skip already recorded sample for resume mode: %s", key)
-            return
-        peak = self._peak_time / time
-        s = str(x).replace(",", ";")
-        row = [s, time, peak, backend]
-        row = x + row
-        logger.debug(f"Record row: {row}")
-        self._write_row(row)
-        self._seen_keys.add(key)
-
-    @override
-    def __call__(self, result: Sequence) -> None:
-        self._write_result(result)
-
-    def __del__(self) -> None:
-        self._outf.close()
+        config = ExplorationConfig()
+        if args is not None:
+            for key, value in vars(args).items():
+                if hasattr(config, key):
+                    setattr(config, key, value)
+        for key, value in overrides.items():
+            if not hasattr(config, key):
+                raise TypeError(f"unknown exploration configuration option: {key}")
+            setattr(config, key, value)
+        config.__post_init__()
+        return config
 
 
 OPERATORS = {
@@ -502,9 +204,8 @@ class Exploration:
     then inspect the structured results through the :attr:`results` field.
     """
 
-    def __init__(self, config: ExplorationConfig | NS | None = None, **overrides: Any):
-        config = default_exploration_config(config=config, **overrides)
-        self.config = config
+    def __init__(self, config: ExplorationConfig | None = None):
+        self.config = config if config is not None else ExplorationConfig()
         self.results: list[Sequence] = []
 
     @staticmethod
@@ -566,8 +267,8 @@ class Exploration:
         impl = module.Backend(graph, **kwargs)
         return impl, backend
 
-    @staticmethod
-    def get_dims(args: NS | ExplorationConfig) -> dict[str, int]:
+    def get_dims(self) -> dict[str, int]:
+        args = self.config
         if not args.operator:
             return {}
         dims_names = cast(list[str], OPERATORS[args.operator]["dims"])
@@ -582,21 +283,21 @@ class Exploration:
         dims_map = {k: v for k, v in zip(dims_names, dims)}
         return dims_map
 
-    @staticmethod
-    def get_dtype(args: NS | ExplorationConfig) -> str:
+    def get_dtype(self) -> str:
+        args = self.config
         if not args.operator:
             return ""
         return args.dtype
 
-    @staticmethod
-    def get_eval_parameters(args: NS | ExplorationConfig):
+    def init_eval_parameters(self):
+        args = self.config
         assert args.operator is not None
         if args.huge_pages:
             NDArray.set_alloc_alignment(2 * 1024 * 1024)
         else:
             NDArray.set_alloc_alignment(256)
-        dims_map = Exploration.get_dims(args)
-        dtype = Exploration.get_dtype(args)
+        dims_map = self.get_dims()
+        dtype = self.get_dtype()
         inputs = cast(list[list[str]], OPERATORS[args.operator]["inputs"])
         outputs = cast(list[list[str]], OPERATORS[args.operator]["outputs"])
         inputs_spec = [
@@ -617,10 +318,9 @@ class Exploration:
         graph: Graph,
         strategy: Strategy,
         in_x: Sample,
-        args: NS | ExplorationConfig | None = None,
         callbacks: CallBacks = {},
     ):
-        args = cast(NS, self.config if args is None else args)
+        args = self.config
         compiled = []
         for backend in args.backends:
             task_ident = f"{graph.name}_{backend}_{ident}"
@@ -631,7 +331,6 @@ class Exploration:
                     graph,
                     strategy,
                     in_x,
-                    args,
                     callbacks=callbacks,
                 )
             )
@@ -644,11 +343,10 @@ class Exploration:
         graph: Graph,
         strategy: Strategy,
         in_x: Sample,
-        args: NS | ExplorationConfig | None = None,
         callbacks: CallBacks = {},
         dump_file: str | None = None,
     ):
-        args = cast(NS, self.config if args is None else args)
+        args = self.config
         assert isinstance(in_x, list), f"X not a list: {in_x} ({type(in_x)})"
         logger.debug("Compile: %s: %s: %s...", ident, backend, in_x)
         impl, backend_name = self.graph_implementer(
@@ -701,10 +399,9 @@ class Exploration:
         backend: str,
         module: Module,
         in_x: Sample,
-        args: NS | ExplorationConfig | None = None,
         callbacks: CallBacks = {},
     ):
-        args = cast(NS, self.config if args is None else args)
+        args = self.config
         logger.debug("Evaluate: %s: %s...", ident, in_x)
         evaluator_args = dict(
             repeat=args.repeat,
@@ -745,10 +442,9 @@ class Exploration:
         strategy: Strategy,
         all_in_x: NPSamples,
         graph: Graph,
-        args: NS | ExplorationConfig | None = None,
         callbacks: CallBacks = {},
     ):
-        args = cast(NS, self.config if args is None else args)
+        args = self.config
         jobs = args.jobs
 
         def do_compile(idx: int, in_x: Sample):
@@ -757,107 +453,103 @@ class Exploration:
                 graph=graph,
                 strategy=strategy,
                 in_x=in_x,
-                args=args,
                 callbacks=callbacks,
             )
 
-        ntasks = len(all_in_x) * len(args.backends)
+        batch_ntasks = len(all_in_x) * len(args.backends)
         search_callback = cast(
             SearchProgress,
             callbacks["search"] if "search" in callbacks else SearchProgress(),
         )
-        search_callback.search_start(ntasks)
+        search_callback.batch_start(batch_ntasks)
         results = []
-        try:
-            for job_idx, job_in_x in enumerate(
-                np.array_split(all_in_x, np.ceil(len(all_in_x) / jobs), axis=0)
-            ):
-                search_callback.compile_batch_start()
-                job_compiled = []
-                if jobs == 1:
-                    search_callback.compile_job_start()
-                    job_compiled.append(
-                        do_compile(idx=job_idx, in_x=job_in_x[0].tolist())
-                    )
+        for job_idx, job_in_x in enumerate(
+            np.array_split(all_in_x, np.ceil(len(all_in_x) / jobs), axis=0)
+        ):
+            search_callback.compile_batch_start()
+            job_compiled = []
+            if jobs == 1:
+                search_callback.compile_job_start()
+                job_compiled.append(do_compile(idx=job_idx, in_x=job_in_x[0].tolist()))
+                search_callback.compile_job_end()
+            else:
+
+                def future_callback(future: Future):
+                    job_compiled.append(future.result())
                     search_callback.compile_job_end()
-                else:
 
-                    def future_callback(future: Future):
-                        job_compiled.append(future.result())
-                        search_callback.compile_job_end()
-
-                    with ThreadPoolExecutor(max_workers=jobs) as executor:
-                        futures = []
-                        for idx, in_x in enumerate(job_in_x):
-                            search_callback.compile_job_start()
-                            future = executor.submit(
-                                do_compile,
-                                idx=job_idx * jobs + idx,
-                                in_x=in_x.tolist(),
+                with ThreadPoolExecutor(max_workers=jobs) as executor:
+                    futures = []
+                    for idx, in_x in enumerate(job_in_x):
+                        search_callback.compile_job_start()
+                        future = executor.submit(
+                            do_compile,
+                            idx=job_idx * jobs + idx,
+                            in_x=in_x.tolist(),
+                        )
+                        future.add_done_callback(future_callback)
+                        futures.append(future)
+                if len(job_compiled) < len(job_in_x):
+                    raise RuntimeError("compilation error in some compile job(s)")
+            search_callback.compile_batch_end()
+            if args.execute:
+                compiled_results = [
+                    x[1] for x in sorted(job_compiled, key=lambda x: x[0])
+                ]
+                search_callback.execute_batch_start()
+                for compiled_list in compiled_results:
+                    for compiled in compiled_list:
+                        search_callback.execute_job_start()
+                        ident, backend, module, dump_file, in_x = compiled
+                        results.append(
+                            self.load_and_evaluate_sample(
+                                ident,
+                                backend,
+                                module,
+                                in_x,
+                                callbacks=callbacks,
                             )
-                            future.add_done_callback(future_callback)
-                            futures.append(future)
-                    if len(job_compiled) < len(job_in_x):
-                        raise RuntimeError("compilation error in some compile job(s)")
-                search_callback.compile_batch_end()
-                if args.execute:
-                    compiled_results = [
-                        x[1] for x in sorted(job_compiled, key=lambda x: x[0])
-                    ]
-                    search_callback.execute_batch_start()
-                    for compiled_list in compiled_results:
-                        for compiled in compiled_list:
-                            search_callback.execute_job_start()
-                            ident, backend, module, dump_file, in_x = compiled
-                            results.append(
-                                self.load_and_evaluate_sample(
-                                    ident,
-                                    backend,
-                                    module,
-                                    in_x,
-                                    args,
-                                    callbacks=callbacks,
-                                )
-                            )
-                            search_callback.execute_job_end()
-                    search_callback.execute_batch_end()
-        finally:
-            search_callback.search_end()
+                        )
+                        search_callback.execute_job_end()
+                search_callback.execute_batch_end()
+            search_callback.compile_batch_end()
         return results
 
     def evaluate_iterative(
         self,
         strategy: Strategy,
         graph: Graph,
-        args: NS | ExplorationConfig | None = None,
         callbacks: CallBacks = {},
         peak_time: float = 0,
     ):
-        args = cast(NS, self.config if args is None else args)
+        args = self.config
         optimizer = Optimizers.from_name(args.optimizer)
         opt = optimizer(strategy.sample, args.batch, args.seed, args.optimizer_config)
         all_results = []
-        callbacks["search"].iterations_start(args.trials * len(args.backends))
-        for step in range(0, args.trials, args.batch):
-            in_x = opt.suggest()
-            results = self.evaluate_all_parallel(
-                strategy, np.array(in_x), graph, args, callbacks
-            )
-            all_results.extend(results)
-            peaks = [peak_time / res[-2] for res in results]
-            opt.observe(in_x, peaks)
+        progress = callbacks["search"]
+        progress.search_start(args.trials * len(args.backends))
+        try:
+            for step in range(0, args.trials, args.batch):
+                size = min(args.batch, args.trials - step)
+                in_x = opt.suggest()[:size]
+                results = self.evaluate_all_parallel(
+                    strategy, np.array(in_x), graph, callbacks=callbacks
+                )
+                all_results.extend(results)
+                peaks = [peak_time / res[-2] for res in results]
+                opt.observe(in_x, peaks)
+        finally:
+            progress.search_end()
         opt.finished()
-        callbacks["search"].iterations_end()
         return all_results
 
     def evaluate_generate(
         self,
         strategy: Strategy,
         graph: Graph,
-        args: NS | ExplorationConfig | None = None,
         callbacks: CallBacks = {},
     ):
-        args = cast(NS, self.config if args is None else args)
+        args = self.config
         assert args.search in ["exhaustive", "random"]
         if args.search == "random":
             assert args.trials > 0
@@ -869,37 +561,53 @@ class Exploration:
                 all_in_x = np.array(list(itertools.islice(all_ex_x, args.trials)))
             else:
                 all_in_x = np.array(list(all_ex_x))
-        return self.evaluate_all_parallel(strategy, all_in_x, graph, args, callbacks)
+        progress = callbacks["search"]
+        progress.search_start(len(all_in_x) * len(args.backends))
+        try:
+            res = self.evaluate_all_parallel(
+                strategy, all_in_x, graph, callbacks=callbacks
+            )
+        finally:
+            progress.search_end()
+        return res
 
     def evaluate_data(
         self,
         strategy: Strategy,
         X: NPSamples,
         graph: Graph,
-        args: NS | ExplorationConfig | None = None,
         callbacks: CallBacks = {},
     ):
-        args = cast(NS, self.config if args is None else args)
+        args = self.config
         size = len(X)
         logger.debug(f"Search space size: {size}")
-        return self.evaluate_all_parallel(strategy, X, graph, args, callbacks)
+        progress = callbacks["search"]
+        progress.search_start(size * len(args.backends))
+        try:
+            res = self.evaluate_all_parallel(strategy, X, graph, callbacks=callbacks)
+        finally:
+            progress.search_end()
+        return res
 
     def evaluate_sample(
         self,
         strategy: Strategy,
         in_x: Sample,
         graph: Graph,
-        args: NS | ExplorationConfig | None = None,
         callbacks: CallBacks = {},
     ):
-        args = cast(NS, self.config if args is None else args)
-        return self.evaluate_all_parallel(
-            strategy, np.array([in_x]), graph, args, callbacks
-        )
+        args = self.config
+        progress = callbacks["search"]
+        progress.search_start(1 * len(args.backends))
+        try:
+            res = self.evaluate_all_parallel(
+                strategy, np.array([in_x]), graph, callbacks=callbacks
+            )
+        finally:
+            progress.search_end()
+        return res
 
-    def read_input(
-        self, fname: str, args: NS | ExplorationConfig | None = None
-    ) -> NPSamples:
+    def read_input(self, fname: str) -> NPSamples:
         X = []
         with open(fname, newline="") as infile:
             reader = csv.reader(infile, delimiter=";")
@@ -911,10 +619,9 @@ class Exploration:
                 X.append(eval(row[X_idx], {}, {}))
         return np.array(X)
 
-    def peak_time(
-        self, graph: Graph, args: NS | ExplorationConfig | None = None
-    ) -> float:
-        args = cast(NS, self.config if args is None else args)
+    def peak_time(self, graph: Graph) -> float:
+        args = self.config
+        assert args.peak_flops is not None
         if not args.execute:
             return 0
         ops_count = graph.ops_count()
@@ -976,11 +683,10 @@ class Exploration:
         self,
         strategy: Strategy,
         graph: Graph,
-        args: NS | ExplorationConfig | None = None,
     ) -> list[ResultCallBack]:
-        args = cast(NS, self.config if args is None else args)
+        args = self.config
         callbacks: list[ResultCallBack] = []
-        ptime = self.peak_time(graph, args)
+        ptime = self.peak_time(graph)
         sample_names = strategy.sample_names
         args.memory_callback = MemoryCallback()
         callbacks.append(args.memory_callback)
@@ -1008,49 +714,69 @@ class Exploration:
         self,
         strategy: Strategy,
         graph: Graph,
-        args: NS | ExplorationConfig | None = None,
     ):
-        args = cast(NS, self.config if args is None else args)
+        args = self.config
         ncomp_per_job = len(args.backends)
         nexec_per_job = 1 if args.execute else 0
-        search_callback = SearchProgressTQDM(
+        search_callback = self.progress(
             ncomp_per_job,
             nexec_per_job,
             args.quiet,
             graph.name,
+            progress_cls=args.progress_cls,
         )
-        result_callbacks = self.get_result_callbacks(strategy, graph, args)
+        result_callbacks = self.get_result_callbacks(strategy, graph)
         callbacks = {"result": result_callbacks, "search": search_callback}
         if args.search == "iterative":
-            callbacks["search"] = IterativeProgressTQDM(
-                ncomp_per_job,
-                nexec_per_job,
-                args.quiet,
-                graph.name,
-            )
-            ptime = self.peak_time(graph, args)
+            ptime = self.peak_time(graph)
             return self.evaluate_iterative(
-                strategy, graph, args, callbacks=callbacks, peak_time=ptime
+                strategy, graph, callbacks=callbacks, peak_time=ptime
             )
         if args.search in ["exhaustive", "random"]:
-            return self.evaluate_generate(strategy, graph, args, callbacks=callbacks)
+            return self.evaluate_generate(strategy, graph, callbacks=callbacks)
         if args.search == "data":
             assert args.data is not None
-            X = self.read_input(args.data, args)
-            return self.evaluate_data(strategy, X, graph, args, callbacks=callbacks)
+            X = self.read_input(args.data)
+            return self.evaluate_data(strategy, X, graph, callbacks=callbacks)
         return []
 
-    def optimize(self, args: NS | ExplorationConfig | None = None):
-        args = cast(NS, self.config if args is None else args)
+    def initialize_context(self):
+        args = self.config
+        if "tvm" in args.backends:
+            os.environ["TVM_NUM_THREADS"] = str(args.threads)
+
+        if args.operator and args.eval == "eval" and args.execute:
+            self.init_eval_parameters()
+        if args.execute and args.peak_flops is None:
+            # TODO: get dtype from graph
+            args.peak_flops = HostRuntime.get().evaluate_flops(args.dtype)
+            assert args.peak_flops != 0, (
+                f"unable to evaluate machine flops for type {args.dtype}"
+            )
+            logger.debug(f"Estimated peak flops: %g", args.peak_flops)
+
+    @property
+    def progress(self):
+        cls = self.config.progress_cls
+        if cls == "tqdm":
+            return SearchProgressTQDM
+        elif cls == "mo":
+            return SearchProgressMO
+        assert False, f"unknown progress class: {cls}"
+
+    def optimize(self):
+        args = self.config
+        self.initialize_context()
         if args.operator:
             op_args = (
-                *Exploration.get_dims(args).values(),
-                Exploration.get_dtype(args),
+                *self.get_dims().values(),
+                self.get_dtype(),
             )
             graph = getattr(self, cast(str, OPERATORS[args.operator]["operation"]))(
                 *op_args, name=args.func_name
             )
         else:
+            assert args.graph_file is not None
             graph = self.xtc_load_graph(args.graph_file)
         strategy = self.get_strategy(graph, args)
         self.write_run_manifest(strategy, args)
@@ -1064,25 +790,25 @@ class Exploration:
                 schedule = strategy.default_schedule(args.opt_level)
             ncomp_per_job = len(args.backends)
             nexec_per_job = 1 if args.execute else 0
-            search_callback = SearchProgressTQDM(
+            search_callback = self.progress(
                 ncomp_per_job,
                 nexec_per_job,
                 args.quiet,
                 graph.name,
             )
-            result_callbacks = self.get_result_callbacks(strategy, graph, args)
+            result_callbacks = self.get_result_callbacks(strategy, graph)
             callbacks = {"result": result_callbacks, "search": search_callback}
             results = self.evaluate_sample(
-                strategy, schedule, graph, args, callbacks=callbacks
+                strategy, schedule, graph, callbacks=callbacks
             )
         else:
-            results = self.search_some(strategy, graph, args)
+            results = self.search_some(strategy, graph)
         args.results = list(results or [])
         csv_callback = getattr(args, "csv_callback", None)
         if not args.quiet and csv_callback is not None and len(csv_callback._rows) > 0:
             ordered = sorted(csv_callback._rows, key=lambda x: x[-3])
             in_x, time, peak, backend = ordered[0][-4:]
-            tqdm.write(
+            print(
                 f"Schedule: {backend}: {in_x}: time: {time * 1000:.2f} msecs, peak perf: {peak * 100:.2f}%"
             )
         return args.results
@@ -1123,343 +849,28 @@ class Exploration:
             op = get_operation(operator, name)
             print(f"{name}: {op['dims']}, {op['params']}")
 
+    @staticmethod
+    def list_operators():
+        for name in OPERATORS:
+            print(f"{name}")
+
+    @staticmethod
+    def list_strategies():
+        for name in Strategies.names(include_aliases=True):
+            print(f"{name}")
+
+    @staticmethod
+    def list_optimizers():
+        for name in Optimizers.names():
+            print(f"{name}")
+
     def run(self) -> list[Sequence]:
         args = self.config
-        if getattr(args, "seed", 0) >= 0:
+        if args.seed >= 0:
             np.random.seed(args.seed)
             random.seed(args.seed)
-        self.results = self.optimize(args)
+        self.results = self.optimize()
         return self.results
 
     def __call__(self) -> list[Sequence]:
         return self.run()
-
-
-def setup_args(args: ExplorationConfig | NS):
-    if args.graph_file is not None:
-        args.operator = None
-
-    if "tvm" in args.backends:
-        os.environ["TVM_NUM_THREADS"] = str(args.threads)
-
-    # Workaround to ensure that TVM backend is after MLIR backends,
-    # otherwise the import of tvm breaks the MLIR python bindings
-    args.backends = sorted(args.backends)
-
-    if not args.func_name:
-        args.func_name = args.operator
-    if args.operator:
-        for backend in args.backends:
-            assert backend in cast(list, OPERATORS[args.operator]["backends"]), (
-                f"backend {backend} not available for operator {args.operator}"
-            )
-
-        if not args.strategy:
-            args.strategy = OPERATORS[args.operator]["default_strategy"]
-        if args.eval == "eval" and args.execute:
-            args.eval_parameters = Exploration.get_eval_parameters(args)
-    else:
-        if not args.strategy:
-            args.strategy = "tile_oo"
-        args.eval_parameters = None
-
-    if args.execute and args.peak_flops is None:
-        # TODO: get dtype from graph
-        args.peak_flops = HostRuntime.get().evaluate_flops(args.dtype)
-        assert args.peak_flops != 0, (
-            f"unable to evaluate machine flops for type {args.dtype}"
-        )
-        logger.debug(f"Estimated peak flops: %g", args.peak_flops)
-
-
-def launch_child(argv: Sequence[str], args: NS):
-    env = {}
-    if "tvm" in args.backends:
-        # Force number of threads for TVM
-        env.update({"TVM_NUM_THREADS": str(args.threads)})
-    cmd = [
-        "env",
-        *(f"{k}={v}" for k, v in env.items()),
-        "setarch",
-        "-R",
-        "--",
-        argv[0],
-        "--child",
-        *argv[1:],
-    ]
-    logger.debug("Executing child command: %s", " ".join(cmd))
-    proc = subprocess.run(
-        args=cmd,
-    )
-    if proc.returncode != 0:
-        logger.debug(
-            f"ERROR: running subprocess: exit code: %s, command: %s",
-            proc.returncode,
-            " ".join(cmd),
-        )
-    raise SystemExit(proc.returncode)
-
-
-def main():
-    defaults = ExplorationConfig()
-    default_op = cast(str, defaults.operator)
-    default_dtype = OPERATORS[default_op]["default_type"]
-    default_jobs = defaults.jobs
-    choice_strategies = list(Strategies.names(include_aliases=True))
-    parser = argparse.ArgumentParser(
-        description="Autotune Operator",
-        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
-    )
-    parser.add_argument(
-        "--operator",
-        type=str,
-        choices=list(OPERATORS.keys()),
-        default=defaults.operator,
-        help="operator to optimize",
-    )
-    parser.add_argument(
-        "--graph-file",
-        type=str,
-        help="Graph file",
-    )
-    parser.add_argument(
-        "--op-name", type=str, help="operation name to optimize from the registry"
-    )
-    parser.add_argument(
-        "--ops-list",
-        action="store_true",
-        help="print available operations names for the given operator",
-    )
-    parser.add_argument(
-        "--func-name", type=str, help="function name to generate, default to operator"
-    )
-    parser.add_argument(
-        "--strategy",
-        type=str,
-        help=f"tile strategy to use, default to operator's default. One of {choice_strategies}",
-    )
-    parser.add_argument(
-        "--descript",
-        type=str,
-        help="path to a descript specification to use. Ignores --strategy if used.",
-    )
-    parser.add_argument(
-        "--search",
-        type=str,
-        choices=["random", "exhaustive", "data", "iterative"],
-        default=defaults.search,
-        help="search strategy",
-    )
-    parser.add_argument(
-        "--backends",
-        type=str,
-        nargs="+",
-        choices=["mlir", "tvm", "jir"],
-        default=defaults.backends,
-        help="backends to use",
-    )
-    parser.add_argument(
-        "--optimizer",
-        type=str,
-        default=defaults.optimizer,
-        help=f"optimizer to use. One of {Optimizers.names()}",
-    )
-    parser.add_argument(
-        "--data", type=str, help="data CSV file for input to data search"
-    )
-    parser.add_argument(
-        "--dims", nargs="+", type=int, help="dimensions, default to operators's default"
-    )
-    parser.add_argument(
-        "--huge-pages",
-        action=argparse.BooleanOptionalAction,
-        default=defaults.huge_pages,
-        help="alloc at huge page boundaries",
-    )
-    parser.add_argument(
-        "--test",
-        nargs="+",
-        type=int,
-        default=defaults.test,
-        help="test this input only",
-    )
-    parser.add_argument(
-        "--opt-level",
-        type=int,
-        default=defaults.opt_level,
-        help="opt level, 0-3 one-shot, 4 search",
-    )
-    parser.add_argument(
-        "--dtype",
-        type=str,
-        default=default_dtype,
-        choices=["float32", "float64"],
-        help="data type, default to operator's default",
-    )
-    parser.add_argument(
-        "--trials", type=int, default=defaults.trials, help="num trials"
-    )
-    parser.add_argument(
-        "--threads", type=int, default=defaults.threads, help="number of threads"
-    )
-    parser.add_argument(
-        "--max-unroll",
-        type=int,
-        help="max unroll in tiling strategies, or strategy default",
-    )
-    parser.add_argument("--seed", type=int, default=defaults.seed, help="seed")
-    parser.add_argument(
-        "--output", type=str, default=defaults.output, help="output csv file for search"
-    )
-    parser.add_argument(
-        "--db-file",
-        type=str,
-        help="output json db, for instance: xtc-graphs-db.json",
-    )
-    parser.add_argument(
-        "--resume",
-        action=argparse.BooleanOptionalAction,
-        default=defaults.resume,
-        help="resume from an existing output file and skip already recorded samples",
-    )
-    parser.add_argument(
-        "--append",
-        action=argparse.BooleanOptionalAction,
-        default=defaults.append,
-        help="append new results to output file without deduplication",
-    )
-    parser.add_argument(
-        "--eval",
-        type=str,
-        choices=["eval"],
-        default=defaults.eval,
-        help="evaluation method",
-    )
-    parser.add_argument(
-        "--repeat", type=int, default=defaults.repeat, help="evaluation repeat"
-    )
-    parser.add_argument(
-        "--number", type=int, default=defaults.number, help="evaluation number"
-    )
-    parser.add_argument(
-        "--min-repeat-ms",
-        type=int,
-        default=defaults.min_repeat_ms,
-        help="evaluation min repeat ms",
-    )
-    parser.add_argument(
-        "--validate", action=argparse.BooleanOptionalAction, help="validate results"
-    )
-    parser.add_argument(
-        "--save-temps",
-        action=argparse.BooleanOptionalAction,
-        help="save temps to save temps dir",
-    )
-    parser.add_argument(
-        "--save-temps-dir",
-        type=str,
-        default=defaults.save_temps_dir,
-        help="save temps dir",
-    )
-    parser.add_argument(
-        "--explore-dir",
-        type=str,
-        default=defaults.explore_dir,
-        help="exploration results .so dir",
-    )
-    parser.add_argument(
-        "--optimizer-config", type=str, help="config yaml file for optimizer"
-    )
-    parser.add_argument(
-        "--child",
-        action=argparse.BooleanOptionalAction,
-        default=defaults.child,
-        help="internal flag for marking child execution (obsolete)",
-    )
-    parser.add_argument(
-        "--bare-ptr",
-        action=argparse.BooleanOptionalAction,
-        default=defaults.bare_ptr,
-        help="use bare pointer interface (for TVM backend)",
-    )
-    parser.add_argument(
-        "--jobs", type=int, default=default_jobs, help="parallel compile jobs"
-    )
-    parser.add_argument(
-        "--execute",
-        action=argparse.BooleanOptionalAction,
-        default=defaults.execute,
-        help="do not execute, only compile",
-    )
-    parser.add_argument(
-        "--peak-flops",
-        type=float,
-        help="machine peak flops (flop/sec) for the dtype, or estimated",
-    )
-    parser.add_argument(
-        "--mlir-prefix", type=str, help="MLIR install prefix, defaults to mlir package"
-    )
-    parser.add_argument(
-        "--use-tensors",
-        action=argparse.BooleanOptionalAction,
-        default=defaults.use_tensors,
-        help="use tensors instead of memref for the mlir backend",
-    )
-    parser.add_argument(
-        "--batch", type=int, default=defaults.batch, help="batch size for optimizer"
-    )
-    parser.add_argument(
-        "--debug", action=argparse.BooleanOptionalAction, help="debug mode"
-    )
-    parser.add_argument(
-        "--debug-compile",
-        action=argparse.BooleanOptionalAction,
-        help="debug compile commands",
-    )
-    parser.add_argument(
-        "--debug-xtc", action=argparse.BooleanOptionalAction, help="debug xtc modules"
-    )
-    parser.add_argument(
-        "--debug-optimizer",
-        action=argparse.BooleanOptionalAction,
-        help="debug optimizer",
-    )
-    parser.add_argument(
-        "--quiet",
-        action=argparse.BooleanOptionalAction,
-        help="quiet optional output and progress bar",
-    )
-    parser.add_argument(
-        "--dump", action=argparse.BooleanOptionalAction, help="dump IR while generating"
-    )
-    args = parser.parse_args()
-
-    if args.resume and args.append:
-        parser.error("--resume and --append cannot be used together")
-
-    logging.basicConfig()
-    logger.setLevel(logging.INFO)
-    if args.debug:
-        logger.setLevel(logging.DEBUG)
-    if args.debug_xtc:
-        logging.getLogger("xtc").setLevel(logging.DEBUG)
-    if args.debug_optimizer:
-        logging.getLogger("xtc.search.optimizers").setLevel(logging.INFO)
-
-    if not args.child:
-        launch_child(sys.argv, args)
-
-    if args.ops_list:
-        Exploration.list_operations_dims(args.operator)
-        raise SystemExit()
-
-    if args.seed >= 0:
-        np.random.seed(args.seed)
-        random.seed(args.seed)
-
-    exploration = Exploration(args)
-    exploration.optimize()
-
-
-if __name__ == "__main__":
-    main()

--- a/src/xtc/search/optimizers.py
+++ b/src/xtc/search/optimizers.py
@@ -131,7 +131,7 @@ class RandomForestOptimizer(BaseOptimizer):
     def observe(self, x: list[VecSample], y: list[float]):
         self.X += x
         self.y += y
-        for i in range(0, self.batch):
+        for i in range(len(y)):
             if y[i] > self.best_y:
                 self.best_x = x[i]
                 self.best_y = y[i]

--- a/src/xtc/search/pipeline.py
+++ b/src/xtc/search/pipeline.py
@@ -1,0 +1,117 @@
+#
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2024-2026 The XTC Project Authors
+#
+import itertools
+import logging
+from typing import Any, Callable, Generator, Iterable
+import multiprocessing
+from concurrent import futures
+from dataclasses import dataclass
+import time
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class PipelineTask:
+    id: int
+    payload: Any
+    comp_stamp: float = 0
+    comp_time: float = 0
+    exec_stamp: float = 0
+    exec_time: float = 0
+    comp_result: Any = None
+    exec_result: Any = None
+
+
+class CompileExecutePipeline:
+    def __init__(
+        self,
+        compile_func: Callable[[Any], Any],
+        execute_func: Callable[[Any], Any],
+        compile_jobs: int = 0,
+        execute_jobs: int = 0,
+    ):
+        self._compile_jobs = (
+            max(1, multiprocessing.cpu_count() // 2)
+            if compile_jobs < 1
+            else compile_jobs
+        )
+        self._execute_jobs = 1 if execute_jobs < 1 else execute_jobs
+        self._compile_func = compile_func
+        self._execute_func = execute_func
+
+    def _process_tasks(
+        self,
+        tasks: Iterable[PipelineTask],
+        func: Callable[[Iterable[PipelineTask]], Generator[PipelineTask, None, None]],
+        batch: int,
+    ) -> Generator[PipelineTask, None, None]:
+        iterator = iter(tasks)
+        while batched := tuple(itertools.islice(iterator, batch)):
+            yield from func(batched)
+
+    def _compile_tasks(
+        self, tasks: Iterable[PipelineTask]
+    ) -> Generator[PipelineTask, None, None]:
+        def compile_func(tasks: Iterable[PipelineTask]):
+            def compile(task: PipelineTask) -> PipelineTask:
+                task.comp_stamp = time.time()
+                task.comp_result = self._compile_func(task.payload)
+                task.comp_time = time.time() - task.comp_stamp
+                return task
+
+            with futures.ThreadPoolExecutor(max_workers=self._compile_jobs) as executor:
+                it_map = executor.map(compile, tasks)
+            yield from it_map
+
+        yield from self._process_tasks(
+            tasks,
+            compile_func,
+            batch=self._compile_jobs,
+        )
+
+    def _execute_tasks(
+        self, tasks: Iterable[PipelineTask]
+    ) -> Generator[PipelineTask, None, None]:
+        def execute_func(tasks: Iterable[PipelineTask]):
+            def execute(task: PipelineTask) -> PipelineTask:
+                task.exec_stamp = time.time()
+                task.exec_result = self._execute_func(task.comp_result)
+                task.exec_time = time.time() - task.exec_stamp
+                return task
+
+            with futures.ThreadPoolExecutor(max_workers=self._execute_jobs) as executor:
+                it_map = executor.map(execute, tasks)
+            yield from it_map
+
+        yield from self._process_tasks(
+            tasks,
+            execute_func,
+            batch=self._execute_jobs,
+        )
+
+    def generate(self, payloads: Iterable[Any]) -> Generator[PipelineTask, None, None]:
+        compile_jobs = self._compile_jobs
+        execute_jobs = self._execute_jobs
+        max_jobs = max(compile_jobs, execute_jobs)
+        tasks = (
+            PipelineTask(id=id, payload=payload) for id, payload in enumerate(payloads)
+        )
+
+        def compile_and_execute(
+            tasks: Iterable[PipelineTask],
+        ) -> Generator[PipelineTask, None, None]:
+            compile_results = self._compile_tasks(tasks)
+            execution_results = self._execute_tasks(compile_results)
+            yield from execution_results
+
+        yield from self._process_tasks(
+            tasks,
+            compile_and_execute,
+            batch=max_jobs,
+        )
+
+    def run(self, payloads: Iterable[Any]) -> list[PipelineTask]:
+        return list(self.generate(payloads))

--- a/src/xtc/search/progress.py
+++ b/src/xtc/search/progress.py
@@ -1,0 +1,226 @@
+#
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2024-2026 The XTC Project Authors
+#
+from typing_extensions import override
+from typing import Any
+import threading
+
+
+class SearchProgress:
+    def search_start(self, ntasks: int):
+        pass
+
+    def batch_start(self, batch_ntasks: int):
+        pass
+
+    def compile_batch_start(self):
+        pass
+
+    def compile_job_start(self):
+        pass
+
+    def compile_job_end(self):
+        pass
+
+    def compile_batch_end(self):
+        pass
+
+    def execute_batch_start(self):
+        pass
+
+    def execute_job_start(self):
+        pass
+
+    def execute_job_end(self):
+        pass
+
+    def execute_batch_end(self):
+        pass
+
+    def batch_end(self):
+        pass
+
+    def search_end(self):
+        pass
+
+
+class SearchProgressTQDM(SearchProgress):
+    def __init__(
+        self,
+        ncomp_per_job: int = 1,
+        nexec_per_job: int = 1,
+        quiet: bool = False,
+        prefix: str = "",
+        position: int = 0,
+        progress_cls: str = "tqdm",
+    ):
+        self.ncomp_per_job = ncomp_per_job
+        self.nexec_per_job = nexec_per_job
+        self.quiet = quiet
+        self.prefix = prefix
+        self.position = position
+        self.allbar: Any = None
+        self.compbar: Any = None
+        self.evalbar: Any = None
+        self.ntasks = 0
+        self.progress = self._get_progress_cls(progress_cls)
+
+    def _get_progress_cls(self, progress_cls: str):
+        if progress_cls == "tqdm":
+            import tqdm
+
+            return tqdm.tqdm
+        assert False, f"unknown progress class name: {progress_cls}"
+
+    @override
+    def search_start(self, ntasks: int):
+        self.ntasks = ntasks
+        tqdm_args = dict(
+            total=self.ntasks,
+            miniters=0,
+            mininterval=0,
+            smoothing=0,
+            disable=self.quiet,
+        )
+        self.allbar = self.progress(
+            desc=f"{self.prefix} evaluate".strip(),
+            colour="red",
+            position=self.position + 0,
+            **tqdm_args,  # type: ignore
+        )
+        self.compbar = self.progress(
+            desc=f"{self.prefix} compile".strip(),
+            colour="blue",
+            position=self.position + 1,
+            **tqdm_args,  # type: ignore
+        )
+        if self.nexec_per_job > 0:
+            self.evalbar = self.progress(
+                desc=f"{self.prefix} execute".strip(),
+                colour="green",
+                position=self.position + 2,
+                **tqdm_args,  # type: ignore
+            )
+
+    @override
+    def batch_start(self, batch_ntasks: int):
+        pass
+
+    @override
+    def compile_batch_start(self):
+        self.compbar.unpause()
+
+    @override
+    def compile_job_start(self):
+        pass
+
+    @override
+    def compile_job_end(self):
+        self.compbar.update(self.ncomp_per_job)
+        if self.nexec_per_job == 0:
+            self.allbar.update(self.ncomp_per_job)
+
+    @override
+    def compile_batch_end(self):
+        self.compbar.update(0)
+        self.allbar.update(0)
+
+    @override
+    def execute_batch_start(self):
+        if self.nexec_per_job > 0:
+            self.evalbar.unpause()
+
+    @override
+    def execute_job_start(self):
+        pass
+
+    @override
+    def execute_job_end(self):
+        if self.nexec_per_job > 0:
+            self.evalbar.update(self.nexec_per_job)
+            self.allbar.update(self.nexec_per_job)
+
+    @override
+    def execute_batch_end(self):
+        pass
+
+    @override
+    def batch_end(self):
+        self.compbar.unpause()
+        if self.nexec_per_job > 0:
+            self.evalbar.unpause()
+
+    @override
+    def search_end(self):
+        self.allbar.close()
+        self.compbar.close()
+        if self.nexec_per_job > 0:
+            self.evalbar.close()
+
+
+class SearchProgressMO(SearchProgress):
+    def __init__(
+        self,
+        ncomp_per_job: int = 1,
+        nexec_per_job: int = 1,
+        quiet: bool = False,
+        prefix: str = "",
+        position: int = 0,
+        progress_cls: str = "mo",
+    ):
+        self.ncomp_per_job = ncomp_per_job
+        self.nexec_per_job = nexec_per_job
+        self.quiet = quiet
+        self.prefix = prefix
+        self.allbar: Any = None
+        self.ntasks = 0
+        self.progress = self._get_progress_cls(progress_cls)
+        self.ncomp = 0
+        self.nexec = 0
+        self._lock = threading.Lock()
+
+    def _get_progress_cls(self, progress_cls: str):
+        if progress_cls == "mo":
+            import marimo
+
+            return marimo.status.progress_bar
+        assert False, f"unknown progress class name: {progress_cls}"
+
+    @override
+    def search_start(self, ntasks: int):
+        self.ntasks = ntasks
+        tqdm_args = dict(
+            total=self.ntasks,
+            remove_on_exit=False,
+        )
+        self.allbar = self.progress(
+            subtitle="Starting...",
+            completion_subtitle="Explored {self.ntasks} samples.",
+            title=f"{self.prefix} evaluate".strip(),
+            **tqdm_args,  # type: ignore
+        ).progress
+
+    @override
+    def compile_job_end(self):
+        self.ncomp += self.ncomp_per_job
+        if self.nexec_per_job == 0:
+            with self._lock:
+                self.allbar.update_progress(
+                    self.ncomp_per_job,
+                    subtitle=f"Compiled {self.ncomp}/{self.ntasks}",
+                )
+
+    @override
+    def execute_job_end(self):
+        if self.nexec_per_job > 0:
+            self.nexec += self.nexec_per_job
+            with self._lock:
+                self.allbar.update_progress(
+                    self.nexec_per_job,
+                    subtitle=f"Evaluated {self.nexec}/{self.ntasks}",
+                )
+
+    @override
+    def search_end(self):
+        self.allbar.close()

--- a/tests/filecheck/backends/tensor_dialect/test_pad_conv2d_mlir_tensor_fused.py
+++ b/tests/filecheck/backends/tensor_dialect/test_pad_conv2d_mlir_tensor_fused.py
@@ -26,7 +26,7 @@ sched = sch.schedule()
 
 comp = impl.get_compiler(
     shared_lib=True,
-    dump_file="pad_conv2d_nhwc_mini_mlir_tensor",
+    dump_file="pad_conv2d_nhwc_mini_mlir_tensor_fused",
     print_source_ir=True,
     print_transformed_ir=True,
     print_bufferization_ir=True,

--- a/tests/graphs/conv2d.graph.yaml
+++ b/tests/graphs/conv2d.graph.yaml
@@ -1,0 +1,36 @@
+name: conv2d
+inputs:
+- uid: '%0'
+  expr:
+    type:
+      shape:
+      - 1
+      - 230
+      - 230
+      - 3
+      dtype: float32
+- uid: '%1'
+  expr:
+    type:
+      shape:
+      - 7
+      - 7
+      - 3
+      - 64
+      dtype: float32
+outputs:
+- uid: '%2'
+nodes:
+- name: O
+  uid: '%2'
+  expr:
+    op:
+      name: conv2d
+      attrs:
+        stride:
+        - 2
+        - 2
+    args:
+    - '%0'
+    - '%1'
+ops_version: b1d3d482365150a5

--- a/tests/graphs/matmul.graph.yaml
+++ b/tests/graphs/matmul.graph.yaml
@@ -1,0 +1,29 @@
+name: matmul
+inputs:
+- uid: '%0'
+  expr:
+    type:
+      shape:
+      - 512
+      - 128
+      dtype: float32
+- uid: '%1'
+  expr:
+    type:
+      shape:
+      - 128
+      - 1024
+      dtype: float32
+outputs:
+- uid: '%2'
+nodes:
+- name: C
+  uid: '%2'
+  expr:
+    op:
+      name: matmul
+      attrs: {}
+    args:
+    - '%0'
+    - '%1'
+ops_version: b1d3d482365150a5

--- a/tests/pytest/graphs/test_graph_serialization.py
+++ b/tests/pytest/graphs/test_graph_serialization.py
@@ -1,5 +1,23 @@
+import pytest
 import tempfile
 import xtc.graphs.xtc.op as O
+from pathlib import Path
+
+GRAPHS_DIR = Path(__file__).parents[2] / "graphs"
+
+@pytest.mark.parametrize(
+    "opname",
+    [
+        "matmul",
+        "conv2d",
+    ]
+)
+def test_matmul_graph_load(opname: str):
+    with O.graph() as gb:
+        gb.load(GRAPHS_DIR / f"{opname}.graph.yaml")
+    graph = gb.graph
+    assert graph.name == opname
+
 
 def test_matmul_relu_to_from_dict():
     I, J, K, dtype = 4, 32, 512, "float32"
@@ -15,7 +33,7 @@ def test_matmul_relu_to_from_dict():
         gb2.from_dict(graph_dict)
     assert graph_dict != {}
     assert graph_dict == gb2.graph.to_dict()
-        
+
 
 def test_conv2d_pad_sdump_sload():
     N, H, W, F, R, S, C, SH, SW, dtype = 1, 8, 8, 16, 5, 5, 3, 2, 2, "float32"
@@ -57,10 +75,10 @@ def test_mlp_fc_custom_output():
             l4 = fc(l3, w4, 10)
         O.reshape(l4, shape=(-1,))
         O.outputs(l1)
-   
+
     graph_dict = gb.graph.to_dict()
     with O.graph() as gb2:
         gb2.from_dict(graph_dict)
     assert graph_dict != {}
     assert graph_dict == gb2.graph.to_dict()
-    
+

--- a/tests/pytest/unit/search/test_pipeline.py
+++ b/tests/pytest/unit/search/test_pipeline.py
@@ -1,0 +1,43 @@
+from types import SimpleNamespace as NS
+from xtc.search.pipeline import CompileExecutePipeline
+import time
+import pytest
+
+def _delay():
+    time.sleep(0.1)
+
+def _compile(payload: NS):
+    print(f"compile {payload.id}")
+    assert payload.input == f"Input {payload.id}"
+    _delay()
+    return NS(id=payload.id, compiled=f"Compiled {payload.id}")
+
+def _execute(payload: NS):
+    print(f"execute {payload.id}")
+    assert payload.compiled == f"Compiled {payload.id}"
+    time.sleep(0.1)
+    _delay()
+    return NS(id=payload.id, executed=f"Executed {payload.id}")
+
+@pytest.mark.parametrize(
+    "compile_jobs, execute_jobs, ntasks",
+    [
+        (1, 1, 4),
+        (0, 0, 4),
+        (3, 4, 11),
+    ],
+)
+def test_pipeline(compile_jobs: int, execute_jobs: int, ntasks: int):
+    pipeline = CompileExecutePipeline(
+        compile_jobs = compile_jobs,
+        execute_jobs = execute_jobs,
+        compile_func=_compile,
+        execute_func=_execute,
+    )
+    payloads = (NS(id=id, input=f"Input {id}") for id in range(ntasks))
+    tasks = pipeline.run(payloads)
+    for task in tasks:
+        print(task)
+    assert all([task.id == id for id, task in enumerate(tasks)])
+    assert all([task.comp_result.compiled == f"Compiled {id}" for id, task in enumerate(tasks)])
+    assert all([task.exec_result.executed == f"Executed {id}" for id, task in enumerate(tasks)])


### PR DESCRIPTION
# Motivation

Modularize some components of loop-explore in order to simplify `src/xtc/search/explore.py`

# Description

Created in `src/xtc/search/`, modules `progress.py` for progress bars, `callback.py` for results callbacks and `pipeline.py` for multithreaded compile/execute pipeline

# Commits

Ref to commit changes:
- explore: refactor progress classes: add callback and progress modules, move loop-explore arguments parsing to cli script
- explore: refactor compile/execute pipeline: add pipeline module and use it for the compil/execute pipeline
- ci: add coverage of loop-explore script: when running workflow, include explore script tests in coverage
- ci: skip codecov validation which randomly fails: fix for github codecov action to workarounf a spurious error in the action on gpg validation of script, skip validation


# TODOs

- [x] improve coverage before merge