### PR TITLE
data: output tensor values as .4g

### DIFF
--- a/src/xtc/graphs/xtc/data.py
+++ b/src/xtc/graphs/xtc/data.py
@@ -228,8 +228,8 @@ class XTCTensor(Tensor):
             data = self._data.reshape((-1,))
             if len(data) > 8:
                 data_str = (
-                    f"{' '.join([f'{d:g}' for d in data[:4]])}..."
-                    f"{' '.join([f'{d:g}' for d in data[-4:]])}"
+                    f"{' '.join([f'{d:.4g}' for d in data[:4]])}..."
+                    f"{' '.join([f'{d:.4g}' for d in data[-4:]])}"
                 )
             else:
                 data_str = f"{' '.join([f'{d:g}' for d in data])}"

--- a/tests/filecheck/graphs/test_mlp.py
+++ b/tests/filecheck/graphs/test_mlp.py
@@ -59,4 +59,4 @@ print(f"Outputs: {outs}")
 # CHECK-NEXT:    - %11: matmul(%10, %4) : [1x128xfloat32, 128x10xfloat32] -> [1x10xfloat32]
 # CHECK-NEXT:  
 # CHECK-NEXT:  Inputs: [Tensor(type=1x3072xfloat32, data=-4 -3 -2 -1...4 -4 -3 -2), Tensor(type=3072x512xfloat32, data=-4 -3 -2 -1...-2 -1 0 1), Tensor(type=512x256xfloat32, data=-4 -3 -2 -1...-3 -2 -1 0), Tensor(type=256x128xfloat32, data=-4 -3 -2 -1...0 1 2 3), Tensor(type=128x10xfloat32, data=-4 -3 -2 -1...3 4 -4 -3)]
-# CHECK-NEXT:  Outputs: [Tensor(type=1x10xfloat32, data=3.56365e+10 5.29314e+10 1.02672e+10 -2.69143e+10...-1.62482e+10 1.04668e+09 1.83416e+10 3.56365e+10)]
+# CHECK-NEXT:  Outputs: [Tensor(type=1x10xfloat32, data=3.564e+10 5.293e+10 1.027e+10 -2.691e+10...-1.625e+10 1.047e+09 1.834e+10 3.564e+10)]

--- a/tests/filecheck/graphs/test_mlp_fc.py
+++ b/tests/filecheck/graphs/test_mlp_fc.py
@@ -75,4 +75,4 @@ print(f"Outputs: {outs}")
 # CHECK-NEXT:  
 # CHECK-NEXT:  [10xfloat32]
 # CHECK-NEXT:  Inputs: [Tensor(type=32x32x3xfloat32, data=-4 -3 -2 -1...4 -4 -3 -2), Tensor(type=3072x512xfloat32, data=-4 -3 -2 -1...-2 -1 0 1), Tensor(type=512x256xfloat32, data=-4 -3 -2 -1...-3 -2 -1 0), Tensor(type=256x128xfloat32, data=-4 -3 -2 -1...0 1 2 3), Tensor(type=128x10xfloat32, data=-4 -3 -2 -1...3 4 -4 -3)]
-# CHECK-NEXT:  Outputs: [Tensor(type=10xfloat32, data=3.56365e+10 5.29314e+10 1.02672e+10 -2.69143e+10...-1.62482e+10 1.04668e+09 1.83416e+10 3.56365e+10)]
+# CHECK-NEXT:  Outputs: [Tensor(type=10xfloat32, data=3.564e+10 5.293e+10 1.027e+10 -2.691e+10...-1.625e+10 1.047e+09 1.834e+10 3.564e+10)]


### PR DESCRIPTION

# Motivation

Limit precision of string value for tensor data.

This avoids differences in tests due to fp rounding.

# Description

On string output changed format from `:g` to `:.4g` keeping only 4 significant digits.

