### PR TITLE
release: add release notes guidance and cache tag tests

### DIFF
--- a/.github/workflows/xtc-tests.yml
+++ b/.github/workflows/xtc-tests.yml
@@ -65,7 +65,6 @@ jobs:
           echo "cache-name=${CACHE_NAME}" >>"${GITHUB_OUTPUT}"
       - name: Look up cached test results
         id: test-cache
-        if: ${{ !startsWith(github.ref, 'refs/tags/') }}
         env:
           CACHE_NAME: ${{ steps.test-cache-identity.outputs.cache-name }}
           GH_TOKEN: ${{ github.token }}
@@ -195,7 +194,7 @@ jobs:
           skip_validation: true
           fail_ci_if_error: true
       - name: Prepare test result cache
-        if: ${{ !startsWith(github.ref, 'refs/tags/') && steps.test-cache.outputs.hit != 'true' }}
+        if: steps.test-cache.outputs.hit != 'true'
         env:
           TREE_SHA: ${{ steps.test-cache-identity.outputs.tree-sha }}
         run: |
@@ -211,7 +210,7 @@ jobs:
             cp -R artifacts xtc-test-cache/artifacts
           fi
       - name: Cache successful test results
-        if: ${{ !startsWith(github.ref, 'refs/tags/') && steps.test-cache.outputs.hit != 'true' }}
+        if: steps.test-cache.outputs.hit != 'true'
         uses: actions/upload-artifact@v5
         with:
           name: ${{ steps.test-cache-identity.outputs.cache-name }}

--- a/docs/develop/releasing.md
+++ b/docs/develop/releasing.md
@@ -35,6 +35,15 @@ git tag -a xtc-v0.3.0 -m "XTC 0.3.0"
 git push upstream xtc-v0.3.0
 ```
 
+To create the GitHub release notes, use `docs/templates/release_notes.md` as the
+structure and collect the pull requests merged between the previous and current
+tags (for example, `xtc-v0.2.0..xtc-v0.3.0`). The feature and fix sections may be
+selected and summarized with LLM assistance, but the changes section should list
+all merged pull requests and the new-contributors section should identify each
+contributor's first pull request. Review the generated Markdown, then publish it
+with `gh release create <tag> --notes-file <release-notes.md>` (or attach it to an
+existing GitHub release).
+
 The tag workflow checks that the package version is exactly `X.Y.Z`, builds and
 validates the wheel and source distribution, and publishes them to PyPI. The
 GitHub `pypi` environment should require maintainer approval.

--- a/docs/templates/release_notes.md
+++ b/docs/templates/release_notes.md
@@ -1,0 +1,29 @@
+## XTC Release {{ tag }}
+
+We're pleased to announce XTC version {{ tag }}. Thanks to all contributors.
+
+## Important features
+
+{% for pull in important_features_since_last_tag %}
+* [{{ pull.title }}]({{ pull.url }})
+  {{ pull.three_line_summary }}
+{% endfor %}
+
+## Important fixes
+
+{% for pull in important_fixes_since_last_tag %}
+* [{{ pull.title }}]({{ pull.url }}){% if pull.related_issue %}, fixes [{{ pull.related_issue.title }}]({{ pull.related_issue.url }}){% endif %}
+  {{ pull.three_line_summary }}
+{% endfor %}
+
+## Changes
+
+{% for pull in pulls_since_last_tag %}
+* [{{ pull.title }}]({{ pull.url }}) by @{{ pull.user }}
+{% endfor %}
+
+## New contributors
+
+{% for pull in new_contributor_first_pull %}
+* @{{ pull.user }} made their first contribution in [{{ pull.title }}]({{ pull.url }})
+{% endfor %}


### PR DESCRIPTION
# Motivation

Provide a consistent process for preparing GitHub release notes and avoid rerunning tests when a release tag points to a Git tree that has already passed CI.

# Description

Add a Jinja2 release-note template covering important features, fixes, merged pull requests, and new contributors.

Document how to collect changes between tags, review generated Markdown, and publish release notes with the GitHub CLI.

Enable Git-tree-based test-result cache lookup and publication for tag builds. Package building, validation, and publication remain uncached.

# Commits

- `docs: add release notes template and guidance`
- `ci: enable test result cache for tags`

# Discussion

The tag test cache uses the same Git tree, operating system, and Python-version identity as branch and pull-request builds.

Testing:
- `actionlint .github/workflows/xtc-tests.yml`
- `git diff --check`

TODO:
- [x] No outstanding work identified.
