### PR TITLE
ci: cancel concurrent test jobs

### DIFF
--- a/.github/workflows/xtc-pages.yml
+++ b/.github/workflows/xtc-pages.yml
@@ -12,10 +12,11 @@ permissions:
   pages: write
   id-token: write
 
+
 # Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
 # However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
 concurrency:
-  group: "pages"
+  group: ci-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: false
 
 jobs:

--- a/.github/workflows/xtc-tests.yml
+++ b/.github/workflows/xtc-tests.yml
@@ -7,6 +7,10 @@ on:
   pull_request:
   workflow_dispatch:
 
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     if: github.event_name != 'pull_request'


### PR DESCRIPTION
# Motivation

Automatically interrupt previous jobs on the same branch for tests.

# Description

Add concurency group and cancel for test jobs.

For pages jobs, do not cancel.

