### PR TITLE
tvm: support split schedules

### DIFF
--- a/src/xtc/backends/tvm/TVMOpsCompiler.py
+++ b/src/xtc/backends/tvm/TVMOpsCompiler.py
@@ -5,6 +5,9 @@
 from abc import ABC, abstractmethod
 from typing_extensions import override
 from typing import Any, TypeAlias, cast
+import tempfile
+from pathlib import Path
+import shutil
 
 import tvm
 import tvm.te as te
@@ -87,9 +90,21 @@ class TVMSchedulableExprTIR(TVMSchedulableExpr):
         }
         for sched in schedule_map.values():
             if sched:
-                exec(sched, namespace, namespace)
+                self._exec_schedule(sched, namespace)
         sch = cast(TIRSchedule, namespace["sch"])
         return TVMScheduledExprTIR(self, sch)
+
+    def _exec_schedule(self, sched: str, namespace: dict[str, Any]):
+        tdir = Path(tempfile.mkdtemp(dir="."))
+        try:
+            outf = tdir / "schedule.py"
+            outf.write_text(sched)
+            code = compile(sched, outf, "exec")
+            exec(code, namespace, namespace)
+        except Exception:
+            raise
+        else:
+            shutil.rmtree(tdir)
 
 
 class TVMScheduledExpr(ABC):

--- a/src/xtc/backends/tvm/TVMOpsCompiler.py
+++ b/src/xtc/backends/tvm/TVMOpsCompiler.py
@@ -15,6 +15,7 @@ from .TVMOps import (
     TVMOperation,
     TVMGraph,
 )
+from .TVMScheduleTransforms import loop_partition_rebased
 
 __all__ = [
     "TVMExprCompiler",
@@ -80,9 +81,14 @@ class TVMSchedulableExprTIR(TVMSchedulableExpr):
             return TVMScheduledExprTIR(self, sch)
         schedule_map = schedule.schedule_impl
         sch.work_on(func_name)
+        namespace = {
+            "sch": sch,
+            "loop_partition_rebased": loop_partition_rebased,
+        }
         for sched in schedule_map.values():
             if sched:
-                exec(sched, {"sch": sch}, {})
+                exec(sched, namespace, namespace)
+        sch = cast(TIRSchedule, namespace["sch"])
         return TVMScheduledExprTIR(self, sch)
 
 

--- a/src/xtc/backends/tvm/TVMScheduleTransforms.py
+++ b/src/xtc/backends/tvm/TVMScheduleTransforms.py
@@ -1,0 +1,81 @@
+#
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2024-2026 The XTC Project Authors
+#
+from typing import Any, cast
+
+import tvm
+import tvm.s_tir
+
+
+def loop_partition_rebased(
+    sch: tvm.s_tir.Schedule,
+    loop: Any,
+    factors: list[int | None],
+) -> tuple[tvm.s_tir.Schedule, list[Any]]:
+    """Partition a loop and rebase each resulting loop to start at zero.
+
+    TVM's loop_partition preserves the original loop coordinates, while several
+    schedule primitives, including split, require a zero loop minimum.  Rebuild
+    the partition loops with a zero minimum and add the old minimum to every use
+    of their induction variable.
+
+    Rebuilding the IR invalidates schedule RVs, so child blocks are reacquired
+    by name and returned with the new schedule.
+    """
+    working_on = sch.func_working_on
+    assert working_on is not None
+
+    partitions = sch.loop_partition(loop, cast(Any, factors))
+    children = [sch.get_child_blocks(partition)[0] for partition in partitions]
+    child_names = [cast(str, cast(Any, sch.get(child)).name_hint) for child in children]
+    partition_vars = [
+        cast(Any, sch.get(partition)).loop_var for partition in partitions
+    ]
+
+    def postorder(node: Any) -> Any:
+        if not isinstance(node, tvm.tirx.For):
+            return node
+        if not any(node.loop_var.same_as(var) for var in partition_vars):
+            return node
+        if isinstance(node.min, tvm.tirx.IntImm) and node.min.value == 0:
+            return node
+
+        old_var = node.loop_var
+        new_var = tvm.ir.Var(f"{old_var.name}_zero", old_var.ty)
+        body = tvm.tirx.stmt_functor.substitute(
+            node.body,
+            {old_var: new_var + node.min},
+        )
+        return tvm.tirx.For(
+            new_var,
+            cast(Any, 0),
+            node.extent,
+            node.kind,
+            body,
+            node.thread_binding,
+            node.annotations,
+            node.step,
+            node.span,
+        )
+
+    old_mod = cast(Any, sch.mod)
+    old_func = old_mod[working_on]
+    new_body = tvm.tirx.stmt_functor.ir_transform(
+        old_func.body,
+        None,
+        postorder,
+        ["tirx.For"],
+    )
+
+    new_mod = tvm.IRModule(
+        old_mod.functions,
+        attrs=old_mod.attrs,
+        global_infos=old_mod.global_infos,
+    )
+    new_mod.update_func(working_on, old_func.with_body(new_body))
+
+    new_sch = tvm.s_tir.Schedule(new_mod)
+    new_sch.work_on(working_on.name_hint)
+    new_children = [new_sch.get_sblock(name) for name in child_names]
+    return new_sch, new_children

--- a/src/xtc/backends/tvm/TVMScheduler.py
+++ b/src/xtc/backends/tvm/TVMScheduler.py
@@ -50,16 +50,19 @@ class TVMScheduleEmitterTIR(TVMScheduleEmitter):
         root = sched.root_node
         if root is None:
             return
-        self._dump_schedule_node(sched, root)
-
-    def _dump_schedule_node(self, sched: LoopNest, node: LoopNestNode):
-        assert node is not None, "unexpected undefined node"
-        assert not node.splits, "node split not implemented for this backend"
+        block = "O"
         sch = self._sch_var
         outf = self._outf
-        dims = sched.abstract_dims
-        block = "O"
         print(f'{block} = {sch}.get_sblock("{self._op.name}")', file=outf)
+        dims = sched.abstract_dims
+        self._dump_schedule_node(block, dims, sched, root)
+
+    def _dump_schedule_node(
+        self, block: str, dims: list[str], sched: LoopNest, node: LoopNestNode
+    ):
+        assert node is not None, "unexpected undefined node"
+        sch = self._sch_var
+        outf = self._outf
         print(f"{', '.join(dims)}, = {sch}.get_loops({block})", file=outf)
         if node.fuse_consumer_at:
             print(f"O_F0 = {sch}.get_consumers({block})[0]", file=outf)
@@ -79,8 +82,13 @@ class TVMScheduleEmitterTIR(TVMScheduleEmitter):
                     f"I_F{prod_idx} = {sch}.get_producers({block})[{prod_idx}]",
                     file=outf,
                 )
