### PR TITLE
explore: support selectable module output types

### DIFF
--- a/src/xtc/backends/tvm/TVMCompiler.py
+++ b/src/xtc/backends/tvm/TVMCompiler.py
@@ -467,18 +467,18 @@ class PackedOperatorWrapper:
                 cmd = (
                     f"{cc_command(self._arch)} {sh_opts} {opts} "
                     f"{' '.join(object_fnames)}  "
-                    f"{packed_lib_fname}.a "
+                    f"{relative_to(packed_lib_fname, output_dir)}.a "
                     f"-o {unpacked_lib_base}{ext}"
                 )
                 p = subprocess.run(
                     shlex.split(cmd),
                     text=True,
                     capture_output=True,
-                    cwd=unpacked_lib_dir,
+                    cwd=output_dir,
                 )
                 if p.returncode != 0:
                     raise RuntimeError(
-                        f"Failed command {cmd} (cwd: {unpacked_lib_dir}:\n"
+                        f"Failed command {cmd} (cwd: {output_dir}:\n"
                         f"{p.stdout}\n"
                         f"{p.stderr}\n"
                     )

--- a/src/xtc/cli/explore.py
+++ b/src/xtc/cli/explore.py
@@ -281,6 +281,13 @@ def main():
         "--batch", type=int, default=defaults.batch, help="batch size for optimizer"
     )
     parser.add_argument(
+        "--module-type",
+        type=str,
+        choices=["shlib", "arlib", "csrc"],
+        default=defaults.module_type,
+        help="type of module",
+    )
+    parser.add_argument(
         "--debug",
         action=argparse.BooleanOptionalAction,
         default=False,

--- a/src/xtc/search/explore.py
+++ b/src/xtc/search/explore.py
@@ -112,6 +112,7 @@ class ExplorationConfig:
     descript: str | None = None
     use_tensors: bool = False
     progress_cls: str = "tqdm"
+    module_type: str = "shlib"
 
     def __post_init__(self):
         if self.graph_file is not None:
@@ -366,11 +367,17 @@ class Exploration:
         if dump_file is None:
             dump_file = f"{args.explore_dir}/payload_{ident}"
         compile_args = dict(
-            shared_lib=True,
             dump_file=dump_file,
             bare_ptr=args.bare_ptr,
             debug=args.debug_compile,
         )
+        if args.module_type == "shlib":
+            compile_args.update(dict(shared_lib=True))
+        elif args.module_type == "arlib":
+            compile_args.update(dict(ar_lib=True))
+        else:
+            assert args.module_type == "csrc"
+            compile_args.update(dict(emit_c=True))
         if args.dump:
             compile_args.update(
                 dict(


### PR DESCRIPTION
# Motivation

Allow exploration to select the generated module format instead of always producing a shared library. Ensure TVM archive linking also works when building outside the current directory.

# Description

- Add `--module-type` with `shlib`, `arlib`, and `csrc` choices.
- Map the selected module type to the corresponding compiler option.
- Run TVM archive linking from the output directory and resolve the packed archive path relative to it.

# Commits

- `fb6ddec` tvm: fix issue when building in non current directory
- `290f348` explore: add --module-type option

# Discussion

Testing not run (not requested).

TODO:
- [x] No outstanding TODOs.
