### PR TITLE
macOS: added *.dylib to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ __pycache__
 __marimo__
 *.so
 *.csv
+*.dylib
 venv
 .venv
 build


### PR DESCRIPTION
The filecheck tests each create *.dylib files on macOS so I added it to the gitignore.