-        for t_axis, t_tiles in [(k, v) for k, v in node.tiles.items() if v]:
+        axes = []
+        for t_axis in dims:
+            t_tiles = node.tiles.get(t_axis, {})
             t_names = [t_axis] + list(t_tiles)
+            axes += t_names
+            if not t_tiles:
+                continue
             factors = functools.reduce(
                 lambda acc, x: acc + [x // acc[-1]], reversed(t_tiles.values()), [1]
             )
@@ -89,7 +97,14 @@ class TVMScheduleEmitterTIR(TVMScheduleEmitter):
                 f"{', '.join(t_names)}, = {sch}.split({t_axis}, factors=[{', '.join(t_factors)}])",
                 file=outf,
             )
-        print(f"{sch}.reorder({', '.join(node.interchange)})", file=outf)
+        outer = [axis for axis in node.interchange if axis in axes]
+        reorder = outer + axes
+        if node.splits:
+            split_axis = list(node.splits)[0]
+            reorder = outer + [split_axis] + axes
+        reorder = list(dict.fromkeys(reorder))
+        inner = [axis for axis in reorder if axis not in outer]
+        print(f"{sch}.reorder({', '.join(reorder)})", file=outf)
         if node.buffer_at:
             for axis in node.buffer_at:
                 print(f"{sch}.reverse_compute_at(O_W0, {axis})", file=outf)
@@ -125,6 +140,22 @@ class TVMScheduleEmitterTIR(TVMScheduleEmitter):
                 f"{sch}.parallel({node.parallelize[-1]})",
                 file=outf,
             )
+        if node.splits:
+            split_axis = list(node.splits)[0]
+            splits = node.splits[split_axis]
+            split_factors = [str(x) for x in list(splits.values())[1:]]
+            print(
+                f"{sch}, {block}_SPLITS = loop_partition_rebased("
+                f"{sch}, {split_axis}, [{', '.join(split_factors)}, None])",
+                file=outf,
+            )
+            for idx, split in enumerate(splits):
+                split_block = f"{block}_{split_axis}_{idx}"
+                print(
+                    f"{split_block} = {block}_SPLITS[{idx}]",
+                    file=outf,
+                )
+                self._dump_schedule_node(split_block, inner, sched, node.children[idx])
 
     @override
     def emit(self, scheduler: "TVMScheduler"):

