### PR TITLE
strategy: preserve argument order during construction

### DIFF
--- a/src/xtc/search/strategies.py
+++ b/src/xtc/search/strategies.py
@@ -1257,7 +1257,7 @@ class Strategies:
     @classmethod
     def create(cls, name: str, graph: Graph, *args: Any, **kwargs: Any) -> Strategy:
         registration = cls.registration(name)
-        all_args = {graph, *registration.default_args, *args}
+        all_args = [graph, *registration.default_args, *args]
         all_kwargs = {**registration.default_kwargs, **kwargs}
         return registration.cls(*all_args, **all_kwargs)
 


### PR DESCRIPTION
# Motivation

`Strategies.create` currently collects positional constructor arguments in a set, which does not preserve their order. This can pass the graph, registered defaults, and caller-provided arguments to strategy constructors in the wrong positions.

# Description

Build the positional arguments as a list so that the graph, registered defaults, and caller-provided arguments are passed to strategy constructors in the expected order.

# Testing

Not run (small argument-container correction).

# Commits

- `strategy: fix strategy construction`

# Discussion

None.

TODO:
- [x] No additional work identified.
