### PR TITLE
tests: fixed duplicate dump file names

### DIFF
--- a/tests/filecheck/backends/tensor_dialect/test_conv2d_relu_tensor_fused.py
+++ b/tests/filecheck/backends/tensor_dialect/test_conv2d_relu_tensor_fused.py
@@ -23,7 +23,7 @@ sched = sch.schedule()
 
 comp = impl.get_compiler(
     shared_lib=True,
-    dump_file="conv2d_relu_mlir_tensor",
+    dump_file="conv2d_relu_mlir_tensor_fused",
     print_source_ir=True,
     print_transformed_ir=True,
     print_bufferization_ir=True,

--- a/tests/filecheck/backends/tensor_dialect/test_matmul_relu_mlir_tensor_fused.py
+++ b/tests/filecheck/backends/tensor_dialect/test_matmul_relu_mlir_tensor_fused.py
@@ -23,7 +23,7 @@ sched = sch.schedule()
 
 comp = impl.get_compiler(
     shared_lib=True,
-    dump_file="matmul_relu_mlir_tensor",
+    dump_file="matmul_relu_mlir_tensor_fused",
     print_source_ir=True,
     print_transformed_ir=True,
     print_bufferization_ir=True,


### PR DESCRIPTION
The Consumer fusion branch had duplicate file names that caused intermittent errors that hadn't been detected.