--- a/tests/filecheck/backends/test_conv2d_y9k12_split.py
+++ b/tests/filecheck/backends/test_conv2d_y9k12_split.py
@@ -1,0 +1,147 @@
+# RUN: python %s --mlir 2>&1 | filecheck %s
+# RUN: python %s --mlir --descript 2>&1 | filecheck %s
+# RUN: python %s --tvm 2>&1 | filecheck %s
+# RUN: python %s --tvm --descript 2>&1 | filecheck %s
+# REQUIRES: module_tvm
+
+import sys
+import xtc.graphs.xtc.op as O
+from importlib import import_module
+from xtc.artifacts import get_operation
+from xtc.schedules.descript import descript_scheduler
+
+backend = "mlir"
+descript = False
+if len(sys.argv) > 1:
+    assert sys.argv[1][:2] == "--"
+    backend = sys.argv[1][2:]
+    if len(sys.argv) > 2 and sys.argv[2] == "--descript":
+        descript = True
+
+backend = import_module(f"xtc.backends.{backend}")
+
+# A reduced version of Yolo9000_12
+N, H, W, F, R, S, C = 1, 34, 34, 128, 3, 3, 32
+SH, SW = 1, 1
+dtype = "float32"
+abstract_dims = ["b", "h", "w", "f", "r", "s", "c"]
+abstract_sizes = dict(zip(abstract_dims, [N, H, W, F, R, S, C]))
+
+a = O.tensor((N, H + R - 1, W + S - 1, C), dtype)
+b = O.tensor((R, S, C, F), dtype)
+
+with O.graph(name="conv2d_nhwc_yolo9k2") as gb:
+    O.conv2d(a, b, stride=(SH, SW), name="C")
+
+graph = gb.graph
+print(graph)
+
+impl = backend.Backend(graph)
+sch = impl.get_scheduler()
+
+if descript:
+    descript_spec = {
+        "b": {},
+        "w[0:20]" : {
+            "s": {},
+            "w#10": {},
+            "h": {},
+            "r": {},
+            "c": {},
+            "h#17": {},
+            "c#16": {},
+            "c#2": {"unroll" : 2},
+            "w#5": {"unroll" : 5},
+            "f": {"unroll" : 64},
+            "f#16": {"vectorize" : True}
+        },
+        "w[20:34]" : {
+            "w#14": {},
+            "s": {},
+            "h": {},
+            "r": {},
+            "c": {},
+            "h#34": {},
+            "h#17": {},
+            "c#16": {},
+            "c#2": {"unroll" : 2},
+            "w#7": {"unroll" : 7},
+            "f": {"unroll" : 64},
+            "f#16": {"vectorize" : True}
+        }
+    }
+
+    descript_scheduler(
+        scheduler=sch,
+        node_name="C",
+        abstract_dims=abstract_dims,
+        abstract_dim_sizes=abstract_sizes,
+        spec=descript_spec,
+    )
+else:
+    sch.split("w", {"wl": 0, "wh": 20})
+    sch.interchange(["b", "wl", "wh"])
+    sch.strip_mine("w", {"w0": 10, "w1": 5}, root="./wl")
+    sch.strip_mine("h", {"h0": 17}, root="./wl")
+    sch.strip_mine("c", {"c0": 16, "c1": 2}, root="./wl")
+    sch.strip_mine("f", {"f0": 16}, root="./wl")
+    sch.interchange(["w", "s", "w0", "h", "r", "c", "h0", "c0", "c1", "w1", "f", "f0"], root="./wl")
+    sch.unroll({"c1": 2, "w1": 5, "f": 64}, root="./wl")
+    sch.vectorize(["f0"], root="./wl")
+    sch.strip_mine("w", {"w0": 14, "w1": 7}, root="./wh")
+    sch.strip_mine("h", {"h0": 34, "h1": 17}, root="./wh")
+    sch.strip_mine("c", {"c0": 16, "c1": 2}, root="./wh")
+    sch.strip_mine("f", {"f0": 16}, root="./wh")
+    sch.interchange(["w", "w0", "s", "h", "r", "c", "h0", "h1", "c0", "c1", "w1", "f", "f0"], root="./wh")
+    sch.unroll({"c1": 2, "w1": 7, "f": 64}, root="./wh")
+    sch.vectorize(["f0"], root="./wh")
+
+loop_nest = sch.get_loop_nest()
+print(loop_nest.root_node.pretty_print())
+loop_nest.check()
+
+res = impl.evaluate(
+    sch.schedule(),
+)
+print("VALID:", isinstance(res, float))
+# CHECK:       graph:
+# CHECK-NEXT:    name: conv2d_nhwc_yolo9k2
+# CHECK-NEXT:    inputs:
+# CHECK-NEXT:    - %0 : 1x36x36x32xfloat32
+# CHECK-NEXT:    - %1 : 3x3x32x128xfloat32
+# CHECK-NEXT:    outputs:
+# CHECK-NEXT:    - %2 : 1x34x34x128xfloat32
+# CHECK-NEXT:    nodes:
+# CHECK-NEXT:    - %2: conv2d(%0, %1, stride=(1, 1)) {name = 'C'} : [1x36x36x32xfloat32, 3x3x32x128xfloat32] -> [1x34x34x128xfloat32]
+# CHECK-NEXT:  
+# CHECK-NEXT:  loop b
+# CHECK-NEXT:    split(w, 0, 20)
+# CHECK-NEXT:      loop w
+# CHECK-NEXT:        loop s
+# CHECK-NEXT:          tile(w, 10)
+# CHECK-NEXT:            loop h
+# CHECK-NEXT:              loop r
+# CHECK-NEXT:                loop c
+# CHECK-NEXT:                  tile(h, 17)
+# CHECK-NEXT:                    tile(c, 16)
+# CHECK-NEXT:                      tile(c, 2)  // unroll(2)
+# CHECK-NEXT:                        tile(w, 5)  // unroll(5)
+# CHECK-NEXT:                          loop f  // unroll(64)
+# CHECK-NEXT:                            tile(f, 16)  // vectorized
+# CHECK-NEXT:                              ...
+# CHECK-NEXT:    split(w, 20, ...)
+# CHECK-NEXT:      loop w
+# CHECK-NEXT:        tile(w, 14)
+# CHECK-NEXT:          loop s
+# CHECK-NEXT:            loop h
+# CHECK-NEXT:              loop r
+# CHECK-NEXT:                loop c
+# CHECK-NEXT:                  tile(h, 34)
+# CHECK-NEXT:                    tile(h, 17)
+# CHECK-NEXT:                      tile(c, 16)
+# CHECK-NEXT:                        tile(c, 2)  // unroll(2)
+# CHECK-NEXT:                          tile(w, 7)  // unroll(7)
+# CHECK-NEXT:                            loop f  // unroll(64)
+# CHECK-NEXT:                              tile(f, 16)  // vectorized
+# CHECK-NEXT:                                ...
+# CHECK-NEXT:  VALID: True

