### PR TITLE
Add aarch64 python package support

### DIFF
--- a/.github/workflows/xtc-tests.yml
+++ b/.github/workflows/xtc-tests.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-14, macos-15]
+        os: [ubuntu-latest, ubuntu-24.04-arm, macos-14, macos-15]
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
     steps: &build-steps
       - name: Checkout XTC Repository
@@ -100,6 +100,6 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-15]
+        os: [ubuntu-latest, ubuntu-24.04-arm, macos-15]
         python-version: ["3.12"]
     steps: *build-steps

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ XTC is a domain-specific dataflow graph compiler for linear algebra operations. 
 
 If needed, install uv following the instructions [here](https://docs.astral.sh/uv/).
 
-Debian-like x86_64 Linux distributions (Python: 3.10 to 3.14 inclusive):
+Debian-like x86_64 or aarch64 Linux distributions (Python: 3.10 to 3.14 inclusive):
 ```bash
 sudo apt install python3 python3-dev build-essential libomp5 binutils binutils-aarch64-linux-gnu binutils-x86-64-linux-gnu
 sudo apt install libpfm4-dev # Optional: interface to Linux perf counters

--- a/dependencies.toml
+++ b/dependencies.toml
@@ -39,19 +39,19 @@ dependencies = [
 [groups.llvm]
 publish = false
 dependencies = [
-    'xtc-llvm-tools==22.1.8.1',
+    'xtc-llvm-tools==22.1.8.2',
 ]
 
 [groups.mlir]
 include = ["llvm"]
 dependencies = [
-    'xtc-mlir-tools==22.1.8.2',
-    'xtc-mlir-python-bindings==22.1.8.2',
-    'xtc-mlir-extra-tools==22.1.8.6',
+    'xtc-mlir-tools==22.1.8.3',
+    'xtc-mlir-python-bindings==22.1.8.3',
+    'xtc-mlir-extra-tools==22.1.8.7',
 ]
 
 [groups.tvm]
 include = ["llvm"]
 dependencies = [
-    'xtc-tvm-python-bindings==0.19.0.11',
+    'xtc-tvm-python-bindings==0.19.0.12',
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,11 +21,11 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-default = ['xtc-llvm-tools==22.1.8.1', 'xtc-mlir-tools==22.1.8.2', 'xtc-mlir-python-bindings==22.1.8.2', 'xtc-mlir-extra-tools==22.1.8.6', 'xtc-tvm-python-bindings==0.19.0.11']
-dev = ['xtc-llvm-tools==22.1.8.1', 'xtc-mlir-tools==22.1.8.2', 'xtc-mlir-python-bindings==22.1.8.2', 'xtc-mlir-extra-tools==22.1.8.6', 'xtc-tvm-python-bindings==0.19.0.11', "coverage>=7.8.0", "filecheck", "lit", "mkdocs", "mkdocs-material", "mkdocstrings-python", "mypy==1.15.0", "pytest", "pytest-xdist", "pyright==1.1.407", "types-PyYAML", "marimo==0.19.6", "ruff==0.14.10"]
+default = ['xtc-llvm-tools==22.1.8.2', 'xtc-mlir-tools==22.1.8.3', 'xtc-mlir-python-bindings==22.1.8.3', 'xtc-mlir-extra-tools==22.1.8.7', 'xtc-tvm-python-bindings==0.19.0.12']
+dev = ['xtc-llvm-tools==22.1.8.2', 'xtc-mlir-tools==22.1.8.3', 'xtc-mlir-python-bindings==22.1.8.3', 'xtc-mlir-extra-tools==22.1.8.7', 'xtc-tvm-python-bindings==0.19.0.12', "coverage>=7.8.0", "filecheck", "lit", "mkdocs", "mkdocs-material", "mkdocstrings-python", "mypy==1.15.0", "pytest", "pytest-xdist", "pyright==1.1.407", "types-PyYAML", "marimo==0.19.6", "ruff==0.14.10"]
 test = ["coverage>=7.8.0", "filecheck", "lit", "mkdocs", "mkdocs-material", "mkdocstrings-python", "mypy==1.15.0", "pytest", "pytest-xdist", "pyright==1.1.407", "types-PyYAML", "marimo==0.19.6", "ruff==0.14.10"]
-mlir = ['xtc-llvm-tools==22.1.8.1', 'xtc-mlir-tools==22.1.8.2', 'xtc-mlir-python-bindings==22.1.8.2', 'xtc-mlir-extra-tools==22.1.8.6']
-tvm = ['xtc-llvm-tools==22.1.8.1', 'xtc-tvm-python-bindings==0.19.0.11']
+mlir = ['xtc-llvm-tools==22.1.8.2', 'xtc-mlir-tools==22.1.8.3', 'xtc-mlir-python-bindings==22.1.8.3', 'xtc-mlir-extra-tools==22.1.8.7']
+tvm = ['xtc-llvm-tools==22.1.8.2', 'xtc-tvm-python-bindings==0.19.0.12']
 
 [tool.setuptools]
 platforms = ["Linux"]


### PR DESCRIPTION
# Motivation

This PR depends upon PR #115, refer to the last commit only.

Add support for python package dependencies such that xtc can be installed on aarch64 with standard:

    pip install -e .[dev]

# Description

Update llvm/mlir/tvm binary package dependencies to latest ondes published on pypi for aarch64 (in addition to x86_64 and macos)

Add CI test for aarch64 runner (ubuntu-latest-arm).

# Commits

Ref to last commit.
