### PR TITLE
schedule: fix issue with missing interchange

### DIFF
--- a/src/xtc/schedules/plain_schedule.py
+++ b/src/xtc/schedules/plain_schedule.py
@@ -85,7 +85,7 @@ class PlainNodeSchedule:
             for dim in self.dims:
                 self.permutation[DEFAULT_ROOT].extend(
                     [make_loop_name(DEFAULT_ROOT, dim)]
-                    + list(self.tiles[make_loop_name(DEFAULT_ROOT, dim)])
+                    + list(self.tiles.get(make_loop_name(DEFAULT_ROOT, dim), {}))
                 )
 
 

--- a/tests/filecheck/backends/test_matmul_no_interchange.py
+++ b/tests/filecheck/backends/test_matmul_no_interchange.py
@@ -1,0 +1,58 @@
+# RUN: python %s --mlir 2>&1 | filecheck %s
+# RUN: python %s --tvm 2>&1 | filecheck %s
+
+import sys
+import xtc.graphs.xtc.op as O
+from importlib import import_module
+
+backend = "mlir"
+descript = False
+if len(sys.argv) > 1:
+    assert sys.argv[1][:2] == "--"
+    backend = sys.argv[1][2:]
+
+backend = import_module(f"xtc.backends.{backend}")
+
+I, J, K, dtype = 4, 32, 256, "float32"
+a = O.tensor((I, K), dtype, name="A")
+b = O.tensor((K, J), dtype, name="B")
+
+with O.graph(name="matmul") as gb:
+    O.matmul(a, b, name="C")
+
+graph = gb.graph
+print(graph)
+
+impl = backend.Backend(graph)
+
+sch = impl.get_scheduler()
+sch.strip_mine("i", {"i1": 2})
+sch.strip_mine("j", {"j1": 16})
+sch.unroll({"i1": 2})
+
+loop_nest = sch.get_loop_nest()
+print(loop_nest.root_node.pretty_print())
+loop_nest.check()
+
+res = impl.evaluate(
+    sch.schedule(),
+)
+print("VALID:", isinstance(res, float))
+
+# CHECK:       graph:
+# CHECK-NEXT:    name: matmul
+# CHECK-NEXT:    inputs:
+# CHECK-NEXT:    - %0 : 4x256xfloat32
+# CHECK-NEXT:    - %1 : 256x32xfloat32
+# CHECK-NEXT:    outputs:
+# CHECK-NEXT:    - %2 : 4x32xfloat32
+# CHECK-NEXT:    nodes:
+# CHECK-NEXT:    - %2: matmul(%0, %1) {name = 'C'} : [4x256xfloat32, 256x32xfloat32] -> [4x32xfloat32]
+# CHECK-NEXT:  
+# CHECK-NEXT:  loop i
+# CHECK-NEXT:    tile(i, 2)  // unroll(2)
+# CHECK-NEXT:      loop j
+# CHECK-NEXT:        tile(j, 16)
+# CHECK-NEXT:          loop k
+# CHECK-NEXT:            ...
+# CHECK-NEXT:  VALID: True


### PR DESCRIPTION
# Motivation

Fix an issue when interchange is not specified.

The behavior should be to add default tiling interchange order.

Fix the following test:
```
sch = impl.get_scheduler()
sch.tile("i", {"i1": 2})
sch.tile("j", {"j1": 16})
sch.vectorize(["j1"])
sch.unroll({"i1": 2})
sched = sch.schedule()
```
In this case the inferred interchange is:
```
i, i1, j, j1, k
```

This PR fixes this test which raised a `KeyError`.

To be noted, this test is invalid anyway as we do not allow vectorization above non vectorized axis, here: `j1, k`, though this PR removes an `KeyError` exception.

# Description

Update the logic for the default tiling and intechange in PlainNodeSchedule initializer

Added a dedicated test which does tile some axes but does not specify interchange.

# Commits

Ref single commit

# Discussion

n/a