--- a/tests/filecheck/backends/test_matmul_split.py
+++ b/tests/filecheck/backends/test_matmul_split.py
@@ -1,5 +1,7 @@
 # RUN: python %s --mlir 2>&1 | filecheck %s
 # RUN: python %s --mlir --descript 2>&1 | filecheck %s
+# RUN: python %s --tvm 2>&1 | filecheck %s
+# RUN: python %s --tvm --descript 2>&1 | filecheck %s
 
 import sys
 import xtc.graphs.xtc.op as O

--- a/tests/filecheck/backends/test_matmul_split_nested.py
+++ b/tests/filecheck/backends/test_matmul_split_nested.py
@@ -1,5 +1,7 @@
 # RUN: python %s --mlir 2>&1 | filecheck %s
 # RUN: python %s --mlir --descript 2>&1 | filecheck %s
+# RUN: python %s --tvm 2>&1 | filecheck %s
+# RUN: python %s --tvm --descript 2>&1 | filecheck %s
 
 import sys
 import xtc.graphs.xtc.op as O


### PR DESCRIPTION
# Motivation

TVM cannot split loops produced by `loop_partition` when their minimum is non-zero. This prevents nested XTC schedules from tiling or vectorizing partitioned loop ranges.

# Description

Add an XTC-side TVM schedule transformation that rebases partitioned loops to zero while preserving their original index offset.

Update the TVM schedule emitter and execution environment to support schedule replacement and reacquire invalidated block RVs. Enable TVM coverage for simple and nested matrix multiplication split schedules.

# Commits

- `tvm: implement split for tvm schedule`

# Discussion

The transformation reconstructs the TVM schedule after rebasing because direct schedule RV mutation is unavailable.

TODO:
- [x] Test simple partitioned loops with TVM.
- [x] Test nested partitioning followed by tiling and vectorization.

# Testing

- `lit -v tests/filecheck/backends/test_matmul_split.py tests/filecheck/backends/test_matmul_split_nested.py`
- `pyright src/xtc/backends/tvm/TVMScheduleTransforms.py src/xtc/backends/tvm/TVMOpsCompiler.py src/xtc/backends/tvm/TVMScheduler.py`
- Ruff checks and `git diff --check`
