### PR TITLE
Update numpy version requirement for python 3.10+

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.2.dev1"
 license = { text = "BSD 3 Clause" }
 authors = [{ name = "Hugo Pompougnac", email = "hugo.pompougnac@inria.fr" }]
 classifiers = ["Programming Language :: Python :: 3"]
-dependencies = ['jinja2', 'matplotlib', 'numpy', 'ordered-set', 'py-cpuinfo', 'tqdm', 'typing_extensions', 'pyyaml','scikit-learn','lit','filecheck','xdsl~=0.57.1', 'strictyaml']
+dependencies = ['jinja2', 'matplotlib', 'numpy<2.3', 'ordered-set', 'py-cpuinfo', 'tqdm', 'typing_extensions', 'pyyaml','scikit-learn','lit','filecheck','xdsl~=0.57.1', 'strictyaml']
 requires-python = ">=3.10"
 
 [project.optional-dependencies]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 jinja2
 matplotlib
-numpy
+numpy<2.3
 ordered-set
 py-cpuinfo
 tqdm


### PR DESCRIPTION
The current CI does not work anymore with the error
```
mypy
/opt/hostedtoolcache/Python/3.12.13/x64/lib/python3.12/site-packages/numpy/__init__.pyi:737: error: Type statement is only supported in Python 3.12 and greater  [syntax]
Found 1 error in 1 file (errors prevented further checking)
make: *** [Makefile:46: check-mypy] Error 2
```

Solution put the mypy python version to 3.12
