### PR TITLE
Support environment library paths

### DIFF
--- a/src/xtc/utils/ext_tools.py
+++ b/src/xtc/utils/ext_tools.py
@@ -3,15 +3,12 @@
 # Copyright (c) 2024-2026 The XTC Project Authors
 #
 import ctypes.util
-import subprocess
-import re
-import platform
-
 import os
 import platform
-import ctypes.util
-import subprocess
 import re
+import shutil
+import subprocess
+from pathlib import Path
 
 
 def get_library_path(libname: str) -> str:
@@ -29,13 +26,37 @@ def get_library_path(libname: str) -> str:
     if platform.system() == "Darwin":
         return libfile
 
-    result = subprocess.run(["/sbin/ldconfig", "-p"], capture_output=True, text=True)
-    for line in result.stdout.splitlines():
-        if libfile in line:
-            match = re.search(r"=>\s+(\S+)", line)
-            if match:
-                return match.group(1)
-    assert False
+    libpath = Path(libfile)
+    if libpath.is_absolute() and libpath.is_file():
+        return str(libpath)
+
+    # Nix and other non-FHS environments expose libraries through environment
+    # search paths rather than the host's ldconfig cache.
+    search_paths: list[Path] = []
+    for variable in ("LD_LIBRARY_PATH", "LIBRARY_PATH"):
+        search_paths.extend(
+            Path(path)
+            for path in os.environ.get(variable, "").split(os.pathsep)
+            if path
+        )
+    for directory in search_paths:
+        candidate = directory / libfile
+        if candidate.is_file():
+            return str(candidate)
+
+    ldconfig = shutil.which("ldconfig")
+    if ldconfig is not None:
+        result = subprocess.run([ldconfig, "-p"], capture_output=True, text=True)
+        for line in result.stdout.splitlines():
+            if libfile in line:
+                match = re.search(r"=>\s+(\S+)", line)
+                if match:
+                    return match.group(1)
+
+    searched = os.pathsep.join(str(path) for path in search_paths)
+    raise RuntimeError(
+        f"could not resolve {libfile} for {libname}; searched: {searched}"
+    )
 
 
 def get_shlib_extension():

--- a/tests/pytest/utils/test_ext_tools.py
+++ b/tests/pytest/utils/test_ext_tools.py
@@ -1,0 +1,52 @@
+from pathlib import Path
+from subprocess import CompletedProcess
+
+import pytest
+
+from xtc.utils import ext_tools
+
+
+@pytest.mark.parametrize("search_variable", ["LD_LIBRARY_PATH", "LIBRARY_PATH"])
+def test_get_library_path_uses_environment_search_paths(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, search_variable: str
+) -> None:
+    library_name = "libomp.so.5"
+    library = tmp_path / library_name
+    library.touch()
+
+    monkeypatch.setattr(ext_tools.platform, "system", lambda: "Linux")
+    monkeypatch.setattr(
+        ext_tools.ctypes.util, "find_library", lambda _name: library_name
+    )
+    monkeypatch.delenv("LD_LIBRARY_PATH", raising=False)
+    monkeypatch.delenv("LIBRARY_PATH", raising=False)
+    monkeypatch.setenv(search_variable, str(tmp_path))
+    monkeypatch.setattr(ext_tools.shutil, "which", lambda _name: None)
+
+    assert ext_tools.get_library_path("omp") == str(library)
+
+
+def test_get_library_path_falls_back_to_ldconfig(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    library_name = "libomp.so.5"
+    library = "/usr/lib/x86_64-linux-gnu/libomp.so.5"
+
+    monkeypatch.setattr(ext_tools.platform, "system", lambda: "Linux")
+    monkeypatch.setattr(
+        ext_tools.ctypes.util, "find_library", lambda _name: library_name
+    )
+    monkeypatch.delenv("LD_LIBRARY_PATH", raising=False)
+    monkeypatch.delenv("LIBRARY_PATH", raising=False)
+    monkeypatch.setattr(ext_tools.shutil, "which", lambda _name: "/sbin/ldconfig")
+    monkeypatch.setattr(
+        ext_tools.subprocess,
+        "run",
+        lambda *_args, **_kwargs: CompletedProcess(
+            args=["/sbin/ldconfig", "-p"],
+            returncode=0,
+            stdout=f"\t{library_name} (libc6,x86-64) => {library}\n",
+        ),
+    )
+
+    assert ext_tools.get_library_path("omp") == library


### PR DESCRIPTION
# Motivation

Add better support for library localization with get_library_path in particular for non-debian systems.

# Description

Resolve in order:
- LD_LIBRARY_PATH
- LIBRARY_PATH
- ldconfig in path

# Commits

Ref commit

# Discussion

Missing legacy behavior to fallback to `/sbin/ldconfig` (when `/sbin` is not in `PATH`), I will make a fursther pull request afterward.